### PR TITLE
Prioritize Qwen API-key providers before OAuth fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ cp .env.example .env
   - `qwen` を一度実行し、ブラウザで qwen.ai アカウント認証すると自動で利用可能になります。
   - 途中で `/auth` コマンドを実行すると Qwen OAuth に切替できます。
   - 参考: Qwen Code 公式リポジトリ（Authorization セクション）: https://github.com/QwenLM/qwen-code
+- リミット到達時の自動フォールバック:
+  - Auto-Coder は設定済みの OpenAI 互換エンドポイントを優先的に使用し、すべての API キーが枯渇した場合にのみ Qwen OAuth に戻ります。
+  - 設定ファイルの場所: `~/.auto-coder/qwen-providers.toml`（`AUTO_CODER_QWEN_CONFIG` でパスを上書き可、`AUTO_CODER_CONFIG_DIR` でディレクトリ指定も可）。
+  - TOML 例:
+
+    ```toml
+    [[qwen.providers]]
+    # Option 1: Alibaba Cloud ModelStudio
+    name = "modelstudio"
+    api_key = "dashscope-..."  # 取得した API キーを設定
+    # base_url と model は省略すると既定値（dashscope互換 / qwen3-coder-plus）
+
+    [[qwen.providers]]
+    # Option 2: OpenRouter Free Tier
+    name = "openrouter"
+    api_key = "openrouter-..."
+    model = "qwen/qwen3-coder:free"  # 省略時は既定値を使用
+    ```
+
+  - 記述順にフォールバックします（API キー → OAuth の順番）。API キーのみ記入すれば既定 URL/モデルが適用され、実行時に `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` が自動注入されます。
 - OpenAI 互換モード:
   - 以下の環境変数を設定して利用できます。
     - `OPENAI_API_KEY`（必須）

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -721,6 +721,37 @@ deployment:
         - "tests/test_llm_cli_neutral.py::test_qwen_client_llm_alias"
         - "tests/test_llm_cli_neutral.py::test_codex_client_llm_alias"
 
+    provider_fallback:
+      name: "Qwen OAuth usage limit fallback"
+      description: |
+        Prefer configured OpenAI-compatible providers (ModelStudio, OpenRouter, etc.)
+        before falling back to the shared Qwen OAuth pool when usage limits occur.
+      configuration:
+        files:
+          - path: "~/.auto-coder/qwen-providers.toml"
+            description: |
+              TOML file defining fallback providers. Each entry supplies ``name`` and
+              ``api_key``; known providers auto-fill ``base_url``/``model``.
+          - env: "AUTO_CODER_QWEN_CONFIG"
+            description: "Override the exact config file path"
+          - env: "AUTO_CODER_CONFIG_DIR"
+            description: "Override the directory that contains qwen-providers.toml"
+      behavior:
+        - "Providers are attempted in file order before OAuth"
+        - "OPENAI_API_KEY/OPENAI_BASE_URL/OPENAI_MODEL are injected per provider"
+        - "Successful provider becomes the active default for subsequent calls"
+        - "Aggregates AutoCoderUsageLimitError details if all providers are exhausted"
+      implementation:
+        - "src/auto_coder/qwen_client.py"
+        - "src/auto_coder/qwen_provider_config.py"
+      tests:
+        - "tests/test_qwen_provider_config.py::test_load_qwen_provider_configs_defaults"
+        - "tests/test_qwen_provider_config.py::test_load_qwen_provider_configs_skips_missing_key"
+        - "tests/test_qwen_client_fallback.py::test_qwen_client_prefers_configured_api_keys_before_oauth"
+        - "tests/test_qwen_client_fallback.py::test_qwen_client_fallback_to_openrouter"
+        - "tests/test_qwen_client_fallback.py::test_qwen_client_fallbacks_to_oauth_after_api_keys"
+        - "tests/test_qwen_client_fallback.py::test_qwen_client_all_limits_raise"
+
     backend_manager:
       name: "Cyclic Multi-Backend Manager"
       description: "Manages multiple AI backends and switches cyclically on usage limits or repeated failures."

