### PR TITLE
ci: automate version updates

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,52 @@
+name: Update Version
+
+on:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  update-version:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Update version strings
+        id: update_version
+        run: |
+          VERSION=$(python scripts/update_version.py)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Detect changes
+        id: git_status
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit updated version
+        if: steps.git_status.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.update_version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: auto-update version to ${VERSION}"
+
+      - name: Push changes
+        if: steps.git_status.outputs.changed == 'true'
+        run: git push

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -4,7 +4,7 @@
 
 application:
   name: "Auto-Coder"
-  version: "0.1.0"
+  version: "2025.9.24.1+g9386893"
   description: "Automated application development using AI CLI backends (codex default, switchable to gemini via --backend) and GitHub integration"
 
 features:

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -4,7 +4,7 @@
 
 application:
   name: "Auto-Coder"
-  version: "2025.9.24.1+g9386893"
+  version: "2025.9.24.2+g2410e9a"
   description: "Automated application development using AI CLI backends (codex default, switchable to gemini via --backend) and GitHub integration"
 
 features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-coder"
-version = "0.1.0"
+version = "2025.9.24.1+g9386893"
 description = "Automated application development using Gemini CLI and GitHub integration"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-coder"
-version = "2025.9.24.1+g9386893"
+version = "2025.9.24.2+g2410e9a"
 description = "Automated application development using Gemini CLI and GitHub integration"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Utility to update the Auto-Coder version string across the repository."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_git_command(args: list[str]) -> str:
