### PR TITLE
Handle missing PR checks gracefully

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -716,7 +716,15 @@ Please proceed with analyzing and taking action on this PR now.
             # Note: gh pr checks returns non-zero exit code when some checks fail
             # This is expected behavior, not an error
             if result.returncode != 0 and not result.stdout.strip():
-                # Only treat as error if there's no output (real failure)
+                stderr_msg = (result.stderr or "").strip().lower()
+                if "no checks reported" in stderr_msg:
+                    return {
+                        'success': True,
+                        'checks': [],
+                        'failed_checks': [],
+                        'total_checks': 0
+                    }
+                # Only treat as error if there's no output and no known informational message
                 self._log_action(f"Failed to get PR checks for #{pr_number}", False, result.stderr)
                 return {
                     'success': False,

--- a/tests/test_automation_engine.py
+++ b/tests/test_automation_engine.py
@@ -906,6 +906,24 @@ class TestAutomationEngine:
         assert result['total_checks'] == 3
         assert len(result['failed_checks']) == 0  # No failed checks
 
+    @patch('subprocess.run')
+    def test_check_github_actions_status_no_checks_reported(self, mock_run, mock_github_client, mock_gemini_client):
+        """Handle gh CLI message when no checks are reported."""
+        mock_run.return_value = Mock(
+            returncode=1,
+            stdout='',
+            stderr="no checks reported on the 'feat/global-search' branch"
+        )
+
+        engine = AutomationEngine(mock_github_client, mock_gemini_client)
+        pr_data = {'number': 123}
+
+        result = engine._check_github_actions_status("test/repo", pr_data)
+
+        assert result['success'] is True
+        assert result['total_checks'] == 0
+        assert result['failed_checks'] == []
+
     @patch('src.auto_coder.automation_engine.CommandExecutor.run_command')
     def test_checkout_pr_branch_success(self, mock_run_command, mock_github_client, mock_gemini_client):
         """Test successful PR branch checkout."""

--- a/tests/test_e2e_pr_checks_no_checks.py
+++ b/tests/test_e2e_pr_checks_no_checks.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+from src.auto_coder.github_client import GitHubClient
+from src.auto_coder.automation_engine import AutomationEngine
+
+
+@pytest.mark.e2e
+@pytest.mark.headless
+class TestPRChecksNoChecks:
+    def test_pr_with_no_checks_reports_as_success(self):
+        token = os.environ.get("GITHUB_TOKEN", "placeholder-token")
+        github_client = GitHubClient(token)
+        engine = AutomationEngine(github_client, None)
+        pr_data = {'number': 515}
+        result = engine._check_github_actions_status('kitamura-tetsuo/outliner', pr_data)
+        assert result['success'] is True
+        assert len(result['failed_checks']) == 0


### PR DESCRIPTION
## Summary
- handle gh CLI 'no checks reported' message
- add unit and e2e tests for PR checks retrieval

## Testing
- `pytest tests/test_automation_engine.py::TestAutomationEngine::test_check_github_actions_status_no_checks_reported -q`
- `pytest tests/test_e2e_pr_checks_no_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3411ed84832fa59ed148ccf31a7f