### PR TITLE
Log fix-to-pass test metadata and LLM output

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from .automation_config import AutomationConfig
 from .utils import log_action
 from .test_runner import fix_to_pass_tests
+from . import test_runner as test_runner_module
 from .pr_processor import process_pull_requests, _create_pr_analysis_prompt as _engine_pr_prompt
 from .issue_processor import process_issues, create_feature_issues, process_single
 from .logger_config import get_logger
@@ -82,6 +83,22 @@ class AutomationEngine:
 
     def fix_to_pass_tests(self, max_attempts: Optional[int] = None) -> Dict[str, Any]:
         """Run tests and, if failing, repeatedly request LLM fixes until tests pass."""
+        run_override = getattr(self, '_run_local_tests', None)
+        apply_override = getattr(self, '_apply_workspace_test_fix', None)
+
+        if callable(run_override) or callable(apply_override):
+            original_run = test_runner_module.run_local_tests
+            original_apply = test_runner_module.apply_workspace_test_fix
+            try:
+                if callable(run_override):
+                    test_runner_module.run_local_tests = run_override
+                if callable(apply_override):
+                    test_runner_module.apply_workspace_test_fix = apply_override
+                return fix_to_pass_tests(self.config, self.dry_run, max_attempts, self.llm)
+            finally:
+                test_runner_module.run_local_tests = original_run
+                test_runner_module.apply_workspace_test_fix = original_apply
+
         return fix_to_pass_tests(self.config, self.dry_run, max_attempts, self.llm)
 
     def _save_report(self, data: Dict[str, Any], filename: str) -> None:

--- a/src/auto_coder/backend_manager.py
+++ b/src/auto_coder/backend_manager.py
@@ -4,7 +4,7 @@ apply_workspace_test_fix での同一プロンプト3連続時の自動切替を
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Any
+from typing import Callable, Dict, List, Optional, Any, Tuple
 
 from .logger_config import get_logger
 from .exceptions import AutoCoderUsageLimitError
@@ -166,6 +166,19 @@ class BackendManager:
         self._last_model = getattr(cur_cli2, 'model_name', None)
         self._last_backend = self._current_backend_name()
         return out
+
+    def get_last_backend_and_model(self) -> Tuple[Optional[str], Optional[str]]:
+        """Return the backend/model used for the most recent execution."""
+
+        backend = self._last_backend or self._current_backend_name()
+        model = self._last_model
+        if model is None:
+            try:
+                cli = self._get_or_create_client(self._current_backend_name())
+                model = getattr(cli, 'model_name', None)
+            except Exception:
+                model = None
+        return backend, model
 
     # ---------- 互換補助 ----------
     def switch_to_conflict_model(self) -> None:

--- a/src/auto_coder/test_runner.py
+++ b/src/auto_coder/test_runner.py
@@ -1,11 +1,13 @@
-"""
-Test runner functionality for Auto-Coder automation engine.
-"""
+"""Test runner functionality for Auto-Coder automation engine."""
 
+import csv
 import math
 import os
 import json
-from typing import Dict, Any, List, Optional
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, List, Optional, Tuple
 from datetime import datetime
 
 from .utils import CommandExecutor, change_fraction, slice_relevant_error_window, extract_first_failed_test, log_action
@@ -15,6 +17,109 @@ from .prompt_loader import render_prompt
 
 logger = get_logger(__name__)
 cmd = CommandExecutor()
