### PR TITLE
Add pipx auto-update logic with notifications

### DIFF
--- a/src/auto_coder/cli.py
+++ b/src/auto_coder/cli.py
@@ -20,6 +20,7 @@ from .automation_config import AutomationConfig
 from .git_utils import get_current_repo_name, is_git_repository
 from .auth_utils import get_github_token, get_gemini_api_key, get_auth_status
 from .logger_config import setup_logger, get_logger
+from .update_manager import maybe_run_auto_update
 
 # Load environment variables
 load_dotenv()
@@ -351,7 +352,7 @@ def qwen_help_has_flags(required_flags: list[str]) -> bool:
 @click.version_option(version="0.1.0", package_name="auto-coder")
 def main() -> None:
     """Auto-Coder: Automated application development using Gemini CLI and GitHub integration."""
-    pass
+    maybe_run_auto_update()
 
 
 @main.command()

--- a/src/auto_coder/update_manager.py
+++ b/src/auto_coder/update_manager.py
@@ -1,0 +1,161 @@
+"""Utility helpers for keeping pipx installations up to date."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import click
+
+from .logger_config import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_INTERVAL_SECONDS = 6 * 60 * 60  # every 6 hours
+_STATE_FILENAME = "update_state.json"
+_PACKAGE_NAME = "auto-coder"
+
+
+def _auto_update_disabled() -> bool:
+    """Return True when auto-update checks are disabled via environment."""
+    flag = os.environ.get("AUTO_CODER_DISABLE_AUTO_UPDATE")
+    if not flag:
+        return False
+    return flag.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _running_inside_pipx_env() -> bool:
+    """Best-effort detection for pipx-managed execution environments."""
+    prefix_path = Path(sys.prefix)
+    if any(part.lower() == "pipx" for part in prefix_path.parts):
+        return True
+    for env_name in ("PIPX_HOME", "PIPX_BIN_DIR"):
+        if os.environ.get(env_name):
+            return True
+    return False
+
+
+def _get_interval_seconds() -> int:
+    """Fetch the auto-update interval from environment or use default."""
+    value = os.environ.get("AUTO_CODER_UPDATE_INTERVAL_SECONDS")
+    if value is None:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        seconds = int(value)
+        if seconds < 0:
+            raise ValueError
+        return seconds
+    except ValueError:
+        logger.warning(
+            "Invalid AUTO_CODER_UPDATE_INTERVAL_SECONDS=%s; using default %s seconds",
+            value,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+
+
+def _state_path() -> Path:
+    """Compute the path that stores auto-update state information."""
+    override_dir = os.environ.get("AUTO_CODER_UPDATE_STATE_DIR")
+    base_dir = Path(override_dir).expanduser() if override_dir else Path.home() / ".cache" / "auto-coder"
+    return base_dir / _STATE_FILENAME
+
+
+def _load_state(path: Path) -> Dict[str, Any]:
+    """Load persisted auto-update state from disk."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        logger.warning("Corrupted auto-update state file detected at %s; ignoring", path)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to load auto-update state at %s: %s", path, exc)
+    return {}
+
+
+def _save_state(path: Path, state: Dict[str, Any]) -> None:
+    """Persist auto-update state to disk."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Unable to persist auto-update state at %s: %s", path, exc)
+
+
+def _notify_manual_update(reason: str) -> None:
+    """Display a manual update instruction to the user."""
+    message = (
+        "Auto-Coder auto-update could not be completed (" f"{reason}" "). "
+        "Please run 'pipx upgrade auto-coder' manually."
+    )
+    click.secho(message, fg="yellow", err=True)
+    logger.warning("Auto-update unavailable: %s", reason)
+
+
+def maybe_run_auto_update() -> None:
+    """Attempt to upgrade pipx installations automatically."""
+    if _auto_update_disabled():
+        logger.debug("Auto-update disabled via AUTO_CODER_DISABLE_AUTO_UPDATE")
+        return
+
+    if not _running_inside_pipx_env():
+        logger.debug("Not running inside pipx environment; skipping auto-update")
+        return
+
+    state_file = _state_path()
+    state = _load_state(state_file)
+
+    last_check = float(state.get("last_check", 0.0)) if "last_check" in state else 0.0
+    interval = _get_interval_seconds()
+    now = time.time()
+    if interval > 0 and (now - last_check) < interval:
+        logger.debug("Last auto-update check %.1f seconds ago; skipping", now - last_check)
+        return
+
+    pipx_executable = shutil.which("pipx")
+    if not pipx_executable:
+        _notify_manual_update("pipx executable not found in PATH")
+        return
+
+    state["last_check"] = now
+    _save_state(state_file, state)
+
+    try:
+        result = subprocess.run(
+            [pipx_executable, "upgrade", _PACKAGE_NAME],
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+    except Exception as exc:
+        _notify_manual_update(f"pipx upgrade execution failed: {exc}")
+        state["last_result"] = "error"
+        state["last_error"] = str(exc)
+        _save_state(state_file, state)
+        return
+
+    if result.returncode == 0:
+        logger.info("Auto-update completed via pipx")
+        state["last_result"] = "success"
+        state["last_error"] = ""
+        if result.stdout:
+            logger.debug("pipx upgrade output: %s", result.stdout.strip())
+        _save_state(state_file, state)
+        return
+
+    reason = result.stderr.strip() or "pipx upgrade returned non-zero exit status"
+    _notify_manual_update(reason)
+    state["last_result"] = "failure"
+    state["last_error"] = reason
+    if result.stdout:
+        state["last_stdout"] = result.stdout.strip()
+    _save_state(state_file, state)

--- a/tests/test_cli_auto_update_e2e.py
+++ b/tests/test_cli_auto_update_e2e.py
@@ -1,0 +1,93 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_fake_pipx(script_path: Path, exit_code: int, stderr: str = "") -> Path:
+    marker_dir = repr(str(script_path.parent))
+    script_contents = f"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+marker = Path({marker_dir}) / "pipx_invocation.json"
+data = {{
+    "argv": sys.argv,
+    "cwd": os.getcwd(),
+}}
+marker.write_text(json.dumps(data))
+if {exit_code}:
+    sys.stderr.write({stderr!r})
+sys.exit({exit_code})
+"""
+    script_path.write_text(script_contents)
+    script_path.chmod(0o755)
+    return script_path
+
+
+def _build_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("PATH", "")
+    env["PATH"] = f"{tmp_path / 'bin'}{os.pathsep}" + env["PATH"]
+    env["PIPX_HOME"] = str(tmp_path / "pipx-home")
+    env["AUTO_CODER_UPDATE_STATE_DIR"] = str(tmp_path / "state")
+    env["AUTO_CODER_UPDATE_INTERVAL_SECONDS"] = "0"
+    env.pop("AUTO_CODER_DISABLE_AUTO_UPDATE", None)
+    return env
+
+
+def test_cli_auto_update_invokes_pipx_upgrade(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script_path = bin_dir / "pipx"
+    _write_fake_pipx(script_path, exit_code=0)
+
+    env = _build_env(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "src.auto_coder.cli", "auth-status"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    marker = bin_dir / "pipx_invocation.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text())
+    assert data["argv"][1:] == ["upgrade", "auto-coder"]
+    assert "Checking authentication status" in result.stdout
+
+    state_file = tmp_path / "state" / "update_state.json"
+    assert state_file.exists()
+    state = json.loads(state_file.read_text())
+    assert state["last_result"] == "success"
+
+
+def test_cli_auto_update_notifies_on_failure(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script_path = bin_dir / "pipx"
+    _write_fake_pipx(script_path, exit_code=1, stderr="simulated error\n")
+
+    env = _build_env(tmp_path)
+    completed = subprocess.run(
+        [sys.executable, "-m", "src.auto_coder.cli", "auth-status"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    marker = bin_dir / "pipx_invocation.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text())
+    assert data["argv"][1:] == ["upgrade", "auto-coder"]
+    assert "Auto-Coder auto-update could not be completed" in completed.stderr
+    assert "pipx upgrade auto-coder" in completed.stderr
+
+    state_file = tmp_path / "state" / "update_state.json"
+    assert state_file.exists()
+    state = json.loads(state_file.read_text())
+    assert state["last_result"] == "failure"

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from src.auto_coder import update_manager
+
+
+@pytest.fixture(autouse=True)
+def clear_disable_flag(monkeypatch):
+    monkeypatch.delenv("AUTO_CODER_DISABLE_AUTO_UPDATE", raising=False)
+    monkeypatch.delenv("AUTO_CODER_UPDATE_INTERVAL_SECONDS", raising=False)
+    monkeypatch.delenv("AUTO_CODER_UPDATE_STATE_DIR", raising=False)
+
+
+def test_maybe_run_auto_update_skips_outside_pipx(monkeypatch):
+    with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=False):
+        with patch("src.auto_coder.update_manager.shutil.which") as mock_which:
+            update_manager.maybe_run_auto_update()
+            mock_which.assert_not_called()
+
+
+def test_maybe_run_auto_update_runs_pipx(monkeypatch, tmp_path):
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("AUTO_CODER_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("AUTO_CODER_UPDATE_INTERVAL_SECONDS", "0")
+
+    fake_result = subprocess.CompletedProcess(
+        args=["pipx", "upgrade", "auto-coder"], returncode=0, stdout="updated", stderr=""
+    )
+
+    with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=True), \
+        patch("src.auto_coder.update_manager.shutil.which", return_value="/usr/bin/pipx"), \
+        patch("src.auto_coder.update_manager.subprocess.run", return_value=fake_result) as mock_run:
+        update_manager.maybe_run_auto_update()
+        mock_run.assert_called_once_with(
+            ["/usr/bin/pipx", "upgrade", "auto-coder"],
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+
+    state_path = state_dir / "update_state.json"
+    assert state_path.exists()
+    state = json.loads(state_path.read_text())
+    assert state["last_result"] == "success"
+    assert state["last_error"] == ""
+
+
+def test_maybe_run_auto_update_reports_failure(monkeypatch, tmp_path, capsys):
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("AUTO_CODER_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("AUTO_CODER_UPDATE_INTERVAL_SECONDS", "0")
+
+    fake_result = subprocess.CompletedProcess(
+        args=["pipx", "upgrade", "auto-coder"], returncode=1, stdout="", stderr="network error"
+    )
+
+    with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=True), \
+        patch("src.auto_coder.update_manager.shutil.which", return_value="/usr/bin/pipx"), \
+        patch("src.auto_coder.update_manager.subprocess.run", return_value=fake_result):
+        update_manager.maybe_run_auto_update()
+
+    err = capsys.readouterr().err
+    assert "Auto-Coder auto-update could not be completed" in err
+    assert "pipx upgrade auto-coder" in err
+
+    state_path = state_dir / "update_state.json"
+    state = json.loads(state_path.read_text())
+    assert state["last_result"] == "failure"
+    assert "network error" in state["last_error"]
+
+
+def test_maybe_run_auto_update_respects_disable_flag(monkeypatch):
+    monkeypatch.setenv("AUTO_CODER_DISABLE_AUTO_UPDATE", "1")
+    with patch("src.auto_coder.update_manager._running_inside_pipx_env") as mock_env:
+        update_manager.maybe_run_auto_update()
+    mock_env.assert_not_called()


### PR DESCRIPTION
## Summary
- add a dedicated update manager that attempts to upgrade pipx installations on a schedule and falls back to user notifications when pipx is unavailable
- invoke the auto-update helper from the CLI entry point so pipx installs stay current or surface manual upgrade prompts
- create focused unit and end-to-end tests that exercise the auto-update success path and manual-notification path

## Testing
- scripts/test.sh tests/test_update_manager.py
- scripts/test.sh tests/test_cli_auto_update_e2e.py
- scripts/test.sh *(fails: numerous pre-existing AutomationEngine and CLI tests expecting unimplemented behaviours; run interrupted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d24a18002c832fa8c85022459bfc33