### PR TITLE
docs: update authentication guidance and run limit defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Gemini CLIを使用してアプリケーション開発を自動化するPython�
 
 ### 前提条件
 - Python 3.9以上
-- GitHub API トークン
-- Gemini API キー
+- [gh CLI](https://cli.github.com/) で事前に認証済みであること（`gh auth login`）
+- [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli?hl=ja) で事前に認証済みであること（`gemini login`）
 
 ### セットアップ
 
@@ -32,26 +32,24 @@ git clone https://github.com/your-username/auto-coder.git
 cd auto-coder
 ```
 
-2. 依存関係をインストール:
+2. 依存関係をインストールして、任意のディレクトリから実行可能にします:
 ```bash
 pip install -e .
+# またはリポジトリをクローンせずに直接インストール
+pip install git+https://github.com/your-username/auto-coder.git
 ```
 
-3. 環境変数を設定:
+3. 必要に応じて設定ファイルを作成:
 ```bash
 cp .env.example .env
-# .envファイルを編集してAPIキーを設定
+# トークンはgh・geminiの認証情報が自動的に使用されるため空欄でも動作します
 ```
 
 ## 使用方法
 
-### 環境変数の設定
+### 認証
 
-必須の環境変数:
-```bash
-export GITHUB_TOKEN="your_github_token"
-export GEMINI_API_KEY="your_gemini_api_key"
-```
+`gh auth login` と `gemini login` を実行しておくことで、APIキーを環境変数に設定せずに利用できます。環境変数を手動で設定する必要はありません。
 
 ### CLIコマンド
 
@@ -74,14 +72,18 @@ auto-coder create-feature-issues --repo owner/repo
 
 #### `process-issues`
 - `--repo`: GitHubリポジトリ (owner/repo形式)
-- `--github-token`: GitHub APIトークン (環境変数でも設定可能)
-- `--gemini-api-key`: Gemini APIキー (環境変数でも設定可能)
 - `--dry-run`: ドライランモード（変更を行わない）
+
+オプション:
+- `--github-token`: gh CLIの認証情報を使用しない場合に手動指定
+- `--gemini-api-key`: Gemini CLIの認証情報を使用しない場合に手動指定
 
 #### `create-feature-issues`
 - `--repo`: GitHubリポジトリ (owner/repo形式)
-- `--github-token`: GitHub APIトークン (環境変数でも設定可能)
-- `--gemini-api-key`: Gemini APIキー (環境変数でも設定可能)
+
+オプション:
+- `--github-token`: gh CLIの認証情報を使用しない場合に手動指定
+- `--gemini-api-key`: Gemini CLIの認証情報を使用しない場合に手動指定
 
 ## 設定
 
@@ -89,14 +91,16 @@ auto-coder create-feature-issues --repo owner/repo
 
 | 変数名 | 説明 | デフォルト値 | 必須 |
 |--------|------|-------------|------|
-| `GITHUB_TOKEN` | GitHub APIトークン | - | ✅ |
-| `GEMINI_API_KEY` | Gemini APIキー | - | ✅ |
+| `GITHUB_TOKEN` | GitHub APIトークン (gh CLIの認証情報を上書きする場合) | - | ❌ |
+| `GEMINI_API_KEY` | Gemini APIキー (Gemini CLIの認証情報を上書きする場合) | - | ❌ |
 | `GITHUB_API_URL` | GitHub API URL | `https://api.github.com` | ❌ |
 | `GEMINI_MODEL` | 使用するGeminiモデル | `gemini-pro` | ❌ |
-| `MAX_ISSUES_PER_RUN` | 1回の実行で処理する最大issue数 | `10` | ❌ |
-| `MAX_PRS_PER_RUN` | 1回の実行で処理する最大PR数 | `5` | ❌ |
+| `MAX_ISSUES_PER_RUN` | 1回の実行で処理する最大issue数 | `-1` | ❌ |
+| `MAX_PRS_PER_RUN` | 1回の実行で処理する最大PR数 | `-1` | ❌ |
 | `DRY_RUN` | ドライランモード | `false` | ❌ |
 | `LOG_LEVEL` | ログレベル | `INFO` | ❌ |
+
+`MAX_ISSUES_PER_RUN` と `MAX_PRS_PER_RUN` はデフォルトで制限なし (`-1`) に設定されています。処理件数を制限したい場合は、正の整数を指定してください。
 
 ## 開発
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,8 @@
 Tests for CLI functionality.
 """
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
+import click
+from unittest.mock import Mock, patch
 from click.testing import CliRunner
 
 from src.auto_coder.cli import main, process_issues, create_feature_issues
@@ -11,216 +11,335 @@ from src.auto_coder.cli import main, process_issues, create_feature_issues
 
 class TestCLI:
     """Test cases for CLI functionality."""
-    
+
     def test_main_command_help(self):
         """Test main command help output."""
         runner = CliRunner()
-        result = runner.invoke(main, ['--help'])
-        
+        result = runner.invoke(main, ["--help"])
+
         assert result.exit_code == 0
         assert "Auto-Coder" in result.output
         assert "Automated application development" in result.output
-    
+
     def test_main_command_version(self):
         """Test main command version output."""
         runner = CliRunner()
-        result = runner.invoke(main, ['--version'])
-        
+        result = runner.invoke(main, ["--version"])
+
         assert result.exit_code == 0
-    
-    @patch('src.auto_coder.cli.AutomationEngine')
-    @patch('src.auto_coder.cli.GeminiClient')
-    @patch('src.auto_coder.cli.GitHubClient')
-    def test_process_issues_success(self, mock_github_client_class, mock_gemini_client_class, mock_automation_engine_class):
-        """Test successful process-issues command."""
-        # Setup
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_process_issues_success(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
+        """Test successful process-issues command with default model."""
         mock_github_client = Mock()
         mock_gemini_client = Mock()
         mock_automation_engine = Mock()
-        
+
         mock_github_client_class.return_value = mock_github_client
         mock_gemini_client_class.return_value = mock_gemini_client
         mock_automation_engine_class.return_value = mock_automation_engine
-        
+        mock_check_cli.return_value = None
+
         runner = CliRunner()
-        
-        # Execute
-        result = runner.invoke(process_issues, [
-            '--repo', 'test/repo',
-            '--github-token', 'test_token',
-            '--gemini-api-key', 'test_key',
-            '--dry-run'
-        ])
-        
-        # Assert
+        result = runner.invoke(
+            process_issues,
+            [
+                "--repo",
+                "test/repo",
+                "--github-token",
+                "test_token",
+                "--dry-run",
+            ],
+        )
+
         assert result.exit_code == 0
         assert "Processing repository: test/repo" in result.output
         assert "Dry run mode: True" in result.output
-        
-        mock_github_client_class.assert_called_once_with('test_token')
-        mock_gemini_client_class.assert_called_once_with('test_key')
+
+        mock_github_client_class.assert_called_once_with("test_token")
+        mock_gemini_client_class.assert_called_once_with(
+            model_name="gemini-2.5-pro"
+        )
         mock_automation_engine_class.assert_called_once_with(
             mock_github_client, mock_gemini_client, dry_run=True
         )
-        mock_automation_engine.run.assert_called_once_with('test/repo')
-    
+        mock_automation_engine.run.assert_called_once_with("test/repo")
+
     def test_process_issues_missing_github_token(self):
         """Test process-issues command with missing GitHub token."""
         runner = CliRunner()
-        
-        result = runner.invoke(process_issues, [
-            '--repo', 'test/repo',
-            '--gemini-api-key', 'test_key'
-        ])
-        
+
+        result = runner.invoke(process_issues, ["--repo", "test/repo"])
+
         assert result.exit_code != 0
         assert "GitHub token is required" in result.output
-    
-    def test_process_issues_missing_gemini_key(self):
-        """Test process-issues command with missing Gemini API key."""
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    def test_process_issues_missing_gemini_cli(self, mock_check_cli):
+        """Test process-issues command when gemini CLI is not available."""
+        mock_check_cli.side_effect = click.ClickException("Gemini CLI missing")
         runner = CliRunner()
-        
-        result = runner.invoke(process_issues, [
-            '--repo', 'test/repo',
-            '--github-token', 'test_token'
-        ])
-        
+
+        result = runner.invoke(
+            process_issues,
+            ["--repo", "test/repo", "--github-token", "test_token"],
+        )
+
         assert result.exit_code != 0
-        assert "Gemini API key is required" in result.output
-    
-    @patch.dict('os.environ', {'GITHUB_TOKEN': 'env_github_token', 'GEMINI_API_KEY': 'env_gemini_key'})
-    @patch('src.auto_coder.cli.AutomationEngine')
-    @patch('src.auto_coder.cli.GeminiClient')
-    @patch('src.auto_coder.cli.GitHubClient')
-    def test_process_issues_with_env_vars(self, mock_github_client_class, mock_gemini_client_class, mock_automation_engine_class):
+        assert "Gemini CLI" in result.output
+
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "env_github_token"})
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_process_issues_with_env_vars(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
         """Test process-issues command using environment variables."""
         # Setup
         mock_github_client = Mock()
         mock_gemini_client = Mock()
         mock_automation_engine = Mock()
-        
+
         mock_github_client_class.return_value = mock_github_client
         mock_gemini_client_class.return_value = mock_gemini_client
         mock_automation_engine_class.return_value = mock_automation_engine
-        
+        mock_check_cli.return_value = None
+
         runner = CliRunner()
-        
+
         # Execute
-        result = runner.invoke(process_issues, [
-            '--repo', 'test/repo'
-        ])
-        
+        result = runner.invoke(process_issues, ["--repo", "test/repo"])
+
         # Assert
         assert result.exit_code == 0
-        mock_github_client_class.assert_called_once_with('env_github_token')
-        mock_gemini_client_class.assert_called_once_with('env_gemini_key')
-    
-    @patch('src.auto_coder.cli.AutomationEngine')
-    @patch('src.auto_coder.cli.GeminiClient')
-    @patch('src.auto_coder.cli.GitHubClient')
-    def test_create_feature_issues_success(self, mock_github_client_class, mock_gemini_client_class, mock_automation_engine_class):
-        """Test successful create-feature-issues command."""
-        # Setup
+        mock_github_client_class.assert_called_once_with("env_github_token")
+        mock_gemini_client_class.assert_called_once()
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_process_issues_custom_model(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
+        """Custom model name is passed to GeminiClient for process-issues."""
+        mock_github_client_class.return_value = Mock()
+        mock_gemini_client_class.return_value = Mock()
+        mock_automation_engine_class.return_value = Mock()
+        mock_check_cli.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(
+            process_issues,
+            [
+                "--repo",
+                "test/repo",
+                "--github-token",
+                "test_token",
+                "--model",
+                "gemini-custom",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_gemini_client_class.assert_called_once_with(
+            model_name="gemini-custom"
+        )
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_create_feature_issues_success(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
+        """Test successful create-feature-issues command with default model."""
         mock_github_client = Mock()
         mock_gemini_client = Mock()
         mock_automation_engine = Mock()
         mock_automation_engine.create_feature_issues.return_value = [
-            {'number': 123, 'title': 'New Feature', 'url': 'https://github.com/test/repo/issues/123'}
+            {
+                "number": 123,
+                "title": "New Feature",
+                "url": "https://github.com/test/repo/issues/123",
+            }
         ]
-        
+
         mock_github_client_class.return_value = mock_github_client
         mock_gemini_client_class.return_value = mock_gemini_client
         mock_automation_engine_class.return_value = mock_automation_engine
-        
+        mock_check_cli.return_value = None
+
         runner = CliRunner()
-        
-        # Execute
-        result = runner.invoke(create_feature_issues, [
-            '--repo', 'test/repo',
-            '--github-token', 'test_token',
-            '--gemini-api-key', 'test_key'
-        ])
-        
-        # Assert
+        result = runner.invoke(
+            create_feature_issues,
+            [
+                "--repo",
+                "test/repo",
+                "--github-token",
+                "test_token",
+            ],
+        )
+
         assert result.exit_code == 0
-        assert "Analyzing repository for feature opportunities: test/repo" in result.output
-        
-        mock_github_client_class.assert_called_once_with('test_token')
-        mock_gemini_client_class.assert_called_once_with('test_key')
-        mock_automation_engine_class.assert_called_once_with(mock_github_client, mock_gemini_client)
-        mock_automation_engine.create_feature_issues.assert_called_once_with('test/repo')
-    
+        assert (
+            "Analyzing repository for feature opportunities: "
+            "test/repo" in result.output
+        )
+
+        mock_github_client_class.assert_called_once_with("test_token")
+        mock_gemini_client_class.assert_called_once_with(
+            model_name="gemini-2.5-pro"
+        )
+        mock_automation_engine_class.assert_called_once_with(
+            mock_github_client, mock_gemini_client
+        )
+        mock_automation_engine.create_feature_issues.assert_called_once_with(
+            "test/repo"
+        )
+
+
     def test_create_feature_issues_missing_github_token(self):
         """Test create-feature-issues command with missing GitHub token."""
         runner = CliRunner()
-        
-        result = runner.invoke(create_feature_issues, [
-            '--repo', 'test/repo',
-            '--gemini-api-key', 'test_key'
-        ])
-        
+
+        result = runner.invoke(create_feature_issues, ["--repo", "test/repo"])
+
         assert result.exit_code != 0
         assert "GitHub token is required" in result.output
-    
-    def test_create_feature_issues_missing_gemini_key(self):
-        """Test create-feature-issues command with missing Gemini API key."""
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    def test_create_feature_issues_missing_gemini_cli(self, mock_check_cli):
+        """Test create-feature-issues when gemini CLI is not available."""
+        mock_check_cli.side_effect = click.ClickException("Gemini CLI missing")
         runner = CliRunner()
-        
-        result = runner.invoke(create_feature_issues, [
-            '--repo', 'test/repo',
-            '--github-token', 'test_token'
-        ])
-        
+
+        result = runner.invoke(
+            create_feature_issues,
+            ["--repo", "test/repo", "--github-token", "test_token"],
+        )
+
         assert result.exit_code != 0
-        assert "Gemini API key is required" in result.output
-    
-    @patch.dict('os.environ', {'GITHUB_TOKEN': 'env_github_token', 'GEMINI_API_KEY': 'env_gemini_key'})
-    @patch('src.auto_coder.cli.AutomationEngine')
-    @patch('src.auto_coder.cli.GeminiClient')
-    @patch('src.auto_coder.cli.GitHubClient')
-    def test_create_feature_issues_with_env_vars(self, mock_github_client_class, mock_gemini_client_class, mock_automation_engine_class):
+        assert "Gemini CLI" in result.output
+
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "env_github_token"})
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_create_feature_issues_with_env_vars(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
         """Test create-feature-issues command using environment variables."""
         # Setup
         mock_github_client = Mock()
         mock_gemini_client = Mock()
         mock_automation_engine = Mock()
         mock_automation_engine.create_feature_issues.return_value = []
-        
+
         mock_github_client_class.return_value = mock_github_client
         mock_gemini_client_class.return_value = mock_gemini_client
         mock_automation_engine_class.return_value = mock_automation_engine
-        
+        mock_check_cli.return_value = None
+
         runner = CliRunner()
-        
+
         # Execute
-        result = runner.invoke(create_feature_issues, [
-            '--repo', 'test/repo'
-        ])
-        
+        result = runner.invoke(create_feature_issues, ["--repo", "test/repo"])
+
         # Assert
         assert result.exit_code == 0
-        mock_github_client_class.assert_called_once_with('env_github_token')
-        mock_gemini_client_class.assert_called_once_with('env_gemini_key')
-    
+        mock_github_client_class.assert_called_once_with("env_github_token")
+        mock_gemini_client_class.assert_called_once()
+
+    @patch("src.auto_coder.cli.check_gemini_cli_or_fail")
+    @patch("src.auto_coder.cli.AutomationEngine")
+    @patch("src.auto_coder.cli.GeminiClient")
+    @patch("src.auto_coder.cli.GitHubClient")
+    def test_create_feature_issues_custom_model(
+        self,
+        mock_github_client_class,
+        mock_gemini_client_class,
+        mock_automation_engine_class,
+        mock_check_cli,
+    ):
+        """Custom model name is passed to GeminiClient for create-feature-issues."""
+        mock_github_client_class.return_value = Mock()
+        mock_gemini_client_class.return_value = Mock()
+        automation_engine = Mock()
+        automation_engine.create_feature_issues.return_value = []
+        mock_automation_engine_class.return_value = automation_engine
+        mock_check_cli.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(
+            create_feature_issues,
+            [
+                "--repo",
+                "test/repo",
+                "--github-token",
+                "test_token",
+                "--model",
+                "gemini-custom",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_gemini_client_class.assert_called_once_with(
+            model_name="gemini-custom"
+        )
+
     def test_process_issues_help(self):
         """Test process-issues command help."""
         runner = CliRunner()
-        result = runner.invoke(process_issues, ['--help'])
-        
+        result = runner.invoke(process_issues, ["--help"])
+
         assert result.exit_code == 0
-        assert "Process GitHub issues and PRs using Gemini CLI" in result.output
+        assert (
+            "Process GitHub issues and PRs using Gemini CLI" in result.output
+        )
         assert "--repo" in result.output
         assert "--github-token" in result.output
-        assert "--gemini-api-key" in result.output
+        assert "--model" in result.output
         assert "--dry-run" in result.output
-    
+
     def test_create_feature_issues_help(self):
         """Test create-feature-issues command help."""
         runner = CliRunner()
-        result = runner.invoke(create_feature_issues, ['--help'])
-        
+        result = runner.invoke(create_feature_issues, ["--help"])
+
         assert result.exit_code == 0
-        assert "Analyze repository and create feature enhancement issues" in result.output
+        assert (
+            "Analyze repository and create feature enhancement issues"
+            in result.output
+        )
         assert "--repo" in result.output
         assert "--github-token" in result.output
-        assert "--gemini-api-key" in result.output
+        assert "--model" in result.output

--- a/tests/test_cli_installation_e2e.py
+++ b/tests/test_cli_installation_e2e.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_accessible_from_any_directory(tmp_path):
+    """Ensure CLI works after installation from any directory."""
+    project_root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-e",
+            str(project_root),
+        ],
+        check=True,
+    )
+    result = subprocess.run(
+        [
+            "auto-coder",
+            "--help",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert "Usage: auto-coder" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,5 @@
-"""
-Tests for configuration functionality.
-"""
+"""Tests for configuration functionality."""
 
-import pytest
 import os
 from unittest.mock import patch
 
@@ -11,121 +8,115 @@ from src.auto_coder.config import Settings
 
 class TestSettings:
     """Test cases for Settings class."""
-    
+
     def test_default_settings(self):
         """Test default settings values."""
         settings = Settings()
-        
+
         assert settings.github_token is None
-        assert settings.github_api_url == 'https://api.github.com'
+        assert settings.github_api_url == "https://api.github.com"
         assert settings.gemini_api_key is None
-        assert settings.gemini_model == 'gemini-pro'
-        assert settings.max_issues_per_run == 10
-        assert settings.max_prs_per_run == 5
+        assert settings.gemini_model == "gemini-pro"
+        assert settings.max_issues_per_run == -1
+        assert settings.max_prs_per_run == -1
         assert settings.dry_run is False
-        assert settings.log_level == 'INFO'
-        assert '%(asctime)s' in settings.log_format
-    
-    @patch.dict(os.environ, {
-        'GITHUB_TOKEN': 'test_github_token',
-        'GITHUB_API_URL': 'https://custom.github.com',
-        'GEMINI_API_KEY': 'test_gemini_key',
-        'GEMINI_MODEL': 'gemini-pro-vision',
-        'MAX_ISSUES_PER_RUN': '20',
-        'MAX_PRS_PER_RUN': '10',
-        'DRY_RUN': 'true',
-        'LOG_LEVEL': 'DEBUG',
-        'LOG_FORMAT': 'custom format'
-    })
+        assert settings.log_level == "INFO"
+        assert "%(asctime)s" in settings.log_format
+
+    @patch.dict(
+        os.environ,
+        {
+            "GITHUB_TOKEN": "test_github_token",
+            "GITHUB_API_URL": "https://custom.github.com",
+            "GEMINI_API_KEY": "test_gemini_key",
+            "GEMINI_MODEL": "gemini-pro-vision",
+            "MAX_ISSUES_PER_RUN": "20",
+            "MAX_PRS_PER_RUN": "10",
+            "DRY_RUN": "true",
+            "LOG_LEVEL": "DEBUG",
+            "LOG_FORMAT": "custom format",
+        },
+    )
     def test_settings_from_environment(self):
         """Test settings loaded from environment variables."""
         settings = Settings()
-        
-        assert settings.github_token == 'test_github_token'
-        assert settings.github_api_url == 'https://custom.github.com'
-        assert settings.gemini_api_key == 'test_gemini_key'
-        assert settings.gemini_model == 'gemini-pro-vision'
+
+        assert settings.github_token == "test_github_token"
+        assert settings.github_api_url == "https://custom.github.com"
+        assert settings.gemini_api_key == "test_gemini_key"
+        assert settings.gemini_model == "gemini-pro-vision"
         assert settings.max_issues_per_run == 20
         assert settings.max_prs_per_run == 10
         assert settings.dry_run is True
-        assert settings.log_level == 'DEBUG'
-        assert settings.log_format == 'custom format'
-    
-    @patch.dict(os.environ, {
-        'GITHUB_TOKEN': 'env_token'
-    })
+        assert settings.log_level == "DEBUG"
+        assert settings.log_format == "custom format"
+
+    @patch.dict(os.environ, {"GITHUB_TOKEN": "env_token"})
     def test_settings_partial_environment(self):
         """Test settings with partial environment variables."""
         settings = Settings()
-        
+
         # Environment variable should override default
-        assert settings.github_token == 'env_token'
-        
+        assert settings.github_token == "env_token"
+
         # Other settings should use defaults
-        assert settings.github_api_url == 'https://api.github.com'
+        assert settings.github_api_url == "https://api.github.com"
         assert settings.gemini_api_key is None
-        assert settings.max_issues_per_run == 10
-    
+        assert settings.max_issues_per_run == -1
+        assert settings.max_prs_per_run == -1
+
     def test_settings_validation(self):
         """Test settings validation."""
         # Test with valid values
         settings = Settings(
             max_issues_per_run=5,
             max_prs_per_run=3,
-            dry_run=True
+            dry_run=True,
         )
-        
+
         assert settings.max_issues_per_run == 5
         assert settings.max_prs_per_run == 3
         assert settings.dry_run is True
-    
-    @patch.dict(os.environ, {
-        'DRY_RUN': 'false'
-    })
+
+    @patch.dict(os.environ, {"DRY_RUN": "false"})
     def test_boolean_environment_variable_false(self):
         """Test boolean environment variable parsing for false values."""
         settings = Settings()
         assert settings.dry_run is False
-    
-    @patch.dict(os.environ, {
-        'DRY_RUN': 'True'
-    })
+
+    @patch.dict(os.environ, {"DRY_RUN": "True"})
     def test_boolean_environment_variable_true_capitalized(self):
         """Test boolean environment variable parsing for capitalized true."""
         settings = Settings()
         assert settings.dry_run is True
-    
-    @patch.dict(os.environ, {
-        'DRY_RUN': '1'
-    })
+
+    @patch.dict(os.environ, {"DRY_RUN": "1"})
     def test_boolean_environment_variable_numeric_true(self):
         """Test boolean environment variable parsing for numeric true."""
         settings = Settings()
         assert settings.dry_run is True
-    
-    @patch.dict(os.environ, {
-        'DRY_RUN': '0'
-    })
+
+    @patch.dict(os.environ, {"DRY_RUN": "0"})
     def test_boolean_environment_variable_numeric_false(self):
         """Test boolean environment variable parsing for numeric false."""
         settings = Settings()
         assert settings.dry_run is False
-    
+
     def test_settings_immutability(self):
         """Test that settings can be modified after creation."""
         settings = Settings()
-        
+
         # Should be able to modify settings
         original_token = settings.github_token
-        settings.github_token = 'new_token'
-        assert settings.github_token == 'new_token'
+        settings.github_token = "new_token"
+        assert settings.github_token == "new_token"
         assert settings.github_token != original_token
-    
+
     def test_config_class_attributes(self):
         """Test Config class attributes."""
         settings = Settings()
-        
+
         # Check that Config class is properly set
-        assert hasattr(settings.Config, 'env_file')
-        assert settings.Config.env_file == '.env'
-        assert settings.Config.env_file_encoding == 'utf-8'
+        assert hasattr(settings.Config, "env_file")
+        assert settings.Config.env_file == ".env"
+        assert settings.Config.env_file_encoding == "utf-8"


### PR DESCRIPTION
## Summary
- recommend gh/gemini CLI auth instead of raw API keys
- allow global CLI usage with install instructions
- add E2E test ensuring CLI works from any directory
- verify `--model` option passes through to `GeminiClient`
- ensure config tests expect unlimited issue/PR limits
- document that issue/PR run limits default to unlimited and require manual setting to impose limits

## Testing
- `pytest tests/test_config.py`
- `pytest tests/test_cli.py`
- `pytest tests/test_cli_installation_e2e.py`
- `pytest tests/automation_engine.py` *(fails: AttributeError/NameError)*
- `pytest tests/test_gemini_client.py` *(fails: Gemini CLI not available)*
- `pytest tests/test_e2e.py` *(fails: missing gemini_client.genai and CLI exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_6893f8193a40832f87522b9bfe49863e