+    result = subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def compute_version() -> str:
+    """Compute the YYYY.M.D[.patch]+g<sha> version for the current HEAD."""
+
+    commit_date = _run_git_command(["show", "-s", "--format=%cd", "--date=format:%Y-%m-%d", "HEAD"])
+    year_str, month_str, day_str = commit_date.split("-")
+    base_date = f"{year_str}.{int(month_str)}.{int(day_str)}"
+
+    commits_today = int(
+        _run_git_command(
+            [
+                "rev-list",
+                "--count",
+                f"--since={year_str}-{month_str}-{day_str} 00:00:00",
+                "HEAD",
+            ]
+        )
+        or "0"
+    )
+    patch_suffix = f".{commits_today - 1}" if commits_today > 1 else ""
+
+    short_sha = _run_git_command(["rev-parse", "--short", "HEAD"])
+    return f"{base_date}{patch_suffix}+g{short_sha}"
+
+
+def _replace_pattern(path: Path, pattern: str, replacement_value: str) -> bool:
+    original = path.read_text()
+
+    def _repl(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{replacement_value}{match.group(3)}"
+
+    updated, count = re.subn(pattern, _repl, original, count=1, flags=re.MULTILINE | re.DOTALL)
+    if count == 0:
+        raise ValueError(f"Could not find pattern in {path}")
+    if updated != original:
+        path.write_text(updated)
+        return True
+    return False
+
+
+def update_version_files(version: str) -> None:
+    update_targets: list[tuple[Path, str]] = [
+        (REPO_ROOT / "pyproject.toml", r'^(version\s*=\s*")([^\"]+)(")'),
+        (REPO_ROOT / "src" / "auto_coder" / "__init__.py", r'^(__version__\s*=\s*")([^\"]+)(")'),
+        (
+            REPO_ROOT / "docs" / "client-features.yaml",
+            r'^(\s*version:\s*")([^\"]+)(")',
+        ),
+    ]
+
+    uv_lock_path = REPO_ROOT / "uv.lock"
+    if uv_lock_path.exists():
+        update_targets.append(
+            (
+                uv_lock_path,
+                r'(\[\[package\]\]\s+name\s*=\s*"auto-coder"\s+version\s*=\s*")([^\"]+)(")',
+            )
+        )
+
+    for path, pattern in update_targets:
+        if not path.exists():
+            raise FileNotFoundError(f"Expected file not found: {path}")
+
+    for path, pattern in update_targets:
+        _replace_pattern(path, pattern, version)
+
+
+def main() -> None:
+    try:
+        version = compute_version()
+        update_version_files(version)
+    except Exception as exc:  # pragma: no cover - simple CLI wrapper
+        print(f"Failed to update version: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(version)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/auto_coder/__init__.py
+++ b/src/auto_coder/__init__.py
@@ -2,6 +2,6 @@
 Auto-Coder: Automated application development using Gemini CLI and GitHub integration.
 """
 
-__version__ = "2025.9.24.1+g9386893"
+__version__ = "2025.9.24.2+g2410e9a"
 __author__ = "Auto-Coder Team"
 __description__ = "Automated application development using Gemini CLI and GitHub integration"

--- a/src/auto_coder/__init__.py
+++ b/src/auto_coder/__init__.py
@@ -2,6 +2,6 @@
 Auto-Coder: Automated application development using Gemini CLI and GitHub integration.
 """
 
-__version__ = "0.1.0"
+__version__ = "2025.9.24.1+g9386893"
 __author__ = "Auto-Coder Team"
 __description__ = "Automated application development using Gemini CLI and GitHub integration"

--- a/src/auto_coder/cli.py
+++ b/src/auto_coder/cli.py
@@ -1,13 +1,13 @@
-"""
-Command Line Interface for Auto-Coder.
-"""
+"""Command Line Interface for Auto-Coder."""
 
-import click
-from typing import Optional
 import os
 import sys
+from typing import Optional
+
+import click
 from dotenv import load_dotenv
 
+from . import __version__ as AUTO_CODER_VERSION
 from .github_client import GitHubClient
 from .gemini_client import GeminiClient
 from .codex_client import CodexClient
@@ -19,7 +19,7 @@ from .backend_manager import BackendManager
 from .automation_config import AutomationConfig
 from .git_utils import get_current_repo_name, is_git_repository
 from .auth_utils import get_github_token, get_auth_status
-from .logger_config import setup_logger, get_logger
+from .logger_config import get_logger, setup_logger
 from .update_manager import maybe_run_auto_update, record_startup_options
 
 # Load environment variables
@@ -349,7 +349,7 @@ def qwen_help_has_flags(required_flags: list[str]) -> bool:
 
 
 @click.group()
-@click.version_option(version="0.1.0", package_name="auto-coder")
+@click.version_option(version=AUTO_CODER_VERSION, package_name="auto-coder")
 def main() -> None:
     """Auto-Coder: Automated application development using Gemini CLI and GitHub integration."""
     record_startup_options(sys.argv, os.environ)

--- a/src/auto_coder/codex_mcp_client.py
+++ b/src/auto_coder/codex_mcp_client.py
@@ -14,15 +14,16 @@ process remains alive to satisfy the requirement of keeping a session for
 
 from __future__ import annotations
 
+import json
 import os
+import select
+import shlex
 import subprocess
 import threading
-import json
-import shlex
 import time
-import select
-from typing import Optional, List, Any, Dict
+from typing import Any, Dict, List, Optional
 
+from . import __version__ as AUTO_CODER_VERSION
 from .logger_config import get_logger
 
 logger = get_logger(__name__)
@@ -112,7 +113,7 @@ class CodexMCPClient:
                 params={
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "auto-coder", "version": "0.1.0"},
+                    "clientInfo": {"name": "auto-coder", "version": AUTO_CODER_VERSION},
                 },
                 timeout=self._handshake_timeout,
             )

--- a/tests/test_codex_mcp_client.py
+++ b/tests/test_codex_mcp_client.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from src.auto_coder import __version__ as AUTO_CODER_VERSION
 from src.auto_coder.codex_mcp_client import CodexMCPClient
 
 
@@ -33,7 +34,7 @@ def test_handshake_timeout_uses_configured_limit(monkeypatch):
         params={
             "protocolVersion": "2024-11-05",
             "capabilities": {},
-            "clientInfo": {"name": "auto-coder", "version": "0.1.0"},
+            "clientInfo": {"name": "auto-coder", "version": AUTO_CODER_VERSION},
         },
         timeout=client._handshake_timeout,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "auto-coder"
-version = "2025.9.24.1+g9386893"
+version = "2025.9.24.2+g2410e9a"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "auto-coder"
-version = "0.1.0"
+version = "2025.9.24.1+g9386893"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that updates repository version strings from the latest commit metadata and pushes the result
- introduce a Python helper script to compute YYYY.M.D[.patch]+g<sha> versions and rewrite project metadata consistently
- refactor CLI/runtime code and fixtures to consume the shared version constant while updating stored metadata to the new format

## Testing
- pytest *(fails: numerous existing AttributeErrors/missing optional dependencies such as CommandExecutor and playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68d38b6846f0832f913728e2905c88fe