### PR TITLE
Allow single PR/issue processing with @auto-coder label

### DIFF
--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -783,15 +783,6 @@ def process_single(
 
                     set_progress_item("PR", number, related_issues, branch_name)
 
-                    # Skip if PR already has @auto-coder label
-                    pr_labels = pr_data.get("labels", [])
-                    if "@auto-coder" in pr_labels:
-                        msg = f"Skipping PR #{number} - already has @auto-coder label"
-                        logger.info(msg)
-                        result["errors"].append(msg)
-                        newline_progress()
-                        return result
-
                     # Check GitHub Actions status before processing
                     github_checks = _check_github_actions_status(repo_name, pr_data, config)
                     detailed_checks = get_detailed_checks_from_history(github_checks, repo_name)
@@ -831,15 +822,6 @@ def process_single(
                     push_progress_stage("Getting issue details")
                     issue_data = github_client.get_issue_details_by_number(repo_name, number)
 
-                    # Check if issue already has @auto-coder label (being processed by another instance)
-                    push_progress_stage("Checking status")
-                    current_labels = issue_data.get("labels", [])
-                    if "@auto-coder" in current_labels:
-                        msg = f"Skipping issue #{number} - already has @auto-coder label"
-                        logger.info(msg)
-                        result["errors"].append(msg)
-                        newline_progress()
-                        return result
                     # Add @auto-coder label now that we're actually going to process this issue
                     if not dry_run:
                         if not github_client.try_add_work_in_progress_label(repo_name, number):


### PR DESCRIPTION
Closes #155

Removed the @auto-coder label check in the process_single function to allow processing of specific issues or PRs even when the label is present. This enables users to explicitly process single items using the --only option while maintaining the existing behavior for batch processing where the label prevents concurrent execution.