### PR TITLE
feat: add GitHub Actions log helper

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -358,6 +358,17 @@ special_features:
       - "AutomationEngine._get_allowed_merge_methods"
       - "AutomationEngine._merge_pr updated to use these fallbacks"
 
+  actions_log_fetcher:
+    name: "GitHub Actions URL Log Fetcher"
+    description: "Fetch error logs from a GitHub Actions job URL for debugging"
+    components:
+      - name: "AutomationEngine.get_github_actions_logs_from_url"
+        file: "src/auto_coder/automation_engine.py"
+        description: "Retrieve error logs from a GitHub Actions job URL"
+      - name: "CLI command get-actions-logs"
+        file: "src/auto_coder/cli.py"
+        description: "CLI command to fetch GitHub Actions job logs for debugging"
+
 testing:
   unit_tests:
     description: "Unit tests for individual components"

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -1067,6 +1067,81 @@ Please proceed with analyzing and taking action on this PR now.
 
         return '\n\n'.join(logs) if logs else "No detailed logs available"
 
+    def get_github_actions_logs_from_url(self, url: str) -> str:
+        """Fetch GitHub Actions error logs from a job URL.
+
+        This helper is used for debugging purposes. It accepts a URL of the form:
+        ``https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>`` and
+        returns the same extracted error log text that would be passed to the LLM.
+        """
+
+        try:
+            import re
+
+            m = re.match(
+                r"https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+)/job/([0-9]+)",
+                url,
+            )
+            if not m:
+                return "Invalid GitHub Actions job URL"
+
+            owner, repo, _run_id, job_id = m.groups()
+            repo_name = f"{owner}/{repo}"
+
+            # Fetch job name for nicer output (best-effort)
+            job_name = f"job-{job_id}"
+            job_meta = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo_name}/actions/jobs/{job_id}",
+                    "--json",
+                    "name",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if job_meta.returncode == 0 and job_meta.stdout.strip():
+                try:
+                    job_name = json.loads(job_meta.stdout).get("name", job_name)
+                except Exception:
+                    pass
+
+            api_res = subprocess.run(
+                ["gh", "api", f"repos/{repo_name}/actions/jobs/{job_id}/logs"],
+                capture_output=True,
+                timeout=120,
+            )
+
+            if api_res.returncode != 0 or not api_res.stdout:
+                return "No detailed logs available"
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                zip_path = os.path.join(tmpdir, "job_logs.zip")
+                with open(zip_path, "wb") as f:
+                    f.write(api_res.stdout)
+
+                with zipfile.ZipFile(zip_path, "r") as zf:
+                    texts: List[str] = []
+                    for name in zf.namelist():
+                        if name.lower().endswith(".txt"):
+                            with zf.open(name, "r") as fp:
+                                try:
+                                    texts.append(fp.read().decode("utf-8", errors="ignore"))
+                                except Exception:
+                                    pass
+                    combined = "\n".join(texts)
+
+            important = self._extract_important_errors(
+                {"success": False, "output": combined, "errors": ""}
+            )
+            return f"=== Job {job_name} ({job_id}) ===\n{important}" if important else "No detailed logs available"
+
+        except Exception as e:
+            logger.error(f"Error fetching GitHub Actions logs from URL: {e}")
+            return f"Error getting logs: {e}"
+
     def _handle_pr_merge(self, repo_name: str, pr_data: Dict[str, Any], analysis: Dict[str, Any]) -> List[str]:
         """Handle PR merge process following the intended flow."""
         actions = []

--- a/src/auto_coder/cli.py
+++ b/src/auto_coder/cli.py
@@ -261,6 +261,19 @@ def create_feature_issues(
 
 
 @main.command()
+@click.option('--url', 'actions_url', required=True, help='GitHub Actions job URL')
+@click.option('--github-token', envvar='GITHUB_TOKEN', help='GitHub API token')
+def get_actions_logs(actions_url: str, github_token: Optional[str]) -> None:
+    """Fetch error logs from a GitHub Actions job URL for debugging."""
+    setup_logger()
+    github_token_final = get_github_token_or_fail(github_token)
+    github_client = GitHubClient(github_token_final)
+    engine = AutomationEngine(github_client, None, dry_run=True)
+    logs = engine.get_github_actions_logs_from_url(actions_url)
+    click.echo(logs)
+
+
+@main.command()
 def auth_status() -> None:
     """Check authentication status for GitHub and Gemini."""
     click.echo("Checking authentication status...")

--- a/tests/test_actions_log_cli_e2e.py
+++ b/tests/test_actions_log_cli_e2e.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+import importlib
+
+
+def test_get_actions_logs_cli():
+    sp = importlib.reload(subprocess)
+    from playwright.sync_api import sync_playwright
+
+    url = "https://github.com/kitamura-tetsuo/outliner/actions/runs/16949853465/job/48039894437?pr=496"
+
+    sp.run(["playwright", "install", "chromium"], check=False)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(url)
+        assert "GitHub" in page.title()
+
+    result = sp.run(
+        [
+            sys.executable,
+            "-m",
+            "src.auto_coder.cli",
+            "get-actions-logs",
+            "--url",
+            url,
+            "--github-token",
+            "dummy",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0

--- a/tests/test_github_actions_logs_from_url.py
+++ b/tests/test_github_actions_logs_from_url.py
@@ -1,0 +1,40 @@
+import io
+import json
+import zipfile
+from unittest.mock import Mock, patch
+
+from src.auto_coder.automation_engine import AutomationEngine
+
+
+def test_get_github_actions_logs_from_url(mock_github_client, mock_gemini_client):
+    engine = AutomationEngine(mock_github_client, mock_gemini_client, dry_run=True)
+    url = "https://github.com/kitamura-tetsuo/outliner/actions/runs/16949853465/job/48039894437"
+
+    repo_name = "kitamura-tetsuo/outliner"
+    job_id = "48039894437"
+
+    def fake_run(cmd, capture_output=True, text=False, timeout=60, cwd=None):
+        if cmd[:5] == [
+            "gh",
+            "api",
+            f"repos/{repo_name}/actions/jobs/{job_id}",
+            "--json",
+            "name",
+        ]:
+            return Mock(returncode=0, stdout=json.dumps({"name": "build"}), stderr="")
+        if cmd[:4] == [
+            "gh",
+            "api",
+            f"repos/{repo_name}/actions/jobs/{job_id}/logs",
+        ]:
+            bio = io.BytesIO()
+            with zipfile.ZipFile(bio, "w") as zf:
+                zf.writestr("log.txt", "INFO ok\nERROR boom\n")
+            return Mock(returncode=0, stdout=bio.getvalue(), stderr=b"")
+        return Mock(returncode=1, stdout="", stderr="unknown command")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        logs = engine.get_github_actions_logs_from_url(url)
+
+    assert "Job build (48039894437)" in logs
+    assert "ERROR boom" in logs


### PR DESCRIPTION
## Summary
- add helper to fetch GitHub Actions job logs from URL
- expose debugging command `get-actions-logs`
- document feature and add tests

## Testing
- `python -m pytest tests/test_github_actions_logs_from_url.py -q`
- `python -m pytest -k "not test_actions_log_cli_e2e" -q`
- `python -m pytest tests/test_actions_log_cli_e2e.py -q` *(fails: Page.goto: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_689d33d5f068832f8333a7a41ab37003