### PR TITLE
Load LLM prompts from YAML templates

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -499,6 +499,21 @@ special_features:
       - "tests/test_automation_engine.py::test_create_pr_prompt_is_action_oriented_no_comments"
       - "tests/test_automation_engine.py::test_apply_pr_actions_directly_does_not_post_comments"
 
+  llm_prompts_yaml_config:
+    name: "YAML-configured LLM prompts"
+    description: "All LLM instruction prompts (PR, issues, conflicts, test fixes, feature suggestions) are read from src/auto_coder/prompts.yaml."
+    behavior:
+      - "Central prompt templates defined in YAML with $placeholders"
+      - "Functions render prompts via prompt_loader.render_prompt"
+      - "Supports cache invalidation and custom prompt paths for tests"
+    implementation:
+      - "prompt_loader.py parses YAML and caches templates"
+      - "pr_processor, issue_processor, test_runner, gemini_client, qwen_client, conflict_resolver consume YAML prompts"
+    tests:
+      - "tests/test_prompt_loader.py::test_render_prompt_with_custom_path"
+      - "tests/test_prompt_loader.py::test_get_prompt_template_uses_cache"
+      - "tests/test_e2e_prompt_yaml.py::test_pr_prompt_uses_yaml_template"
+
       - "AutomationEngine._resolve_merge_conflicts_with_gemini updated to use specialized resolver and sequential handling"
 
   base_branch_merge_for_conflicts:

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from .automation_config import AutomationConfig
 from .utils import log_action
 from .test_runner import fix_to_pass_tests
-from .pr_processor import process_pull_requests
+from .pr_processor import process_pull_requests, _create_pr_analysis_prompt as _engine_pr_prompt
 from .issue_processor import process_issues, create_feature_issues, process_single
 from .logger_config import get_logger
 
@@ -93,3 +93,12 @@ class AutomationEngine:
             log_action(f"Report saved to {filepath}")
         except Exception as e:
             logger.error(f"Error saving report {filename}: {e}")
+
+    def _create_pr_analysis_prompt(
+        self,
+        repo_name: str,
+        pr_data: Dict[str, Any],
+        pr_diff: str = "",
+    ) -> str:
+        """Compatibility wrapper used in tests to expose the PR prompt builder."""
+        return _engine_pr_prompt(repo_name, pr_data, pr_diff, self.config)

