### PR TITLE
Add auto-update checks to PR loop and tests

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -120,7 +120,7 @@ features:
             parameters: ["repo_name", "jules_mode (optional)"]
             returns: "Dictionary with automation results"
           - name: "fix_to_pass_tests"
-            description: "Run local tests and iteratively request LLM fixes until tests pass; commits are gated and happen only when the test output or the LLM error summary changes by >=10%; errors if LLM makes no edits"
+            description: "Run local tests and iteratively request LLM fixes until tests pass; commits are gated and happen only when the test output or the LLM error summary changes by >=10%; at the beginning of each iteration the loop checks for Auto-Coder updates and restarts with the original CLI arguments when an upgrade is applied; errors if LLM makes no edits"
             parameters: ["max_attempts (optional)"]
             returns: "Dictionary with success, attempts, and messages"
           - name: "process_single"
@@ -140,10 +140,10 @@ features:
             parameters: ["repo_name"]
             returns: "List of processed issues"
           - name: "_process_pull_requests"
-            description: "Process open pull requests in the repository with two-loop priority order"
+            description: "Process open pull requests in the repository with two-loop priority order, checking for Auto-Coder updates at the start of each iteration and restarting with the recorded CLI arguments when an upgrade is applied"
             parameters: ["repo_name"]
             returns: "List of processed PRs"
-            details: "First loop merges PRs with passing Actions AND mergeable status, second loop fixes remaining PRs"
+            details: "First loop merges PRs with passing Actions AND mergeable status, second loop fixes remaining PRs; each pass re-runs the auto-update check before contacting GitHub so upgrades are applied before continuing"
           - name: "_take_issue_actions"
             description: "Take automated actions based on issue analysis"
             parameters: ["repo_name", "issue_data", "analysis", "solution"]
@@ -160,6 +160,10 @@ features:
             description: "Process a PR for issue resolution when GitHub Actions are failing or pending"
             parameters: ["repo_name", "pr_data"]
             returns: "Dictionary with PR processing results"
+          - name: "_fix_pr_issues_with_testing"
+            description: "Fix PR issues by applying GitHub Actions log guidance then iterating local tests; every loop iteration begins with an auto-update check that restarts with the saved CLI arguments when an upgrade is detected"
+            parameters: ["repo_name", "pr_data", "config", "dry_run", "github_logs"]
+            returns: "List of actions taken"
           - name: "_is_package_lock_only_conflict"
             description: "Check if merge conflicts are only in package-lock.json or similar dependency files"
             parameters: ["conflict_info"]
@@ -280,7 +284,7 @@ features:
               - "--model-auggie": "Model to use when backend=auggie (defaults to GPT-5)"
               - "--gemini-api-key": "Gemini API key (optional, used when backend=gemini)"
           - name: "fix-to-pass-tests"
-            description: "Run tests and request LLM fixes until passing; stop with error if LLM made no edits"
+            description: "Run tests and request LLM fixes until passing; automatically checks for Auto-Coder updates at the start of each LLM attempt and restarts with the original CLI flags when an upgrade completes; stop with error if LLM made no edits"
             options:
               - "--backend": "AI backend(s) to use (codex|codex-mcp|gemini|qwen|auggie). Repeat option to set fallbacks; first value becomes the default. Default: codex"
               - "--model-gemini": "Model to use when backend=gemini"
@@ -349,9 +353,10 @@ workflows:
     description: "Automated workflow for processing GitHub pull requests with two-loop priority order"
     steps:
       1. "Fetch open pull requests from repository (oldest first)"
-      2. "First loop: Check GitHub Actions status AND mergeable status, merge qualifying PRs"
-      3. "Second loop: Process remaining PRs for issue resolution"
-      4. "Generate automation report"
+      2. "At the beginning of each pass iteration, check for Auto-Coder updates and restart with the original CLI arguments when an upgrade is applied"
+      3. "First loop: Check GitHub Actions status AND mergeable status, merge qualifying PRs"
+      4. "Second loop: Process remaining PRs for issue resolution"
+      5. "Generate automation report"
 
   feature_suggestion:
     name: "Feature Suggestion Workflow"

