### PR TITLE
docs: Translate README.md from Japanese to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # Auto-Coder
 
-AI CLIバックエンド（デフォルト: codex。`--backend` を複数指定して gemini / qwen / auggie / codex-mcp とのフォールバック順を設定可能）を用いてアプリケーション開発を自動化するPythonアプリケーションです。GitHubからissueやエラーのPRを取得して構築・修正を行い、必要に応じて機能追加issueを自動作成します。
+A Python application that automates application development using an AI CLI backend (default: `codex`, configurable fallback order for `gemini` / `qwen` / `auggie` / `codex-mcp` via multiple `--backend` arguments). It retrieves issues and error-related PRs from GitHub to build and fix the application, and automatically creates feature-addition issues when necessary.
 
-## 機能
+## Features
 
-### 🔧 主要機能
-- **GitHub API統合**: issueとPRの自動取得・管理
-- **AI分析（codexデフォルト／`--backend` 複数指定でGemini・Qwen・Auggie・codex-mcpをフォールバック順に設定可）**: issueとPRの内容を自動分析
-- **自動化処理**: 分析結果に基づく自動アクション
-- **機能提案**: リポジトリ分析による新機能の自動提案
-- **レポート生成**: 処理結果の詳細レポート
+### 🔧 Core Features
+- **GitHub API Integration**: Automatic retrieval and management of issues and PRs
+- **AI Analysis (codex default / Gemini, Qwen, Auggie, codex-mcp configurable via multiple `--backend` arguments with fallback order)**: Automatic analysis of issue and PR content
+- **Automated Processing**: Automatic actions based on analysis results
+- **Feature Proposals**: Automatic proposal of new features from repository analysis
+- **Report Generation**: Detailed reports of processing results
 
-### 🚀 自動化ワークフロー
-1. **Issue処理**: オープンなissueを取得し、Gemini AIで分析
-2. **PR処理**: オープンなPRを取得し、リスクレベルを評価
-3. **機能提案**: リポジトリコンテキストから新機能を提案
-4. **自動アクション**: 分析結果に基づくコメント追加や自動クローズ
+### 🚀 Automated Workflow
+1. **Issue Processing**: Retrieve open issues and analyze with Gemini AI
+2. **PR Processing**: Retrieve open PRs and evaluate risk levels
+3. **Feature Proposals**: Propose new features from repository context
+4. **Automatic Actions**: Add comments or auto-close based on analysis results
 
-## インストール
+## Installation
 