--- a/src/auto_coder/prompt_loader.py
+++ b/src/auto_coder/prompt_loader.py
@@ -1,0 +1,90 @@
+"""Utilities for loading and formatting LLM instruction prompts from YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from string import Template
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .logger_config import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_PROMPTS_PATH = Path(__file__).resolve().parent / "prompts.yaml"
+
+_PROMPTS_CACHE: Dict[Path, Dict[str, Any]] = {}
+
+
+def _resolve_path(path: Optional[str] = None) -> Path:
+    """Resolve the prompt configuration path."""
+    if path is None:
+        return DEFAULT_PROMPTS_PATH
+    return Path(path).expanduser().resolve()
+
+
+def load_prompts(path: Optional[str] = None) -> Dict[str, Any]:
+    """Load prompts from YAML file, caching the parsed mapping."""
+    resolved = _resolve_path(path)
+    cached = _PROMPTS_CACHE.get(resolved)
+    if cached is not None:
+        return cached
+
+    try:
+        with resolved.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Prompt configuration file not found: {resolved}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Failed to parse prompt configuration: {resolved}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Prompt configuration root must be a mapping: {resolved}")
+
+    _PROMPTS_CACHE[resolved] = data
+    return data
+
+
+def clear_prompt_cache() -> None:
+    """Clear the prompt cache (useful for tests)."""
+    _PROMPTS_CACHE.clear()
+
+
+def _traverse(prompts: Dict[str, Any], key: str) -> Any:
+    """Traverse nested dictionaries using dot-separated keys."""
+    current: Any = prompts
+    for segment in key.split('.'):
+        if not isinstance(current, dict):
+            raise KeyError(f"Prompt path '{key}' does not resolve to a mapping")
+        if segment not in current:
+            raise KeyError(f"Prompt '{key}' not found in configuration")
+        current = current[segment]
+    return current
+
+
+def get_prompt_template(key: str, path: Optional[str] = None) -> str:
+    """Return the raw prompt template string for the given key."""
+    prompts = load_prompts(path)
+    template = _traverse(prompts, key)
+    if not isinstance(template, str):
+        raise ValueError(f"Prompt '{key}' must map to a string template")
+    return template
+
+
+def render_prompt(key: str, *, path: Optional[str] = None, data: Optional[Dict[str, Any]] = None, **kwargs: Any) -> str:
+    """Render a prompt template identified by key with provided parameters."""
+    template_str = get_prompt_template(key, path=path)
+    template = Template(template_str)
+
+    params: Dict[str, Any] = {}
+    if data:
+        params.update(data)
+    params.update(kwargs)
+
+    safe_params = {name: "" if value is None else str(value) for name, value in params.items()}
+    try:
+        return template.safe_substitute(safe_params)
+    except Exception as exc:  # pragma: no cover - Template handles placeholders gracefully
+        logger.error(f"Failed to render prompt '{key}': {exc}")
+        raise

--- a/src/auto_coder/prompts.yaml
+++ b/src/auto_coder/prompts.yaml
@@ -1,0 +1,226 @@
+pr:
+  action: |-
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description (truncated):
+    $pr_body...
+
+    PR Author: $pr_author
+    PR State: $pr_state
+    Draft: $pr_draft
+    Mergeable: $pr_mergeable
+
+    PR Changes (first $diff_limit chars):
+    $pr_diff
+
+  merge_conflict_resolution: |-
+    There are merge conflicts when trying to merge $base_branch branch into PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    Merge Conflict Information:
+    $conflict_info
+
+    Please resolve these merge conflicts by:
+    1. Examining the conflicted files
+    2. Choosing the appropriate resolution for each conflict
+    3. Editing files to fully remove all conflict markers
+    4. Do NOT run git add/commit/push; the system will handle committing.
+
+    After resolving the conflicts, respond with a single-line summary of what you resolved.
+
+    Please proceed with resolving these merge conflicts now.
+
+  github_actions_fix: |-
+    Fix the following GitHub Actions test failures for PR #$pr_number:
+
+    Repository: $repo_name
+    PR Title: $pr_title
+
+    GitHub Actions Error Logs (truncated):
+    $github_logs
+
+    Your task:
+    1) Identify the root cause(s) of the failing checks based on the logs.
+    2) Apply the necessary code changes directly in the repository to fix them.
+    3) After applying changes, run the appropriate quick checks if available (linters/unit tests) to sanity-verify.
+    4) Do NOT run git commit/push; the system will handle committing and pushing.
+
+    Output requirements:
+    - First, provide a concise summary of what you changed and why.
+    - Return only a short summary line; no commit/push output is needed.
+
+  local_test_fix: |-
+    Fix the following local test failures for PR #$pr_number:
+
+    Repository: $repo_name
+    PR Title: $pr_title
+
+    Test Output:
+    $test_output
+
+    Test Errors:
+    $test_errors
+
+    Key Errors:
+    Error summary would go here
+
+     Local test command used:
+     $test_command
+
+    Please analyze the test failures and provide specific code fixes.
+    Focus on making the tests pass while maintaining code quality.
+
+    After analyzing, apply the necessary fixes to the codebase.
+
+issue:
+  action: |-
+    Analyze the following GitHub issue and take appropriate actions:
+
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+
+    Issue Description:
+    $issue_body...
+
+    Issue Labels: $issue_labels
+    Issue State: $issue_state
+    Created by: $issue_author
+
+    Please analyze this issue and determine the appropriate action:
+
+    1. If this is a duplicate or invalid issue (spam, unclear, already resolved, etc.), close it with an appropriate comment
+    2. If this is a valid bug report or feature request, provide analysis and implementation
+    3. If this needs clarification, add a comment requesting more information
+
+    For valid issues that can be implemented:
+    - Analyze the requirements
+    - Implement the necessary code changes
+    - Create or modify files as needed
+    - Ensure the implementation follows best practices
+    - Prefer the smart, reasonable and logically beautiful change that resolves issues.
+
+    For duplicate/invalid issues:
+    - Close the issue
+    - Add a polite comment explaining why it was closed
+
+    After taking action, respond with a summary of what you did.
+
+    Please proceed with analyzing and taking action on this issue now.
+
+tests:
+  workspace_fix: |-
+    You are operating directly in this repository workspace with write access.
+
+    Goal: Make local tests pass by applying safe edits.
+
+    Task Memory File: ./llm_task.md
+    - If the file exists, review the "Logging Protocol" section before making changes.
+    - After completing your attempt, insert a new entry at the top of "## Experiment Log" using this exact template:
+    ```
+    ### YYYY-MM-DD HH:MM (local)
+    - Change Summary:
+    - Expected Outcome:
+    - Tests Run: `bash scripts/test.sh ...`
+    - Actual Outcome:
+    - Variance Analysis:
+    - Follow-ups / Notes:
+    ```
+    - Keep earlier log entries intact and maintain the newest entry first ordering.
+
+    STRICT RULES:
+    - Do NOT run git commit/push; the system will handle that.
+    - Prefer the smart, reasonable and logically beautiful change that resolves failures and preserves intent.
+
+    Local Test Failure Summary (truncated):
+    $error_summary
+
+     Local test command used:
+     $test_command
+
+    Now apply the fix directly in the repository.
+    Run tests again after applying the fix to verify that the fix resolves the issue.
+    Return a single concise line summarizing the change.
+
+  commit_message: |-
+    You have just applied code changes to fix failing local tests.
+    Craft a concise commit subject (single line, <= 72 chars, imperative mood) summarizing the change.
+
+    Rules:
+    - Subject line only. No body, no backticks, no code blocks.
+    - Do NOT include commands like git commit/push.
+    - Prefer specifics (file/function/test) if clear from context.
+
+gemini:
+  pr_analysis: |-
+    Analyze the following GitHub pull request and provide a structured analysis:
+
+    Title: $title
+    Body: $body
+    Labels: $labels
+    Branch: $head_branch -> $base_branch
+    Changes: +$additions -$deletions files: $changed_files
+    Draft: $draft
+    Mergeable: $mergeable
+
+    Please provide analysis in the following JSON format:
+    {
+        "category": "bugfix|feature|refactor|documentation|test",
+        "risk_level": "low|medium|high",
+        "review_priority": "low|medium|high",
+        "estimated_review_time": "minutes|hours",
+        "recommendations": [
+            {
+                "action": "description of recommended action",
+                "rationale": "why this action is recommended"
+            }
+        ],
+        "potential_issues": ["issue1", "issue2"],
+        "summary": "brief summary of the changes"
+    }
+
+feature:
+  suggestion: |-
+    Based on the following repository context, suggest new features that would be valuable:
+
+    Repository: $repo_name
+    Description: $description
+    Language: $language
+    Recent Issues: $recent_issues
+    Recent PRs: $recent_prs
+
+    Please provide feature suggestions in the following JSON format:
+    [
+        {
+            "title": "Feature title",
+            "description": "Detailed description of the feature",
+            "rationale": "Why this feature would be valuable",
+            "priority": "low|medium|high",
+            "complexity": "simple|moderate|complex",
+            "estimated_effort": "hours|days|weeks",
+            "labels": ["enhancement", "feature"],
+            "acceptance_criteria": [
+                "criteria 1",
+                "criteria 2"
+            ]
+        }
+    ]

--- a/src/auto_coder/qwen_client.py
+++ b/src/auto_coder/qwen_client.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from .logger_config import get_logger
 from .exceptions import AutoCoderUsageLimitError
 from .utils import CommandExecutor
+from .prompt_loader import render_prompt
 
 logger = get_logger(__name__)
 
@@ -150,32 +151,14 @@ class QwenClient:
             return []
 
     def _create_feature_suggestion_prompt(self, repo_context: Dict[str, Any]) -> str:
-        return f"""
-Based on the following repository context, suggest new features that would be valuable:
-
-Repository: {repo_context.get('name', 'Unknown')}
-Description: {repo_context.get('description', 'No description')}
-Language: {repo_context.get('language', 'Unknown')}
-Recent Issues: {repo_context.get('recent_issues', [])}
-Recent PRs: {repo_context.get('recent_prs', [])}
-
-Please provide feature suggestions in the following JSON format:
-[
-    {{
-        "title": "Feature title",
-        "description": "Detailed description of the feature",
-        "rationale": "Why this feature would be valuable",
-        "priority": "low|medium|high",
-        "complexity": "simple|moderate|complex",
-        "estimated_effort": "hours|days|weeks",
-        "labels": ["enhancement", "feature"],
-        "acceptance_criteria": [
-            "criteria 1",
-            "criteria 2"
-        ]
-    }}
-]
-"""
+        return render_prompt(
+            "feature.suggestion",
+            repo_name=repo_context.get('name', 'Unknown'),
+            description=repo_context.get('description', 'No description'),
+            language=repo_context.get('language', 'Unknown'),
+            recent_issues=repo_context.get('recent_issues', []),
+            recent_prs=repo_context.get('recent_prs', []),
+        )
 
     def _parse_feature_suggestions(self, response_text: str) -> List[Dict[str, Any]]:
         try:

--- a/tests/test_e2e_prompt_yaml.py
+++ b/tests/test_e2e_prompt_yaml.py
@@ -1,0 +1,52 @@
+"""E2E-style tests ensuring prompts are sourced from YAML templates."""
+
+from textwrap import dedent
+
+import pytest
+
+from src.auto_coder import prompt_loader
+from src.auto_coder.automation_config import AutomationConfig
+from src.auto_coder.pr_processor import _create_pr_analysis_prompt
+
+
+@pytest.fixture
+def sample_pr(sample_pr_data):
+    data = dict(sample_pr_data)
+    data['body'] = 'Example body text for YAML prompt test.'
+    data['user'] = {'login': 'octocat'}
+    return data
+
+
+def test_pr_prompt_uses_yaml_template(tmp_path, sample_pr):
+    """Customizing the YAML template should affect generated prompts end-to-end."""
+    custom_yaml = tmp_path / 'prompts.yaml'
+    custom_yaml.write_text(
+        dedent(
+            """
+            pr:
+              action: |
+                CUSTOM DIRECTIVE
+                Repository: $repo_name
+                Number: $pr_number
+            """
+        ),
+        encoding='utf-8',
+    )
+
+    prompt_loader.clear_prompt_cache()
+    original_path = prompt_loader.DEFAULT_PROMPTS_PATH
+    prompt_loader.DEFAULT_PROMPTS_PATH = custom_yaml
+    try:
+        prompt = _create_pr_analysis_prompt(
+            repo_name='owner/repo',
+            pr_data=sample_pr,
+            pr_diff='diff-data',
+            config=AutomationConfig(),
+        )
+    finally:
+        prompt_loader.DEFAULT_PROMPTS_PATH = original_path
+        prompt_loader.clear_prompt_cache()
+
+    assert 'CUSTOM DIRECTIVE' in prompt
+    assert 'owner/repo' in prompt
+    assert str(sample_pr['number']) in prompt

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -1,0 +1,44 @@
+"""Tests for prompt loader utilities."""
+
+import pytest
+
+from src.auto_coder.prompt_loader import (
+    DEFAULT_PROMPTS_PATH,
+    clear_prompt_cache,
+    get_prompt_template,
+    render_prompt,
+)
+
+
+@pytest.fixture
+def temp_prompt_file(tmp_path):
+    path = tmp_path / 'prompts.yaml'
+    path.write_text('category:\n  message: "Hello $name!"\n', encoding='utf-8')
+    return path
+
+
+def test_render_prompt_with_custom_path(temp_prompt_file):
+    clear_prompt_cache()
+    result = render_prompt('category.message', path=str(temp_prompt_file), name='World')
+    assert result == 'Hello World!'
+
+
+def test_get_prompt_template_uses_cache(temp_prompt_file):
+    clear_prompt_cache()
+    # First load caches the file
+    first = get_prompt_template('category.message', path=str(temp_prompt_file))
+    assert 'Hello $name!' in first
+
+    # Overwrite file; cached version should still be returned
+    temp_prompt_file.write_text('category:\n  message: "Changed"\n', encoding='utf-8')
+    cached = get_prompt_template('category.message', path=str(temp_prompt_file))
+    assert cached == first
+
+    clear_prompt_cache()
+    refreshed = get_prompt_template('category.message', path=str(temp_prompt_file))
+    assert refreshed == 'Changed'
+
+
+def test_default_prompt_file_exists():
+    path = DEFAULT_PROMPTS_PATH
+    assert path.exists(), f"Default prompt file missing at {path}"


### PR DESCRIPTION
## Summary
- move all LLM instruction templates into `src/auto_coder/prompts.yaml` and load them through a shared prompt loader
- switch PR, issue, conflict, and test fix flows to render prompts from YAML while keeping AutomationEngine compatibility
- add regression tests for the prompt loader plus an E2E check that overriding the YAML file changes generated PR prompts

## Testing
- `pytest tests/test_prompt_loader.py`
- `pytest tests/test_e2e_prompt_yaml.py`
- `pytest tests/test_automation_engine.py::test_create_pr_prompt_is_action_oriented_no_comments`
- `pytest tests/test_apply_workspace_test_fix_switch.py`


------
https://chatgpt.com/codex/tasks/task_e_68d254e5d000832fb5fd2f957b0a9d3f