--- a/src/auto_coder/cli.py
+++ b/src/auto_coder/cli.py
@@ -20,7 +20,7 @@ from .automation_config import AutomationConfig
 from .git_utils import get_current_repo_name, is_git_repository
 from .auth_utils import get_github_token, get_auth_status
 from .logger_config import setup_logger, get_logger
-from .update_manager import maybe_run_auto_update
+from .update_manager import maybe_run_auto_update, record_startup_options
 
 # Load environment variables
 load_dotenv()
@@ -352,6 +352,7 @@ def qwen_help_has_flags(required_flags: list[str]) -> bool:
 @click.version_option(version="0.1.0", package_name="auto-coder")
 def main() -> None:
     """Auto-Coder: Automated application development using Gemini CLI and GitHub integration."""
+    record_startup_options(sys.argv, os.environ)
     maybe_run_auto_update()
 
 

--- a/src/auto_coder/update_manager.py
+++ b/src/auto_coder/update_manager.py
@@ -8,8 +8,9 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 import click
 
@@ -20,6 +21,21 @@ logger = get_logger(__name__)
 _DEFAULT_INTERVAL_SECONDS = 6 * 60 * 60  # every 6 hours
 _STATE_FILENAME = "update_state.json"
 _PACKAGE_NAME = "auto-coder"
+_CAPTURE_RESTART_ENV = "AUTO_CODER_TEST_CAPTURE_RESTART"
+
+_STARTUP_ARGS: Optional[tuple[str, ...]] = None
+_STARTUP_ENV: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class AutoUpdateResult:
+    """Structured result describing a pipx auto-update attempt."""
+
+    attempted: bool
+    updated: bool
+    reason: str = ""
+    stdout: str = ""
+    stderr: str = ""
 
 
 def _auto_update_disabled() -> bool:
@@ -101,15 +117,120 @@ def _notify_manual_update(reason: str) -> None:
     logger.warning("Auto-update unavailable: %s", reason)
 
 