-### 前提条件
-- Python 3.9以上
-- [gh CLI](https://cli.github.com/) で事前に認証済みであること（`gh auth login`）
-- [Codex CLI](https://github.com/openai/codex) がインストール済み（デフォルトのバックエンド）
-- [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli?hl=ja) は Gemini バックエンドを使用する場合に必要（`gemini login`）
+### Prerequisites
+- Python 3.9 or higher
+- [gh CLI](https://cli.github.com/) pre-authenticated (`gh auth login`)
+- [Codex CLI](https://github.com/openai/codex) installed (default backend)
+- [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli?hl=en) required when using Gemini backend (`gemini login`)
 
-### セットアップ
+### Setup
 
-1. リポジトリをクローン:
+1. Clone the repository:
 ```bash
 git clone https://github.com/your-username/auto-coder.git
 cd auto-coder
@@ -36,442 +36,442 @@ cd auto-coder
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync
 
-2. 依存関係をインストールして、任意のディレクトリから実行可能にします:
+2. Install dependencies and make it executable from any directory:
 ```bash
 source ./venv/bin/activate
 pip install -e .
-# またはリポジトリをクローンせずに直接インストール
+# Or install directly without cloning the repository
 pip install git+https://github.com/your-username/auto-coder.git
 ```
 
-> 補足（PEP 668 回避/推奨）: システム Python が外部管理（externally-managed）で `pip install` がブロックされる環境では、pipx によるインストールを推奨します。
+> Note (PEP 668 avoidance/recommended): In environments where system Python is externally managed and `pip install` is blocked, we recommend installation via pipx.
 >
-> Debian/Ubuntu 系の例:
+> Example for Debian/Ubuntu:
 >
 > ```bash
 > sudo apt update && sudo apt install -y pipx
-> pipx ensurepath   # 必要に応じてシェルを再起動/再ログイン
+> pipx ensurepath   # Restart/re-login to shell if needed
 > pipx install git+https://github.com/kitamura-tetsuo/auto-coder.git
 > auto-coder --help
 > ```
 
 
-3. 必要に応じて設定ファイルを作成:
+3. Create configuration file if needed:
 ```bash
 cp .env.example .env
-# トークンはgh・geminiの認証情報が自動的に使用されるため空欄でも動作します
+# Tokens can be left blank as gh and gemini authentication information is used automatically
 ```
 
-## 使用方法
+## Usage
 
-### 認証
+### Authentication
 
-基本的には `gh auth login` を実施してください。Gemini バックエンドを使用する場合は `gemini login` を行うことで、APIキーを環境変数に設定せずに利用できます（codex バックエンドでは --model は無視されます）。
+Basically, just run `gh auth login`. When using the Gemini backend, running `gemini login` allows you to use it without setting API keys in environment variables (the --model flag is ignored for the codex backend).
 
 
-#### Qwen の利用について（認証）
-- Qwen OAuth（推奨）:
-  - `qwen` を一度実行し、ブラウザで qwen.ai アカウント認証すると自動で利用可能になります。
-  - 途中で `/auth` コマンドを実行すると Qwen OAuth に切替できます。
-  - 参考: Qwen Code 公式リポジトリ（Authorization セクション）: https://github.com/QwenLM/qwen-code
-- リミット到達時の自動フォールバック:
-  - Auto-Coder は設定済みの OpenAI 互換エンドポイントを優先的に使用し、すべての API キーが枯渇した場合にのみ Qwen OAuth に戻ります。
-  - 設定ファイルの場所: `~/.auto-coder/qwen-providers.toml`（`AUTO_CODER_QWEN_CONFIG` でパスを上書き可、`AUTO_CODER_CONFIG_DIR` でディレクトリ指定も可）。
-  - TOML 例:
+#### Regarding Qwen Usage (Authentication)
+- Qwen OAuth (recommended):
+  - Run `qwen` once, and after authenticating your qwen.ai account in the browser, it will be automatically available.
+  - Running the `/auth` command midway will switch to Qwen OAuth.
+  - Reference: Qwen Code official repository (Authorization section): https://github.com/QwenLM/qwen-code
+- Automatic fallback when limits are reached:
+  - Auto-Coder prioritizes configured OpenAI-compatible endpoints and only returns to Qwen OAuth when all API keys are exhausted.
+  - Configuration file location: `~/.auto-coder/qwen-providers.toml` (path can be overridden with `AUTO_CODER_QWEN_CONFIG`, directory can be specified with `AUTO_CODER_CONFIG_DIR`).
+  - TOML example:
 
     ```toml
     [[qwen.providers]]
     # Option 1: Alibaba Cloud ModelStudio
     name = "modelstudio"
-    api_key = "dashscope-..."  # 取得した API キーを設定
-    # base_url と model は省略すると既定値（dashscope互換 / qwen3-coder-plus）
+    api_key = "dashscope-..."  # Set the obtained API key
+    # base_url and model can be omitted to use defaults (dashscope-compatible / qwen3-coder-plus)
 
     [[qwen.providers]]
     # Option 2: OpenRouter Free Tier
     name = "openrouter"
     api_key = "openrouter-..."
-    model = "qwen/qwen3-coder:free"  # 省略時は既定値を使用
+    model = "qwen/qwen3-coder:free"  # Uses default when omitted
     ```
 
-  - 記述順にフォールバックします（API キー → OAuth の順番）。API キーのみ記入すれば既定 URL/モデルが適用され、実行時に `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` が自動注入されます。
-- OpenAI 互換モード:
-  - 以下の環境変数を設定して利用できます。
-    - `OPENAI_API_KEY`（必須）
-    - `OPENAI_BASE_URL`（プロバイダに応じて指定）
-    - `OPENAI_MODEL`（例: `qwen3-coder-plus`）
-  - 当ツールの Qwen バックエンドは非対話モードで `qwen -p/--prompt` を使用し、モデルは `--model/-m` フラグまたは `OPENAI_MODEL` に従います（両方指定時は `--model` を優先）。
+  - Fallback occurs in the order written (API key → OAuth). If only API keys are filled in, default URL/model is applied, and `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` are automatically injected at runtime.
+- OpenAI-compatible mode:
+  - Available by setting the following environment variables.
+    - `OPENAI_API_KEY` (required)
+    - `OPENAI_BASE_URL` (specify according to provider)
+    - `OPENAI_MODEL` (example: `qwen3-coder-plus`)
+  - The Qwen backend of this tool uses non-interactive mode with `qwen -p/--prompt`, and the model follows the `--model/-m` flag or `OPENAI_MODEL` (--model takes precedence if both are specified).
 
-#### Auggie の利用について
-- CLI を `npm install -g @augmentcode/auggie` でインストールしてください。
-- 当ツールでは非対話モードで `auggie --print --model <モデル名> "<プロンプト>"` を呼び出します。
-- Auggie バックエンドの呼び出しは 1 日あたり 20 回までです。21 回目以降は日付が切り替わるまで自動的に停止し、他のバックエンドへフォールバックします。
-- `--model` を指定しない場合は `GPT-5` を既定モデルとして使用します。任意のモデルを指定したい場合は `--model` オプションで上書きできます。
+#### Regarding Auggie Usage
+- Install CLI with `npm install -g @augmentcode/auggie`.
+- This tool calls `auggie --print --model <model name> "<prompt>"` in non-interactive mode.
+- Auggie backend calls are limited to 20 per day. The 21st and subsequent calls automatically stop until the date changes and fallback to other backends.
+- If `--model` is not specified, `GPT-5` is used as the default model. You can override with the `--model` option to specify any model.
 
-### CLIコマンド
+### CLI Commands
 
-#### issueとPRの処理
+#### Processing Issues and PRs
 ```bash
-# デフォルト（codex バックエンド）で実行
+# Run with default (codex backend)
 auto-coder process-issues --repo owner/repo
 
-# バックエンドを gemini に切替してモデル指定
+# Switch backend to gemini and specify model
 auto-coder process-issues --repo owner/repo --backend gemini --model-gemini gemini-2.5-pro
 
-# バックエンドを qwen に切替してモデル指定（例: qwen3-coder-plus）
+# Switch backend to qwen and specify model (example: qwen3-coder-plus)
 auto-coder process-issues --repo owner/repo --backend qwen --model-qwen qwen3-coder-plus
 
-# バックエンドを auggie に切替（デフォルトで GPT-5 を使用）
+# Switch backend to auggie (uses GPT-5 by default)
 auto-coder process-issues --repo owner/repo --backend auggie
 
-# codex をデフォルト、Gemini をフォールバックに設定
+# Set codex as default, Gemini as fallback
 auto-coder process-issues --repo owner/repo --backend codex --backend gemini
 
-# ドライランモードで実行（変更を行わない）
+# Run in dry-run mode (no changes made)
 auto-coder process-issues --repo owner/repo --dry-run
 
-# 特定のIssue/PRのみ処理（番号指定）
+# Process only specific Issue/PR (by number)
 auto-coder process-issues --repo owner/repo --only 123
 
-# 特定のPRのみ処理（URL指定）
+# Process only specific PR (by URL)
 auto-coder process-issues --repo owner/repo --only https://github.com/owner/repo/pull/456
 ```
 
-#### 機能提案issueの作成
+#### Creating Feature Proposal Issues
 ```bash
-# デフォルト（codex バックエンド）で実行
+# Run with default (codex backend)
 auto-coder create-feature-issues --repo owner/repo
 
-# バックエンドを gemini に切替してモデル指定
+# Switch backend to gemini and specify model
 auto-coder create-feature-issues --repo owner/repo --backend gemini --model-gemini gemini-2.5-pro
 
-# バックエンドを qwen に切替してモデル指定（例: qwen3-coder-plus）
+# Switch backend to qwen and specify model (example: qwen3-coder-plus)
 auto-coder create-feature-issues --repo owner/repo --backend qwen --model-qwen qwen3-coder-plus
 
-# バックエンドを auggie に切替（デフォルトで GPT-5 を使用）
+# Switch backend to auggie (uses GPT-5 by default)
 auto-coder create-feature-issues --repo owner/repo --backend auggie
 
-# codex をデフォルト、Gemini をフォールバックに設定
+# Set codex as default, Gemini as fallback
 auto-coder create-feature-issues --repo owner/repo --backend codex --backend gemini
 ```
 
-#### テスト合格まで自動修正（fix-to-pass-tests）
-ローカルテストを実行し、失敗していたら LLM に最小限の修正を依頼して再実行を繰り返します。LLM が一切編集しなかった場合はエラーで停止します。
+#### Auto-fix until tests pass (fix-to-pass-tests)
+Run local tests, and if they fail, ask the LLM for minimal fixes and repeatedly re-execute. Stops with an error if the LLM doesn't make any edits.
 
 ```bash
-# デフォルト（codex バックエンド）で実行
+# Run with default (codex backend)
 auto-coder fix-to-pass-tests
 
-# バックエンドを gemini に切替してモデル指定
+# Switch backend to gemini and specify model
 auto-coder fix-to-pass-tests --backend gemini --model-gemini gemini-2.5-pro
 
-# バックエンドを qwen に切替してモデル指定（例: qwen3-coder-plus）
+# Switch backend to qwen and specify model (example: qwen3-coder-plus)
 auto-coder fix-to-pass-tests --backend qwen --model-qwen qwen3-coder-plus
 
-# バックエンドを auggie に切替（デフォルトで GPT-5 を使用）
+# Switch backend to auggie (uses GPT-5 by default)
 auto-coder fix-to-pass-tests --backend auggie
 
-# codex をデフォルト、Gemini をフォールバックに設定
+# Set codex as default, Gemini as fallback
 auto-coder fix-to-pass-tests --backend codex --backend gemini
 
-# 試行回数を指定（例: 最大5回）
+# Specify number of attempts (example: max 5 times)
 auto-coder fix-to-pass-tests --max-attempts 5
 
-# ドライラン（編集は行わず、実行フローのみ）
+# Dry run (no editing, flow only)
 auto-coder fix-to-pass-tests --dry-run
 ```
 
-### コマンドオプション
+### Command Options
 
 #### `process-issues`
-- `--repo`: GitHubリポジトリ (owner/repo形式)
-- `--backend`: 使用するAIバックエンド（codex|codex-mcp|gemini|qwen|auggie）。複数指定すると指定順にフォールバックし、先頭がデフォルト。デフォルトは codex。
-- `--model`: モデル指定（Gemini/Qwen/Auggieで有効。backend=codex/codex-mcp の場合は無視され、警告が表示されます。Auggieは未指定時にGPT-5を使用）
-- `--dry-run`: ドライランモード（変更を行わない）
-- `--skip-main-update/--no-skip-main-update`: PRのチェックが失敗している場合に、修正を試みる前に PRのベースブランチをPRブランチへ取り込むかの挙動を切替（デフォルト: ベースブランチ取り込みをスキップ）。
-  - 既定値: `--skip-main-update`（スキップ）
-  - 明示的に ベースブランチ 取り込みを行いたい場合は `--no-skip-main-update` を指定
-- `--ignore-dependabot-prs/--no-ignore-dependabot-prs`: Dependabot によるPRを処理対象から除外（デフォルト: 除外しない）
-- `--only`: 特定のIssue/PRのみ処理（URLまたは番号指定）
+- `--repo`: GitHub repository (owner/repo format)
+- `--backend`: AI backend to use (codex|codex-mcp|gemini|qwen|auggie). Multiple backends can be specified for fallback in order, with the first being default. Default is codex.
+- `--model`: Model specification (valid for Gemini/Qwen/Auggie. Ignored when backend=codex/codex-mcp, with warning displayed. Auggie uses GPT-5 when unspecified)
+- `--dry-run`: Dry-run mode (no changes made)
+- `--skip-main-update/--no-skip-main-update`: Switch behavior of whether to merge PR base branch into PR branch before attempting fixes when PR checks fail (default: skip base branch merge).
+  - Default: `--skip-main-update` (skip)
+  - Specify `--no-skip-main-update` to explicitly perform base branch merge
+- `--ignore-dependabot-prs/--no-ignore-dependabot-prs`: Exclude Dependabot PRs from processing (default: do not exclude)
+- `--only`: Process only specific Issue/PR (URL or number specification)
 
-オプション:
-- `--github-token`: gh CLIの認証情報を使用しない場合に手動指定
-- `--gemini-api-key`: Gemini バックエンド使用時に、CLI認証情報を使わない場合の手動指定
+Options:
+- `--github-token`: Manual specification when not using gh CLI authentication
+- `--gemini-api-key`: Manual specification when not using CLI authentication for Gemini backend
 
 #### `create-feature-issues`
-- `--repo`: GitHubリポジトリ (owner/repo形式)
-- `--backend`: 使用するAIバックエンド（codex|codex-mcp|gemini|qwen|auggie）。複数指定すると指定順にフォールバックし、先頭がデフォルト。デフォルトは codex。
-- `--model`: モデル指定（Gemini/Qwen/Auggieで有効。backend=codex/codex-mcp の場合は無視され、警告が表示されます。Auggieは未指定時にGPT-5を使用）
+- `--repo`: GitHub repository (owner/repo format)
+- `--backend`: AI backend to use (codex|codex-mcp|gemini|qwen|auggie). Multiple backends can be specified for fallback in order, with the first being default. Default is codex.
+- `--model`: Model specification (valid for Gemini/Qwen/Auggie. Ignored when backend=codex/codex-mcp, with warning displayed. Auggie uses GPT-5 when unspecified)
 
-オプション:
-- `--github-token`: gh CLIの認証情報を使用しない場合に手動指定
-- `--gemini-api-key`: Gemini バックエンド使用時に、CLI認証情報を使わない場合の手動指定
+Options:
+- `--github-token`: Manual specification when not using gh CLI authentication
+- `--gemini-api-key`: Manual specification when not using CLI authentication for Gemini backend
 
 #### `fix-to-pass-tests`
-- `--backend`: 使用するAIバックエンド（codex|codex-mcp|gemini|qwen|auggie）。複数指定すると指定順にフォールバックし、先頭がデフォルト。デフォルトは codex。
-- `--model`: モデル指定（Gemini/Qwen/Auggieで有効。backend=codex/codex-mcp の場合は無視され、警告が表示されます。Auggieは未指定時にGPT-5を使用）
-- `--gemini-api-key`: Gemini バックエンド使用時に、CLI認証情報を使わない場合の手動指定
-- `--max-attempts`: テスト修正の最大試行回数（省略時はエンジンの既定値）
-- `--dry-run`: ドライランモード（LLM へは依頼せず、フローのみ確認）
+- `--backend`: AI backend to use (codex|codex-mcp|gemini|qwen|auggie). Multiple backends can be specified for fallback in order, with the first being default. Default is codex.
+- `--model`: Model specification (valid for Gemini/Qwen/Auggie. Ignored when backend=codex/codex-mcp, with warning displayed. Auggie uses GPT-5 when unspecified)
+- `--gemini-api-key`: Manual specification when not using CLI authentication for Gemini backend
+- `--max-attempts`: Maximum number of test fix attempts (uses engine default when omitted)
+- `--dry-run`: Dry-run mode (doesn't request LLM, flow verification only)
 
-動作仕様:
-- テスト実行は `scripts/test.sh` が存在すればそれを使用、なければ `pytest -q --maxfail=1` を実行します。
-  - `scripts/test.sh` は以下の機能をサポートします:
-    - 一貫性のある再現可能な環境のために uv ランナーを優先使用
-    - uv がインストールされていない場合はシステムの Python の pytest にフォールバック
-    - `AC_USE_LOCAL_VENV=1` を設定することでローカルの仮想環境を任意で有効化可能
-    - 依存関係を uv による自動同期機能を常有効化
-- 各失敗ごとにエラー出力から重要部分を抽出し、LLM に最小限の修正を依頼します。
-- 修正後はステージングとコミットを行います。変更が全くない（`nothing to commit`）場合はエラーで停止します。
+Behavior Specification:
+- Test execution uses `scripts/test.sh` if it exists, otherwise runs `pytest -q --maxfail=1`.
+  - `scripts/test.sh` supports the following features:
+    - Prefers using uv runner for consistent, reproducible environments
+    - Falls back to system Python's pytest when uv is not installed
+    - Can optionally activate local virtual environment by setting `AC_USE_LOCAL_VENV=1`
+    - Always enables automatic dependency synchronization with uv
+- For each failure, extracts important parts from error output and asks LLM for minimal fixes.
+- After fixes, stages and commits. Stops with error if there are no changes at all (`nothing to commit`).
 
-## 設定
+## Configuration
 
-### 環境変数
+### Environment Variables
 
-| 変数名 | 説明 | デフォルト値 | 必須 |
-|--------|------|-------------|------|
-| `GITHUB_TOKEN` | GitHub APIトークン (gh CLIの認証情報を上書きする場合) | - | ❌ |
-| `GEMINI_API_KEY` | Gemini APIキー (Gemini CLIの認証情報を上書きする場合) | - | ❌ |
+| Variable Name | Description | Default Value | Required |
+|--------------|-------------|---------------|----------|
+| `GITHUB_TOKEN` | GitHub API token (to override gh CLI authentication) | - | ❌ |
+| `GEMINI_API_KEY` | Gemini API key (to override Gemini CLI authentication) | - | ❌ |
 | `GITHUB_API_URL` | GitHub API URL | `https://api.github.com` | ❌ |
-| `GEMINI_MODEL` | 使用するGeminiモデル | `gemini-pro` | ❌ |
-| `MAX_ISSUES_PER_RUN` | 1回の実行で処理する最大issue数 | `-1` | ❌ |
-| `MAX_PRS_PER_RUN` | 1回の実行で処理する最大PR数 | `-1` | ❌ |
-| `DRY_RUN` | ドライランモード | `false` | ❌ |
-| `LOG_LEVEL` | ログレベル | `INFO` | ❌ |
+| `GEMINI_MODEL` | Gemini model to use | `gemini-pro` | ❌ |
+| `MAX_ISSUES_PER_RUN` | Maximum issues to process per run | `-1` | ❌ |
+| `MAX_PRS_PER_RUN` | Maximum PRs to process per run | `-1` | ❌ |
+| `DRY_RUN` | Dry-run mode | `false` | ❌ |
+| `LOG_LEVEL` | Log level | `INFO` | ❌ |
 
-`MAX_ISSUES_PER_RUN` と `MAX_PRS_PER_RUN` はデフォルトで制限なし (`-1`) に設定されています。処理件数を制限したい場合は、正の整数を指定してください。
+`MAX_ISSUES_PER_RUN` and `MAX_PRS_PER_RUN` are set to unlimited (`-1`) by default. Specify positive integers if you want to limit the number of items processed.
 
-## GraphRAG 統合（実験的機能）
+## GraphRAG Integration (Experimental Feature)
 
-Auto-Coder は Neo4j と Qdrant を使用した GraphRAG（Graph Retrieval-Augmented Generation）統合をサポートしています。
+Auto-Coder supports GraphRAG (Graph Retrieval-Augmented Generation) integration using Neo4j and Qdrant.
 
-### GraphRAG のセットアップ
+### GraphRAG Setup
 
-1. GraphRAG 用の依存関係をインストール:
+1. Install dependencies for GraphRAG:
 ```bash
 pip install -e ".[graphrag]"
 ```
 
-2. Docker で Neo4j と Qdrant を起動:
+2. Start Neo4j and Qdrant with Docker:
 ```bash
-# Docker Compose で起動
+# Start with Docker Compose
 docker compose -f docker-compose.graphrag.yml up -d
 
-# 状態確認
+# Check status
 docker compose -f docker-compose.graphrag.yml ps
 
-# ログ確認
+# Check logs
 docker compose -f docker-compose.graphrag.yml logs
 ```
 
-3. GraphRAG MCP サーバーのセットアップ（オプション）:
+3. GraphRAG MCP Server Setup (optional):
 ```bash
-# 自動セットアップ（推奨）
-# バンドルされたカスタムMCPサーバー（コード分析専用フォーク）を使用
+# Automatic setup (recommended)
+# Use bundled custom MCP server (code-analysis specialized fork)
 auto-coder graphrag setup-mcp
 
-# 手動セットアップ
+# Manual setup
 cd ~/graphrag_mcp
 uv sync
 uv run main.py
 ```
 
-**注**: このMCPサーバーは `rileylemm/graphrag_mcp` のカスタムフォークで、TypeScript/JavaScriptコード分析に特化しています。詳細は `docs/client-features.yaml` の `external_dependencies.graphrag_mcp` セクションを参照してください。
+**Note**: This MCP server is a custom fork of `rileylemm/graphrag_mcp`, specialized for TypeScript/JavaScript code analysis. See `docs/client-features.yaml` `external_dependencies.graphrag_mcp` section for details.
 
-### GraphRAG サービスの動作確認
+### Verifying GraphRAG Service Operation
 
-Neo4j と Qdrant が正しく動作しているか確認するためのスクリプトを用意しています:
+We have prepared a script to verify that Neo4j and Qdrant are operating correctly:
 
 ```bash
-# 全部テスト（デフォルト）
+# Test all (default)
 python scripts/check_graphrag_services.py
 
-# 直接アクセスのみテスト
+# Test direct access only
 python scripts/check_graphrag_services.py --direct-only
 
-# MCP のみテスト
+# Test MCP only
 python scripts/check_graphrag_services.py --mcp-only
 ```
 
-このスクリプトは以下を確認します:
-- Neo4j への直接アクセス（Bolt プロトコル）
-  - データベースバージョン確認
-  - ノード作成・検索
-  - リレーションシップ作成
-  - パス検索
-- Qdrant への直接アクセス（HTTP API）
-  - コレクション作成
-  - ベクトル挿入
-  - 類似検索
-  - フィルタ付き検索
-- GraphRAG MCP 経由でのアクセス
-  - Docker コンテナ状態確認
-  - MCP サーバー状態確認
-  - インデックス状態確認
+This script verifies:
+- Direct access to Neo4j (Bolt protocol)
+  - Database version check
+  - Node creation and search
+  - Relationship creation
+  - Path search
+- Direct access to Qdrant (HTTP API)
+  - Collection creation
+  - Vector insertion
+  - Similarity search
+  - Filtered search
+- Access via GraphRAG MCP
+  - Docker container status check
+  - MCP server status check
+  - Index status check
 
-### VS Code でのデバッグ実行
+### Debugging in VS Code
 
-`.vscode/launch.json` に以下のデバッグ設定が含まれています:
+The following debugging configurations are included in `.vscode/launch.json`:
 
-- **Check GraphRAG Services (All)**: 全部テスト（デフォルト）
-- **Check GraphRAG Services (Direct only)**: 直接アクセスのみテスト
-- **Check GraphRAG Services (MCP only)**: MCP のみテスト
+- **Check GraphRAG Services (All)**: Test all (default)
+- **Check GraphRAG Services (Direct only)**: Test direct access only
+- **Check GraphRAG Services (MCP only)**: Test MCP only
 
-### GraphRAG の接続情報
+### GraphRAG Connection Information
 
-デフォルトの接続情報:
+Default connection information:
 
-| サービス | URL | 認証情報 |
-|---------|-----|---------|
+| Service | URL | Credentials |
+|---------|-----|-------------|
 | Neo4j (Bolt) | `bolt://localhost:7687` | `neo4j` / `password` |
 | Neo4j (HTTP) | `http://localhost:7474` | `neo4j` / `password` |
-| Qdrant (HTTP) | `http://localhost:6333` | 認証なし |
-| Qdrant (gRPC) | `http://localhost:6334` | 認証なし |
+| Qdrant (HTTP) | `http://localhost:6333` | No authentication |
+| Qdrant (gRPC) | `http://localhost:6334` | No authentication |
 
-### トラブルシューティング
+### Troubleshooting
 
-#### Neo4j に接続できない
+#### Cannot connect to Neo4j
 
 ```bash
-# コンテナが起動しているか確認
+# Check if container is running
 docker ps | grep neo4j
 
-# ログを確認
+# Check logs
 docker logs auto-coder-neo4j
 
-# ポートが開いているか確認
+# Check if port is open
 nc -zv localhost 7687
 ```
 
-#### Qdrant に接続できない
+#### Cannot connect to Qdrant
 
 ```bash
-# コンテナが起動しているか確認
+# Check if container is running
 docker ps | grep qdrant
 
-# ログを確認
+# Check logs
 docker logs auto-coder-qdrant
 
-# ポートが開いているか確認
+# Check if port is open
 nc -zv localhost 6333
 ```
 
-## 開発
+## Development
 
-### 開発環境のセットアップ
+### Development Environment Setup
 
-1. 開発用依存関係をインストール:
+1. Install development dependencies:
 ```bash
 pip install -e ".[dev]"
 ```
 
-2. pre-commitフックをセットアップ:
+2. Setup pre-commit hooks:
 ```bash
 pre-commit install
 ```
 
-### VS Code デバッグ設定
+### VS Code Debug Settings
 
-プロジェクトには以下のデバッグ設定が含まれています：
+The project includes the following debug configurations:
 
-- **Auto-Coder: Process Issues (Dry Run)**: outlinerディレクトリでドライランモード実行
-- **Auto-Coder: Create Feature Issues**: outlinerディレクトリで機能提案issue作成
-- **Auto-Coder: Auth Status**: outlinerディレクトリで認証状況確認
-- **Auto-Coder: Process Issues (Live)**: outlinerディレクトリで実際の処理実行
+- **Auto-Coder: Process Issues (Dry Run)**: Dry-run mode execution in outliner directory
+- **Auto-Coder: Create Feature Issues**: Feature proposal issue creation in outliner directory
+- **Auto-Coder: Auth Status**: Authentication status check in outliner directory
+- **Auto-Coder: Process Issues (Live)**: Actual processing execution in outliner directory
 
-デバッグを開始するには：
-1. VS Codeで `F5` を押すか、「実行とデバッグ」パネルを開く
-2. 上記の設定から選択して実行
-3. ブレークポイントを設定してステップ実行が可能
+To start debugging:
+1. Press `F5` in VS Code or open the "Run and Debug" panel
+2. Select from the above configurations and run
+3. Set breakpoints for step-by-step execution
 
-### テストの実行
+### Running Tests
 
 ```bash
-# 全テストを実行
+# Run all tests
 pytest
 
-# カバレッジ付きでテストを実行
+# Run tests with coverage
 pytest --cov=src/auto_coder --cov-report=html
 
-# 特定のテストファイルを実行
+# Run specific test file
 pytest tests/test_github_client.py
 ```
 
-### コード品質チェック
+### Code Quality Checks
 
 ```bash
-# フォーマット
+# Formatting
 black src/ tests/
 
-# インポート順序
+# Import sorting
 isort src/ tests/
 
-# リンター
+# Linting
 flake8 src/ tests/
 
-# 型チェック
+# Type checking
 mypy src/
 
-# pre-commit経由での型チェック（uv使用）
-# pre-commit install によりフックをセットアップ
+# Type checking via pre-commit (using uv)
+# Hooks are set up via pre-commit install
 ```
 
-## アーキテクチャ
+## Architecture
 
-### コンポーネント構成
+### Component Structure
 
 ```
 src/auto_coder/
-├── cli.py              # CLIエントリーポイント
-├── github_client.py    # GitHub API クライアント
-├── gemini_client.py    # Gemini AI クライアント
-├── automation_engine.py # メイン自動化エンジン
-└── config.py          # 設定管理
+├── cli.py              # CLI entry point
+├── github_client.py    # GitHub API client
+├── gemini_client.py    # Gemini AI client
+├── automation_engine.py # Main automation engine
+└── config.py          # Configuration management
 ```
 
-### データフロー
+### Data Flow
 
-1. **CLI** → **AutomationEngine** → **GitHubClient** (データ取得)
-2. **AutomationEngine** → **GeminiClient** (AI分析)
-3. **AutomationEngine** → **GitHubClient** (アクション実行)
-4. **AutomationEngine** → **レポート生成**
+1. **CLI** → **AutomationEngine** → **GitHubClient** (data retrieval)
+2. **AutomationEngine** → **GeminiClient** (AI analysis)
+3. **AutomationEngine** → **GitHubClient** (action execution)
+4. **AutomationEngine** → **Report Generation**
 
-## 出力とレポート
+## Output and Reports
 
-実行結果は `~/.auto-coder/{repository}/` ディレクトリにJSON形式で保存されます:
+Execution results are saved in JSON format in the `~/.auto-coder/{repository}/` directory:
 
-- `automation_report_*.json`: 自動化処理の結果（リポジトリごとに保存）
-- `jules_automation_report_*.json`: Jules モードでの自動化処理の結果
+- `automation_report_*.json`: Results of automation processing (saved per repository)
+- `jules_automation_report_*.json`: Results of automation processing in Jules mode
 
-例: `owner/repo` リポジトリの場合、レポートは `~/.auto-coder/owner_repo/` に保存されます。
+Example: For `owner/repo` repository, reports are saved in `~/.auto-coder/owner_repo/`.
 
-## トラブルシューティング
+## Troubleshooting
 
-### よくある問題
+### Common Issues
 
-1. **GitHub API制限**: レート制限に達した場合は時間をおいて再実行
-2. **Gemini API エラー**: APIキーが正しく設定されているか確認
-3. **権限エラー**: GitHubトークンに適切な権限があるか確認
+1. **GitHub API limits**: Wait some time before retrying if you hit rate limits
+2. **Gemini API errors**: Check if API keys are correctly configured
+3. **Permission errors**: Check if GitHub token has appropriate permissions
 
-### ログの確認
+### Checking Logs
 
 ```bash
-# ログレベルを DEBUG に設定
+# Set log level to DEBUG
 export LOG_LEVEL=DEBUG
 auto-coder process-issues --repo owner/repo --dry-run
 ```
 
-## ライセンス
+## License
 
-このプロジェクトはMITライセンスの下で公開されています。詳細は[LICENSE](LICENSE)ファイルを参照してください。
+This project is published under the MIT license. See the [LICENSE](LICENSE) file for details.
 
-## 貢献
+## Contributing
 
-プルリクエストや issue の報告を歓迎します。貢献する前に、以下を確認してください:
+We welcome pull requests and issue reports. Before contributing, please ensure:
 
-1. テストが通ること
-2. コードスタイルが統一されていること
-3. 新機能には適切なテストが含まれていること
+1. Tests pass
+2. Code style is consistent
+3. New features include appropriate tests
 
-## サポート
+## Support
 
-問題や質問がある場合は、GitHubのissueを作成してください。
+If you have issues or questions, please create a GitHub issue.


### PR DESCRIPTION
Closes #144

Translated the entire README.md file (~478 lines) from Japanese to English while preserving all markdown formatting, code examples, and technical accuracy. This improves accessibility for the international developer community and aligns with the repository's goal of being widely accessible.