+
+
+@dataclass
+class WorkspaceFixResult:
+    """Container for LLM workspace-fix responses used during test retries."""
+
+    summary: str
+    raw_response: Optional[str]
+    backend: str
+    model: str
+
+
+def _normalize_test_file(test_file: Optional[str]) -> str:
+    """Return a friendly identifier for the target test file."""
+
+    if test_file:
+        return test_file
+    return "ALL_TESTS"
+
+
+def _sanitize_for_filename(value: str, *, default: str) -> str:
+    """Sanitize arbitrary text so it is safe for filesystem use."""
+
+    if not value:
+        value = default
+    cleaned = re.sub(r"[^\w.-]+", "_", value)
+    cleaned = cleaned.strip("._")
+    if not cleaned:
+        cleaned = default
+    # Keep filenames reasonably short to avoid OS limits
+    return cleaned[:80]
+
+
+def _log_fix_attempt_metadata(test_file: Optional[str], backend: str, model: str, timestamp: datetime) -> Path:
+    """Append metadata about a fix attempt to the CSV summary log."""
+
+    base_dir = Path(".auto-coder")
+    base_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = base_dir / "fix_to_pass_tests_summury.csv"
+    file_exists = csv_path.exists()
+    record = [
+        _normalize_test_file(test_file),
+        backend or "unknown",
+        model or "unknown",
+        timestamp.isoformat(),
+    ]
+    with csv_path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        if not file_exists:
+            writer.writerow(["current_test_file", "backend", "model", "timestamp"])
+        writer.writerow(record)
+    return csv_path
+
+
+def _write_llm_output_log(
+    *,
+    raw_output: Optional[str],
+    test_file: Optional[str],
+    backend: str,
+    model: str,
+    timestamp: datetime,
+) -> Path:
+    """Persist the raw LLM output for traceability."""
+
+    log_dir = Path(".auto-coder") / "log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = "{time}_{test}_{backend}_{model}.txt".format(
+        time=timestamp.strftime("%Y%m%d_%H%M%S"),
+        test=_sanitize_for_filename(_normalize_test_file(test_file), default="tests"),
+        backend=_sanitize_for_filename(backend or "unknown", default="backend"),
+        model=_sanitize_for_filename(model or "unknown", default="model"),
+    )
+    log_path = log_dir / filename
+    content = raw_output if raw_output is not None else "LLM produced no response"
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write(content)
+    return log_path
+
+
+def _extract_backend_model(llm_client: Any) -> Tuple[str, str]:
+    """Derive backend/model identifiers from the provided LLM client."""
+
+    if llm_client is None:
+        return "unknown", "unknown"
+
+    getter = getattr(llm_client, "get_last_backend_and_model", None)
+    if callable(getter):
+        try:
+            backend, model = getter()
+            backend = backend or "unknown"
+            model = model or getattr(llm_client, "model_name", "unknown")
+            return backend, model
+        except Exception:
+            pass
+
+    backend = getattr(llm_client, "backend", None) or getattr(llm_client, "name", None)
+    if backend is None:
+        backend = llm_client.__class__.__name__
+    model = getattr(llm_client, "model_name", None)
+    if not model:
+        model = "unknown"
+    return str(backend), str(model)
 
 
 def cleanup_llm_task_file(path: str = "./llm_task.md") -> None:
@@ -82,15 +187,25 @@ def run_local_tests(config: AutomationConfig, test_file: Optional[str] = None) -
         }
 
 
-def apply_workspace_test_fix(config: AutomationConfig, test_result: Dict[str, Any], llm_client, dry_run: bool = False) -> str:
-    """Ask the LLM to apply workspace edits based on local test failures.
+def apply_workspace_test_fix(
+    config: AutomationConfig,
+    test_result: Dict[str, Any],
+    llm_client,
+    dry_run: bool = False,
+) -> WorkspaceFixResult:
+    """Ask the LLM to apply workspace edits based on local test failures."""
 
-    Returns a short action summary string.
-    """
+    backend, model = _extract_backend_model(llm_client)
+
     try:
         error_summary = extract_important_errors(test_result)
         if not error_summary:
-            return "No actionable errors found in local test output"
+            return WorkspaceFixResult(
+                summary="No actionable errors found in local test output",
+                raw_response=None,
+                backend=backend,
+                model=model,
+            )
 
         fix_prompt = render_prompt(
             "tests.workspace_fix",
@@ -99,20 +214,40 @@ def apply_workspace_test_fix(config: AutomationConfig, test_result: Dict[str, An
         )
 
         if dry_run:
-            return "[DRY RUN] Would apply fixes for local test failures"
+            return WorkspaceFixResult(
+                summary="[DRY RUN] Would apply fixes for local test failures",
+                raw_response=None,
+                backend=backend,
+                model=model,
+            )
 
         # Use the LLM client/manager to run the prompt
         if hasattr(llm_client, 'run_test_fix_prompt') and callable(getattr(llm_client, 'run_test_fix_prompt')):
             response = llm_client.run_test_fix_prompt(fix_prompt)
         else:
             response = llm_client._run_llm_cli(fix_prompt)
-        if response and response.strip():
-            # Take the first line as the summary and trim
-            first_line = response.strip().splitlines()[0]
-            return first_line[: config.MAX_RESPONSE_SIZE]
-        return "LLM produced no response"
+
+        backend, model = _extract_backend_model(llm_client)
+        raw_response = response.strip() if response and response.strip() else None
+        if raw_response:
+            first_line = raw_response.splitlines()[0]
+            summary = first_line[: config.MAX_RESPONSE_SIZE]
+        else:
+            summary = "LLM produced no response"
+
+        return WorkspaceFixResult(
+            summary=summary,
+            raw_response=raw_response,
+            backend=backend,
+            model=model,
+        )
     except Exception as e:
-        return f"Error applying workspace test fix: {e}"
+        return WorkspaceFixResult(
+            summary=f"Error applying workspace test fix: {e}",
+            raw_response=None,
+            backend=backend,
+            model=model,
+        )
 
 
 def fix_to_pass_tests(config: AutomationConfig, dry_run: bool = False, max_attempts: Optional[int] = None, llm_client=None) -> Dict[str, Any]:
@@ -166,7 +301,8 @@ def fix_to_pass_tests(config: AutomationConfig, dry_run: bool = False, max_attem
             return summary
 
         # Apply LLM-based fix
-        action_msg = apply_workspace_test_fix(config, test_result, llm_client, dry_run)
+        fix_response = apply_workspace_test_fix(config, test_result, llm_client, dry_run)
+        action_msg = fix_response.summary
         summary['messages'].append(action_msg)
 
         if dry_run:
@@ -182,6 +318,24 @@ def fix_to_pass_tests(config: AutomationConfig, dry_run: bool = False, max_attem
         summary['attempts'] = attempt
         logger.info(f"Re-running local tests after LLM fix (attempt {attempt}/{attempts_limit})")
         post_result = run_local_tests(config, test_file=current_test_file)
+
+        log_timestamp = datetime.now()
+        backend_for_log = fix_response.backend
+        model_for_log = fix_response.model
+        try:
+            _log_fix_attempt_metadata(current_test_file, backend_for_log, model_for_log, log_timestamp)
+        except Exception:
+            logger.warning("Failed to record fix-to-pass-tests summary CSV entry", exc_info=True)
+        try:
+            _write_llm_output_log(
+                raw_output=fix_response.raw_response,
+                test_file=current_test_file,
+                backend=backend_for_log,
+                model=model_for_log,
+                timestamp=log_timestamp,
+            )
+        except Exception:
+            logger.warning("Failed to write LLM output log for fix-to-pass-tests", exc_info=True)
 
         post_full_output = f"{post_result.get('errors', '')}\n{post_result.get('output', '')}".strip()
         post_error_summary = extract_important_errors(post_result)

--- a/tests/test_fix_to_pass_tests.py
+++ b/tests/test_fix_to_pass_tests.py
@@ -4,9 +4,10 @@ Tests for fix-to-pass-tests mode.
 
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
-from unittest.mock import Mock
 
+from src.auto_coder import test_runner as test_runner_module
 from src.auto_coder.automation_engine import AutomationEngine
+from src.auto_coder.test_runner import WorkspaceFixResult
 
 
 def _cmd_result(success=True, stdout="", stderr="", returncode=0):
@@ -24,7 +25,12 @@ def test_engine_fix_to_pass_tests_small_change_retries_without_commit(mock_githu
         'return_code': 1,
     })
     # LLM returns a message but effectively makes no meaningful change
-    engine._apply_workspace_test_fix = Mock(return_value="Applied change but minimal impact")
+    engine._apply_workspace_test_fix = Mock(return_value=WorkspaceFixResult(
+        summary='Applied change but minimal impact',
+        raw_response='Applied change but minimal impact',
+        backend='codex',
+        model='gpt-4',
+    ))
 
     # Run with max_attempts=1: it should retry once after LLM and stop without commit, not raise
     result = engine.fix_to_pass_tests(max_attempts=1)
@@ -74,3 +80,91 @@ def test_cli_fix_to_pass_tests_invokes_engine(monkeypatch):
 
     assert res.exit_code == 0
     dummy_engine.fix_to_pass_tests.assert_called_once()
+
+
+def test_fix_to_pass_tests_creates_llm_logs(monkeypatch, tmp_path):
+    from src.auto_coder.automation_config import AutomationConfig
+
+    monkeypatch.chdir(tmp_path)
+
+    config = AutomationConfig()
+
+    failing_result = {
+        'success': False,
+        'output': '',
+        'errors': 'AssertionError',
+        'return_code': 1,
+        'command': 'bash scripts/test.sh',
+        'test_file': 'tests/test_sample.py::test_fail',
+    }
+    post_fix_success = {
+        'success': True,
+        'output': 'ok',
+        'errors': '',
+        'return_code': 0,
+        'command': 'bash scripts/test.sh',
+        'test_file': None,
+    }
+
+    run_results = [failing_result, post_fix_success, post_fix_success]
+
+    def fake_run_local_tests(cfg, test_file=None):
+        result = run_results.pop(0).copy()
+        # Preserve explicit test_file when the stub wants to echo the requested target
+        result.setdefault('test_file', test_file)
+        return result
+
+    monkeypatch.setattr(test_runner_module, 'run_local_tests', fake_run_local_tests)
+
+    fix_response = WorkspaceFixResult(
+        summary='Applied fix',
+        raw_response='Detailed LLM output',
+        backend='codex',
+        model='gpt-4',
+    )
+    monkeypatch.setattr(test_runner_module, 'apply_workspace_test_fix', Mock(return_value=fix_response))
+
+    class DummyCmd:
+        DEFAULT_TIMEOUTS = {'test': 60}
+
+        def __init__(self):
+            self.calls = []
+
+        def run_command(self, command, timeout=None):
+            self.calls.append((tuple(command), timeout))
+            return SimpleNamespace(success=True, stdout='', stderr='', returncode=0)
+
+    dummy_cmd = DummyCmd()
+    monkeypatch.setattr(test_runner_module, 'cmd', dummy_cmd)
+
+    monkeypatch.setattr(
+        test_runner_module,
+        'generate_commit_message_via_llm',
+        Mock(return_value='Auto-Coder: log test'),
+    )
+
+    summary = test_runner_module.fix_to_pass_tests(config, dry_run=False, max_attempts=2, llm_client=Mock())
+
+    assert summary['success'] is True
+
+    csv_path = tmp_path / '.auto-coder' / 'fix_to_pass_tests_summury.csv'
+    assert csv_path.exists()
+    rows = csv_path.read_text(encoding='utf-8').strip().splitlines()
+    assert len(rows) == 2
+    assert rows[0].split(',')[0] == 'current_test_file'
+    assert 'tests/test_sample.py::test_fail' in rows[1]
+    assert ',codex,' in rows[1]
+    assert 'gpt-4' in rows[1]
+
+    log_dir = tmp_path / '.auto-coder' / 'log'
+    log_files = list(log_dir.glob('*.txt'))
+    assert len(log_files) == 1
+    log_name = log_files[0].name
+    sanitized_test = test_runner_module._sanitize_for_filename(
+        test_runner_module._normalize_test_file('tests/test_sample.py::test_fail'),
+        default='tests',
+    )
+    assert sanitized_test in log_name
+    assert 'codex' in log_name
+    assert 'gpt-4' in log_name
+    assert 'Detailed LLM output' in log_files[0].read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
- capture LLM fix metadata in a CSV and persist raw model output per attempt
- expose backend/model information from BackendManager and allow AutomationEngine test overrides
- exercise the new logging contract with a regression test for fix_to_pass_tests

## Testing
- pytest tests/test_fix_to_pass_tests.py tests/test_apply_workspace_test_fix_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68d289cdb114832fa2509f41ac58739e