-def maybe_run_auto_update() -> None:
+def record_startup_options(argv: Sequence[str], env: Optional[Mapping[str, str]] = None) -> None:
+    """Persist the original CLI invocation so restarts can replay it."""
+
+    global _STARTUP_ARGS, _STARTUP_ENV
+
+    try:
+        _STARTUP_ARGS = tuple(argv)
+    except Exception:
+        logger.debug("Failed to capture startup arguments; restart may be unavailable", exc_info=True)
+        _STARTUP_ARGS = None
+
+    if env is not None:
+        try:
+            _STARTUP_ENV = dict(env)
+        except Exception:
+            logger.debug("Failed to capture startup environment snapshot", exc_info=True)
+            _STARTUP_ENV = None
+
+
+def _resolve_startup_command(
+    argv: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> tuple[tuple[str, ...], Dict[str, str]]:
+    """Compute the command/environment that should be used for restart."""
+
+    if argv is None:
+        argv = _STARTUP_ARGS
+    if not argv:
+        return tuple(), {}
+
+    env_snapshot: Optional[Dict[str, str]]
+    if env is not None:
+        env_snapshot = dict(env)
+    elif _STARTUP_ENV is not None:
+        env_snapshot = dict(_STARTUP_ENV)
+    else:
+        env_snapshot = os.environ.copy()
+
+    return tuple(argv), env_snapshot
+
+
+def _capture_restart_event(argv: Sequence[str], env: Mapping[str, str]) -> None:
+    """Record restart intent for tests when capture env var is set."""
+
+    capture_path = os.environ.get(_CAPTURE_RESTART_ENV)
+    if not capture_path:
+        return
+
+    try:
+        path = Path(capture_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "argv": list(argv),
+            "env": dict(env),
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        logger.info("Auto-update restart captured for tests at %s", path)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to capture restart intent at %s: %s", capture_path, exc)
+    raise SystemExit(0)
+
+
+def restart_with_startup_options(
+    argv: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> None:
+    """Restart the current process using the recorded startup arguments."""
+
+    command, restart_env = _resolve_startup_command(argv, env)
+    if not command:
+        logger.warning("Auto-update requested restart but no startup command is recorded")
+        return
+
+    if os.environ.get(_CAPTURE_RESTART_ENV):  # pragma: no cover - path exercised via SystemExit in tests
+        _capture_restart_event(command, restart_env)
+        return
+
+    logger.info("Restarting process after auto-update: %s", " ".join(command))
+    os.execvpe(command[0], list(command), restart_env)
+
+
+def _pipx_upgrade_indicated_change(stdout: str, stderr: str) -> bool:
+    """Best-effort heuristic to detect if pipx reported an actual upgrade."""
+
+    combined = f"{stdout}\n{stderr}".lower()
+    negative_markers = [
+        "already up to date",
+        "nothing to upgrade",
+        "no action taken",
+        "not installed",
+    ]
+    if any(marker in combined for marker in negative_markers):
+        return False
+
+    positive_markers = [
+        "upgraded",
+        "updated",
+        "installing",
+        "installed",
+        "downloading",
+        "downloaded",
+    ]
+    return any(marker in combined for marker in positive_markers)
+
+
+def maybe_run_auto_update() -> AutoUpdateResult:
     """Attempt to upgrade pipx installations automatically."""
     if _auto_update_disabled():
         logger.debug("Auto-update disabled via AUTO_CODER_DISABLE_AUTO_UPDATE")
-        return
+        return AutoUpdateResult(False, False, reason="disabled")
 
     if not _running_inside_pipx_env():
         logger.debug("Not running inside pipx environment; skipping auto-update")
-        return
+        return AutoUpdateResult(False, False, reason="outside-pipx")
 
     state_file = _state_path()
     state = _load_state(state_file)
@@ -119,12 +240,12 @@ def maybe_run_auto_update() -> None:
     now = time.time()
     if interval > 0 and (now - last_check) < interval:
         logger.debug("Last auto-update check %.1f seconds ago; skipping", now - last_check)
-        return
+        return AutoUpdateResult(False, False, reason="interval")
 
     pipx_executable = shutil.which("pipx")
     if not pipx_executable:
         _notify_manual_update("pipx executable not found in PATH")
-        return
+        return AutoUpdateResult(False, False, reason="pipx-missing")
 
     state["last_check"] = now
     _save_state(state_file, state)
@@ -141,16 +262,23 @@ def maybe_run_auto_update() -> None:
         state["last_result"] = "error"
         state["last_error"] = str(exc)
         _save_state(state_file, state)
-        return
+        return AutoUpdateResult(True, False, reason=str(exc), stderr=str(exc))
 
     if result.returncode == 0:
-        logger.info("Auto-update completed via pipx")
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        updated = _pipx_upgrade_indicated_change(stdout, stderr)
         state["last_result"] = "success"
         state["last_error"] = ""
-        if result.stdout:
-            logger.debug("pipx upgrade output: %s", result.stdout.strip())
+        if stdout:
+            state["last_stdout"] = stdout.strip()
+        state["last_returncode"] = 0
         _save_state(state_file, state)
-        return
+        if updated:
+            logger.info("Auto-update completed via pipx")
+        else:
+            logger.debug("pipx upgrade reported success with no changes")
+        return AutoUpdateResult(True, updated, stdout=stdout, stderr=stderr)
 
     reason = result.stderr.strip() or "pipx upgrade returned non-zero exit status"
     _notify_manual_update(reason)
@@ -158,4 +286,16 @@ def maybe_run_auto_update() -> None:
     state["last_error"] = reason
     if result.stdout:
         state["last_stdout"] = result.stdout.strip()
+    state["last_returncode"] = result.returncode
     _save_state(state_file, state)
+    return AutoUpdateResult(True, False, reason=reason, stdout=result.stdout or "", stderr=result.stderr or "")
+
+
+def check_for_updates_and_restart() -> None:
+    """Check for CLI updates and restart the process when an upgrade is applied."""
+
+    result = maybe_run_auto_update()
+    if not result.updated:
+        return
+
+    restart_with_startup_options()

--- a/tests/test_fix_to_pass_tests.py
+++ b/tests/test_fix_to_pass_tests.py
@@ -14,8 +14,12 @@ def _cmd_result(success=True, stdout="", stderr="", returncode=0):
     return SimpleNamespace(success=success, stdout=stdout, stderr=stderr, returncode=returncode)
 
 
-def test_engine_fix_to_pass_tests_small_change_retries_without_commit(mock_github_client, mock_gemini_client):
+def test_engine_fix_to_pass_tests_small_change_retries_without_commit(
+    mock_github_client, mock_gemini_client, monkeypatch
+):
     engine = AutomationEngine(mock_github_client, mock_gemini_client, dry_run=False)
+
+    monkeypatch.setattr(test_runner_module, 'check_for_updates_and_restart', Mock(return_value=None))
 
     # Always failing output to simulate <10% change across retries
     engine._run_local_tests = Mock(return_value={
@@ -86,6 +90,8 @@ def test_fix_to_pass_tests_creates_llm_logs(monkeypatch, tmp_path):
     from src.auto_coder.automation_config import AutomationConfig
 
     monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(test_runner_module, 'check_for_updates_and_restart', Mock(return_value=None))
 
     config = AutomationConfig()
 

--- a/tests/test_fix_to_pass_tests_restart_e2e.py
+++ b/tests/test_fix_to_pass_tests_restart_e2e.py
@@ -1,0 +1,104 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from .test_cli_auto_update_e2e import _build_env
+
+
+def _write_fake_upgrading_pipx(script_path: Path) -> Path:
+    marker = script_path.parent / "pipx_invocation.json"
+    script_contents = f"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+marker = Path({str(script_path.parent)!r}) / "pipx_invocation.json"
+existing = []
+if marker.exists():
+    try:
+        existing = json.loads(marker.read_text())
+    except Exception:
+        existing = []
+existing.append({{"argv": sys.argv, "cwd": os.getcwd()}})
+marker.write_text(json.dumps(existing))
+print('upgraded package auto-coder from 0.0.1 to 0.0.2')
+"""
+    script_path.write_text(script_contents)
+    script_path.chmod(0o755)
+    return script_path
+
+
+def test_fix_to_pass_tests_loop_triggers_restart_on_update(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_upgrading_pipx(bin_dir / "pipx")
+    codex_stub = bin_dir / "codex"
+    codex_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [ \"$1\" = \"--version\" ]; then\n"
+        "  echo 'codex stub'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ \"$1\" = \"exec\" ]; then\n"
+        "  echo 'codex exec stub'\n"
+        "  exit 0\n"
+        "fi\n"
+        "echo 'codex stub invoked' >&2\n"
+        "exit 0\n"
+    )
+    codex_stub.chmod(0o755)
+
+    env = _build_env(tmp_path)
+    env["AUTOCODER_CODEX_CLI"] = "echo codex"
+    env["AUTO_CODER_TEST_CAPTURE_RESTART"] = str(tmp_path / "restart.json")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    existing_py_path = env.get("PYTHONPATH") or ""
+    extra_paths = [str(repo_root), str(repo_root / "src")]
+    if existing_py_path:
+        extra_paths.append(existing_py_path)
+    env["PYTHONPATH"] = os.pathsep.join(extra_paths)
+
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    test_script = scripts_dir / "test.sh"
+    marker_file = tmp_path / "test-script-invoked"
+    test_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'should not run' > /dev/null\n"
+        f"touch '{marker_file}'\n"
+        "exit 1\n"
+    )
+    test_script.chmod(0o755)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "src.auto_coder.cli",
+        "fix-to-pass-tests",
+        "--dry-run",
+    ]
+
+    completed = subprocess.run(
+        cmd,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert not marker_file.exists(), "test script should not run when restart happens first"
+
+    restart_marker = tmp_path / "restart.json"
+    assert restart_marker.exists()
+    restart_payload = json.loads(restart_marker.read_text())
+    assert "fix-to-pass-tests" in restart_payload["argv"]
+
+    pipx_marker = bin_dir / "pipx_invocation.json"
+    assert pipx_marker.exists()
+    invocations = json.loads(pipx_marker.read_text())
+    assert len(invocations) >= 1
+    assert invocations[0]["argv"][1:] == ["upgrade", "auto-coder"]

--- a/tests/test_pr_processor_auto_update.py
+++ b/tests/test_pr_processor_auto_update.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.auto_coder.automation_config import AutomationConfig
+from src.auto_coder import pr_processor as pr_module
+
+
+class _DummyGitHubClient:
+    """Simple stub client to exercise PR processing flows."""
+
+    def __init__(self):
+        self.details_calls: list[int] = []
+
+    def get_open_pull_requests(self, repo_name, limit=None):
+        return [SimpleNamespace(number=1)]
+
+    def get_pr_details(self, pr):
+        self.details_calls.append(pr.number)
+        return {
+            'number': pr.number,
+            'title': f'Stub PR {pr.number}',
+            'mergeable': True,
+        }
+
+
+def _config_with_pr_limit() -> AutomationConfig:
+    cfg = AutomationConfig()
+    cfg.max_prs_per_run = -1
+    return cfg
+
+
+def test_process_pull_requests_checks_update_before_merge_pass(monkeypatch):
+    client = _DummyGitHubClient()
+
+    call_count = {'value': 0}
+
+    def _fake_check():
+        call_count['value'] += 1
+        raise SystemExit(0)
+
+    monkeypatch.setattr(pr_module, 'check_for_updates_and_restart', _fake_check)
+
+    cfg = _config_with_pr_limit()
+
+    with pytest.raises(SystemExit):
+        pr_module.process_pull_requests(client, cfg, dry_run=True, repo_name='owner/repo')
+
+    assert call_count['value'] == 1
+    assert client.details_calls == []
+
+
+def test_process_pull_requests_second_pass_checks_update(monkeypatch):
+    client = _DummyGitHubClient()
+
+    call_order: list[str] = []
+
+    def _fake_check():
+        call_order.append('check')
+        if len(call_order) == 2:
+            raise SystemExit(0)
+
+    monkeypatch.setattr(pr_module, 'check_for_updates_and_restart', _fake_check)
+    monkeypatch.setattr(
+        pr_module,
+        '_check_github_actions_status',
+        lambda repo, pr_data, config: {'success': False},
+    )
+
+    cfg = _config_with_pr_limit()
+
+    with pytest.raises(SystemExit):
+        pr_module.process_pull_requests(client, cfg, dry_run=True, repo_name='owner/repo')
+
+    assert call_order == ['check', 'check']
+    assert client.details_calls == [1]
+
+
+def test_fix_pr_issues_with_testing_checks_updates_each_iteration(monkeypatch):
+    check_calls: list[int] = []
+
+    def _fake_check():
+        check_calls.append(len(check_calls))
+        if len(check_calls) == 2:
+            raise SystemExit(0)
+
+    monkeypatch.setattr(pr_module, 'check_for_updates_and_restart', _fake_check)
+    monkeypatch.setattr(pr_module, '_apply_github_actions_fix', lambda *args, **kwargs: [])
+    monkeypatch.setattr(pr_module, '_apply_local_test_fix', lambda *args, **kwargs: [])
+
+    test_results = iter([
+        {
+            'success': False,
+            'output': '',
+            'errors': '',
+            'command': 'bash scripts/test.sh',
+        }
+    ])
+
+    def _fake_run_local_tests(config):
+        return next(test_results)
+
+    monkeypatch.setattr(pr_module, 'run_local_tests', _fake_run_local_tests)
+
+    cfg = AutomationConfig()
+    pr_data = {'number': 7}
+
+    with pytest.raises(SystemExit):
+        pr_module._fix_pr_issues_with_testing('owner/repo', pr_data, cfg, dry_run=True, github_logs='')
+
+    assert check_calls == [0, 1]

--- a/tests/test_process_issues_restart_e2e.py
+++ b/tests/test_process_issues_restart_e2e.py
@@ -1,0 +1,120 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from .test_cli_auto_update_e2e import _build_env
+from .test_fix_to_pass_tests_restart_e2e import _write_fake_upgrading_pipx
+
+
+def _write_restart_runner(script_path: Path, capture_path: Path) -> None:
+    script_path.write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from types import SimpleNamespace\n"
+        "\n"
+        "from src.auto_coder.automation_config import AutomationConfig\n"
+        "from src.auto_coder.pr_processor import process_pull_requests\n"
+        "from src.auto_coder.update_manager import record_startup_options\n"
+        "\n"
+        "class DummyGitHubClient:\n"
+        "    def __init__(self, marker: Path):\n"
+        "        self.marker = marker\n"
+        "\n"
+        "    def _record(self, event):\n"
+        "        data = []\n"
+        "        if self.marker.exists():\n"
+        "            try:\n"
+        "                data = json.loads(self.marker.read_text())\n"
+        "            except Exception:\n"
+        "                data = []\n"
+        "        data.append(event)\n"
+        "        self.marker.write_text(json.dumps(data))\n"
+        "\n"
+        "    def get_open_pull_requests(self, repo_name, limit=None):\n"
+        "        self._record({'event': 'get_open_pull_requests', 'repo': repo_name})\n"
+        "        return [SimpleNamespace(number=1), SimpleNamespace(number=2)]\n"
+        "\n"
+        "    def get_pr_details(self, pr):\n"
+        "        self._record({'event': 'get_pr_details', 'number': pr.number})\n"
+        "        return {'number': pr.number, 'title': f'PR {pr.number}', 'mergeable': True}\n"
+        "\n"
+        "record_startup_options(sys.argv, os.environ)\n"
+        "cfg = AutomationConfig()\n"
+        "cfg.max_prs_per_run = -1\n"
+        "marker = Path(os.environ['AUTO_CODER_TEST_GITHUB_MARKER'])\n"
+        "client = DummyGitHubClient(marker)\n"
+        "\n"
+        "# Ensure deterministic behavior for PR processing\n"
+        "from src.auto_coder import pr_processor as pr_module\n"
+        "pr_module._check_github_actions_status = lambda repo, pr_data, config: {'success': False}\n"
+        "pr_module._process_pr_for_fixes = lambda repo, pr_data, config, dry_run: {'pr_data': pr_data, 'actions_taken': [], 'priority': 'fix'}\n"
+        "\n"
+        "process_pull_requests(client, cfg, dry_run=True, repo_name='owner/repo')\n"
+        "raise RuntimeError('Expected restart before completing PR processing')\n",
+        encoding="utf-8",
+    )
+
+
+def test_process_issues_pr_loop_triggers_restart_on_update(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_upgrading_pipx(bin_dir / "pipx")
+
+    codex_stub = bin_dir / "codex"
+    codex_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [ \"$1\" = \"--version\" ]; then\n"
+        "  echo 'codex stub'\n"
+        "  exit 0\n"
+        "fi\n"
+        "echo 'codex stub invoked' >&2\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    codex_stub.chmod(0o755)
+
+    env = _build_env(tmp_path)
+    env["AUTOCODER_CODEX_CLI"] = "echo codex"
+
+    restart_marker = tmp_path / "restart.json"
+    env["AUTO_CODER_TEST_CAPTURE_RESTART"] = str(restart_marker)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    github_marker = tmp_path / "github-events.json"
+    github_marker.write_text("[]", encoding="utf-8")
+    env["AUTO_CODER_TEST_GITHUB_MARKER"] = str(github_marker)
+
+    existing_py_path = env.get("PYTHONPATH") or ""
+    extra_paths = [str(repo_root), str(repo_root / "src")]
+    if existing_py_path:
+        extra_paths.append(existing_py_path)
+    env["PYTHONPATH"] = os.pathsep.join(extra_paths)
+
+    runner_script = tmp_path / "run_restart.py"
+    _write_restart_runner(runner_script, restart_marker)
+
+    completed = subprocess.run(
+        [sys.executable, str(runner_script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert restart_marker.exists()
+    restart_payload = json.loads(restart_marker.read_text())
+    assert "run_restart.py" in Path(restart_payload["argv"][0]).name
+
+    pipx_marker = bin_dir / "pipx_invocation.json"
+    assert pipx_marker.exists()
+    invocations = json.loads(pipx_marker.read_text())
+    assert len(invocations) >= 1
+    assert invocations[0]["argv"][1:] == ["upgrade", "auto-coder"]
+
+    events = json.loads(github_marker.read_text())
+    assert any(evt.get("event") == "get_open_pull_requests" for evt in events)

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -17,8 +17,11 @@ def clear_disable_flag(monkeypatch):
 def test_maybe_run_auto_update_skips_outside_pipx(monkeypatch):
     with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=False):
         with patch("src.auto_coder.update_manager.shutil.which") as mock_which:
-            update_manager.maybe_run_auto_update()
+            result = update_manager.maybe_run_auto_update()
             mock_which.assert_not_called()
+            assert result.attempted is False
+            assert result.updated is False
+            assert result.reason == "outside-pipx"
 
 
 def test_maybe_run_auto_update_runs_pipx(monkeypatch, tmp_path):
@@ -33,13 +36,16 @@ def test_maybe_run_auto_update_runs_pipx(monkeypatch, tmp_path):
     with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=True), \
         patch("src.auto_coder.update_manager.shutil.which", return_value="/usr/bin/pipx"), \
         patch("src.auto_coder.update_manager.subprocess.run", return_value=fake_result) as mock_run:
-        update_manager.maybe_run_auto_update()
+        result = update_manager.maybe_run_auto_update()
         mock_run.assert_called_once_with(
             ["/usr/bin/pipx", "upgrade", "auto-coder"],
             capture_output=True,
             text=True,
             timeout=900,
         )
+        assert result.attempted is True
+        assert result.updated is True
+        assert result.stdout == "updated"
 
     state_path = state_dir / "update_state.json"
     assert state_path.exists()
@@ -60,11 +66,14 @@ def test_maybe_run_auto_update_reports_failure(monkeypatch, tmp_path, capsys):
     with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=True), \
         patch("src.auto_coder.update_manager.shutil.which", return_value="/usr/bin/pipx"), \
         patch("src.auto_coder.update_manager.subprocess.run", return_value=fake_result):
-        update_manager.maybe_run_auto_update()
+        result = update_manager.maybe_run_auto_update()
 
     err = capsys.readouterr().err
     assert "Auto-Coder auto-update could not be completed" in err
     assert "pipx upgrade auto-coder" in err
+    assert result.attempted is True
+    assert result.updated is False
+    assert "network error" in result.reason
 
     state_path = state_dir / "update_state.json"
     state = json.loads(state_path.read_text())
@@ -75,5 +84,45 @@ def test_maybe_run_auto_update_reports_failure(monkeypatch, tmp_path, capsys):
 def test_maybe_run_auto_update_respects_disable_flag(monkeypatch):
     monkeypatch.setenv("AUTO_CODER_DISABLE_AUTO_UPDATE", "1")
     with patch("src.auto_coder.update_manager._running_inside_pipx_env") as mock_env:
-        update_manager.maybe_run_auto_update()
+        result = update_manager.maybe_run_auto_update()
     mock_env.assert_not_called()
+    assert result.attempted is False
+    assert result.updated is False
+    assert result.reason == "disabled"
+
+
+def test_check_for_updates_and_restart_triggers_capture(monkeypatch, tmp_path):
+    marker = tmp_path / "restart.json"
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("AUTO_CODER_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("AUTO_CODER_UPDATE_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("AUTO_CODER_TEST_CAPTURE_RESTART", str(marker))
+
+    update_manager.record_startup_options(["auto-coder", "fix-to-pass-tests"], {"PATH": "/tmp"})
+
+    fake_result = subprocess.CompletedProcess(
+        args=["pipx", "upgrade", "auto-coder"],
+        returncode=0,
+        stdout="upgraded package auto-coder from 0.0.1 to 0.0.2",
+        stderr="",
+    )
+
+    with patch("src.auto_coder.update_manager._running_inside_pipx_env", return_value=True), \
+        patch("src.auto_coder.update_manager.shutil.which", return_value="/usr/bin/pipx"), \
+        patch("src.auto_coder.update_manager.subprocess.run", return_value=fake_result):
+        with pytest.raises(SystemExit) as exc:
+            update_manager.check_for_updates_and_restart()
+
+    assert exc.value.code == 0
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["argv"] == ["auto-coder", "fix-to-pass-tests"]
+    assert payload["env"]["PATH"] == "/tmp"
+
+
+def test_restart_without_recorded_command():
+    # Clear previously recorded state
+    update_manager.record_startup_options([])
+    with patch("src.auto_coder.update_manager.os.execvpe") as mock_exec:
+        update_manager.restart_with_startup_options()
+    mock_exec.assert_not_called()


### PR DESCRIPTION
## Summary
- add structured auto-update results, record startup options, and restart helper utilities so the CLI can relaunch after pipx upgrades
- invoke the auto-update check at the beginning of each fix-to-pass-tests iteration and teach the CLI to record its startup arguments
- expand documentation and tests, including a new e2e scenario that verifies the loop restarts before running repo tests

## Testing
- pytest tests/test_update_manager.py
- pytest tests/test_fix_to_pass_tests.py
- pytest tests/test_fix_to_pass_tests_restart_e2e.py
- pytest tests/test_cli_auto_update_e2e.py

------
https://chatgpt.com/codex/tasks/task_e_68d33bee84b8832f8b2e16be9d0327d2