--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -15,6 +15,8 @@ class AutomationConfig:
     MAX_PR_DIFF_SIZE: int = 2000
     MAX_PROMPT_SIZE: int = 1000
     MAX_RESPONSE_SIZE: int = 200
+    max_issues_per_run: int = -1
+    max_prs_per_run: int = -1
     # Default max attempts for fix loops
     # Note: tests expect strict default value of 3
     MAX_FIX_ATTEMPTS: int = 3

--- a/src/auto_coder/qwen_provider_config.py
+++ b/src/auto_coder/qwen_provider_config.py
@@ -1,0 +1,133 @@
+"""Helpers for loading Qwen provider fallback configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+try:  # Python 3.11+ ships with tomllib
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    import tomli as tomllib  # type: ignore[import]
+
+from .logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+CONFIG_OVERRIDE_ENV = "AUTO_CODER_QWEN_CONFIG"
+CONFIG_DIR_ENV = "AUTO_CODER_CONFIG_DIR"
+CONFIG_FILENAME = "qwen-providers.toml"
+
+
+@dataclass
+class QwenProviderConfig:
+    """Representation of a single Qwen provider option."""
+
+    name: str
+    api_key: str
+    base_url: Optional[str]
+    model: Optional[str]
+    description: str
+
+
+_PROVIDER_DEFAULTS = {
+    "modelstudio": {
+        "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        "model": "qwen3-coder-plus",
+        "description": "Alibaba Cloud ModelStudio compatible endpoint",
+    },
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "model": "qwen/qwen3-coder:free",
+        "description": "OpenRouter free tier compatible endpoint",
+    },
+}
+
+
+def _resolve_config_path() -> Path:
+    """Return the path to the Qwen provider configuration file."""
+
+    override = os.environ.get(CONFIG_OVERRIDE_ENV)
+    if override:
+        return Path(override).expanduser()
+
+    base_dir = os.environ.get(CONFIG_DIR_ENV)
+    if base_dir:
+        return Path(base_dir).expanduser() / CONFIG_FILENAME
+
+    return Path.home() / ".auto-coder" / CONFIG_FILENAME
+
+
+def _iter_provider_entries(raw_providers: Iterable[dict]) -> Iterable[QwenProviderConfig]:
+    """Convert raw provider dicts into ``QwenProviderConfig`` objects."""
+
+    for entry in raw_providers:
+        name_raw = entry.get("name")
+        if not name_raw:
+            logger.warning("Skipping Qwen provider without a name: %s", entry)
+            continue
+
+        name = str(name_raw).strip()
+        if not name:
+            logger.warning("Skipping Qwen provider with empty name: %s", entry)
+            continue
+
+        api_key = entry.get("api_key")
+        if not api_key:
+            logger.info("Skipping Qwen provider '%s' because no api_key was provided", name)
+            continue
+
+        defaults = _PROVIDER_DEFAULTS.get(name.lower(), {})
+        base_url = entry.get("base_url") or defaults.get("base_url")
+        model = entry.get("model") or defaults.get("model")
+        description = entry.get("description") or defaults.get("description") or name
+
+        yield QwenProviderConfig(
+            name=name,
+            api_key=str(api_key),
+            base_url=str(base_url) if base_url else None,
+            model=str(model) if model else None,
+            description=str(description),
+        )
+
+
+def load_qwen_provider_configs() -> List[QwenProviderConfig]:
+    """Load configured Qwen providers from disk.
+
+    The configuration format is a TOML file with the following structure::
+
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-..."
+        # base_url/model are optional; defaults from the known provider table apply.
+
+    Providers are returned in the order defined in the file. Entries without an
+    ``api_key`` are skipped because they cannot be invoked.
+    """
+
+    path = _resolve_config_path()
+    if not path.exists():
+        logger.debug("Qwen provider config not found at %s", path)
+        return []
+
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except FileNotFoundError:
+        return []
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to read Qwen provider config %s: %s", path, exc)
+        return []
+
+    providers = data.get("qwen", {}).get("providers", [])
+    if not isinstance(providers, list):
+        logger.error(
+            "Invalid Qwen provider config at %s: expected list under qwen.providers", path
+        )
+        return []
+
+    return list(_iter_provider_entries(providers))
+

--- a/tests/support/env.py
+++ b/tests/support/env.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from contextlib import ContextDecorator
+from typing import Dict
+
+
+class patch_environment(ContextDecorator):
+    """Context manager to temporarily update environment variables."""
+
+    def __init__(self, updates: Dict[str, str]):
+        self._updates = updates
+        self._original: Dict[str, str | None] = {}
+
+    def __enter__(self) -> None:
+        for key, value in self._updates.items():
+            self._original[key] = os.environ.get(key)
+            os.environ[key] = value
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for key in self._updates:
+            original = self._original.get(key)
+            if original is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original
+

--- a/tests/test_qwen_client_fallback.py
+++ b/tests/test_qwen_client_fallback.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+from unittest.mock import patch
+
+import pytest
+
+from src.auto_coder.exceptions import AutoCoderUsageLimitError
+from src.auto_coder.qwen_client import QwenClient
+from src.auto_coder.utils import CommandResult
+from tests.support.env import patch_environment
+
+
+@patch("subprocess.run")
+@patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+def test_qwen_client_prefers_configured_api_keys_before_oauth(mock_run_command, mock_run, tmp_path) -> None:
+    mock_run.return_value.returncode = 0
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-xyz"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "openrouter-123"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        mock_run_command.return_value = CommandResult(True, "ModelStudio OK", "", 0)
+
+        client = QwenClient(model_name="qwen3-coder-plus")
+        output = client._run_qwen_cli("hello")
+
+    assert output == "ModelStudio OK"
+    assert mock_run_command.call_count == 1
+
+    # The first provider should be the configured ModelStudio API key.
+    first_env = mock_run_command.call_args_list[0].kwargs["env"]
+    assert first_env["OPENAI_API_KEY"] == "dashscope-xyz"
+    assert first_env["OPENAI_BASE_URL"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    assert first_env["OPENAI_MODEL"] == "qwen3-coder-plus"
+
+    # After a successful call the active provider index should remain at zero.
+    assert client._active_provider_index == 0
+    assert client.model_name == "qwen3-coder-plus"
+
+
+@patch("subprocess.run")
+@patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+def test_qwen_client_fallback_to_openrouter(mock_run_command, mock_run, tmp_path) -> None:
+    mock_run.return_value.returncode = 0
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-xyz"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "openrouter-123"
+        model = "qwen/qwen3-coder:free"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        mock_run_command.side_effect = [
+            CommandResult(False, "Rate limit", "", 1),
+            CommandResult(True, "OpenRouter OK", "", 0),
+        ]
+
+        client = QwenClient(model_name="qwen3-coder-plus")
+        output = client._run_qwen_cli("hello")
+
+    assert output == "OpenRouter OK"
+    assert mock_run_command.call_count == 2
+
+    # First call should target ModelStudio, second OpenRouter.
+    first_env = mock_run_command.call_args_list[0].kwargs["env"]
+    assert first_env["OPENAI_API_KEY"] == "dashscope-xyz"
+
+    second_env = mock_run_command.call_args_list[1].kwargs["env"]
+    assert second_env["OPENAI_API_KEY"] == "openrouter-123"
+    assert second_env["OPENAI_BASE_URL"] == "https://openrouter.ai/api/v1"
+    assert second_env["OPENAI_MODEL"] == "qwen/qwen3-coder:free"
+
+    assert client.model_name == "qwen/qwen3-coder:free"
+
+
+@patch("subprocess.run")
+@patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+def test_qwen_client_fallbacks_to_oauth_after_api_keys(mock_run_command, mock_run, tmp_path) -> None:
+    mock_run.return_value.returncode = 0
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-xyz"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "openrouter-123"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        mock_run_command.side_effect = [
+            CommandResult(False, "Rate limit", "", 1),
+            CommandResult(False, "Rate limit", "", 1),
+            CommandResult(True, "OAuth OK", "", 0),
+        ]
+
+        client = QwenClient(model_name="qwen3-coder-plus")
+        output = client._run_qwen_cli("hello")
+
+    assert output == "OAuth OK"
+    assert mock_run_command.call_count == 3
+
+    first_env = mock_run_command.call_args_list[0].kwargs["env"]
+    second_env = mock_run_command.call_args_list[1].kwargs["env"]
+    third_env = mock_run_command.call_args_list[2].kwargs["env"]
+
+    assert first_env["OPENAI_API_KEY"] == "dashscope-xyz"
+    assert second_env["OPENAI_API_KEY"] == "openrouter-123"
+    assert "OPENAI_API_KEY" not in third_env
+    assert client._active_provider_index == 2
+
+
+@patch("subprocess.run")
+@patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+def test_qwen_client_all_limits_raise(mock_run_command, mock_run, tmp_path) -> None:
+    mock_run.return_value.returncode = 0
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-xyz"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "openrouter-123"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        mock_run_command.side_effect = [
+            CommandResult(False, "Rate limit", "", 1),
+            CommandResult(False, "Rate limit", "", 1),
+            CommandResult(False, "Rate limit", "", 1),
+        ]
+
+        client = QwenClient(model_name="qwen3-coder-plus")
+        with pytest.raises(AutoCoderUsageLimitError):
+            client._run_qwen_cli("hello")
+
+    # Final call should come from OAuth with no API key present.
+    final_env = mock_run_command.call_args_list[-1].kwargs["env"]
+    assert "OPENAI_API_KEY" not in final_env
+

--- a/tests/test_qwen_provider_config.py
+++ b/tests/test_qwen_provider_config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from src.auto_coder.qwen_provider_config import load_qwen_provider_configs
+from tests.support.env import patch_environment
+
+
+def test_load_qwen_provider_configs_defaults(tmp_path) -> None:
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+        api_key = "dashscope-xyz"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "openrouter-123"
+        model = "custom-model"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        providers = load_qwen_provider_configs()
+
+    assert [p.name for p in providers] == ["modelstudio", "openrouter"]
+    modelstudio = providers[0]
+    assert modelstudio.base_url == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    assert modelstudio.model == "qwen3-coder-plus"
+
+    openrouter = providers[1]
+    assert openrouter.base_url == "https://openrouter.ai/api/v1"
+    assert openrouter.model == "custom-model"
+
+
+def test_load_qwen_provider_configs_skips_missing_key(tmp_path) -> None:
+    config_path = tmp_path / "qwen-providers.toml"
+    config_path.write_text(
+        """
+        [[qwen.providers]]
+        name = "modelstudio"
+
+        [[qwen.providers]]
+        name = "openrouter"
+        api_key = "valid"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {"AUTO_CODER_QWEN_CONFIG": str(config_path)}
+    with patch_environment(env):
+        providers = load_qwen_provider_configs()
+
+    assert len(providers) == 1
+    assert providers[0].name == "openrouter"
+


### PR DESCRIPTION
## Summary
- ensure QwenClient always appends the OAuth provider last so configured API-key endpoints run first
- refresh README and client-features docs to describe the new API key → OAuth fallback order
- expand unit and E2E coverage to assert ModelStudio/OpenRouter run before OAuth and that OAuth is still used as a final resort

## Testing
- `./.venv/bin/python -m pytest tests/test_qwen_client_fallback.py`
- `./.venv/bin/python -m pytest tests/test_e2e.py::TestE2E::test_cli_process_issues_qwen_prefers_config_providers`
- `./.venv/bin/python -m pytest tests/test_e2e.py::TestE2E::test_cli_process_issues_qwen_exhausts_api_keys_then_oauth`


------
https://chatgpt.com/codex/tasks/task_e_68d48e5eff60832fb956d38e234e9385