### PR TITLE
docs: Translate ACCESS_GUIDE.md from Japanese to English

### DIFF
--- a/ACCESS_GUIDE.md
+++ b/ACCESS_GUIDE.md
@@ -1,79 +1,79 @@
-# MCP Inspector アクセスガイド
+# MCP Inspector Access Guide
 
-## 🌐 アクセスURL
+## 🌐 Access URLs
 
-### 0.0.0.0（推奨 - 外部からアクセス可能）
+### 0.0.0.0 (Recommended - External Access)
 ```
 http://0.0.0.0:6274/?MCP_PROXY_AUTH_TOKEN=973ff60cac74430ba774a6b9bbe0d366232cb452202845a6d706420fcac2f474
 ```
 
-### localhost（ローカルアクセスのみ）
+### localhost (Local Access Only)
 ```
 http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=973ff60cac74430ba774a6b9bbe0d366232cb452202845a6d706420fcac2f474
 ```
 
-## ✅ TCPプロキシによる0.0.0.0サポート
+## ✅ 0.0.0.0 Support via TCP Proxy
 
-TCPプロキシ（`tcp_proxy.py`）を使用して、以下のポートが0.0.0.0でlistenしています：
+Using the TCP proxy (`tcp_proxy.py`), the following ports are listening on 0.0.0.0:
 
 - **Inspector Web UI**: 0.0.0.0:6274
-- **MCPプロキシサーバー**: 0.0.0.0:6277
+- **MCP Proxy Server**: 0.0.0.0:6277
 
-### プロキシの状態確認
+### Checking Proxy Status
 ```bash
 ps aux | grep tcp_proxy
 lsof -i :6274
 lsof -i :6277
 ```
 
-### プロキシのテスト
+### Testing the Proxy
 ```bash
-# ローカルアクセス（直接）
+# Local access (direct)
 curl -s -I http://localhost:6274 | head -3
 
-# 外部アクセス（0.0.0.0経由）
+# External access (via 0.0.0.0)
 curl -s -I http://0.0.0.0:6274 | head -3
 ```
 
-## 🔍 動作確認
+## 🔍 Verification
 
-### 1. Webブラウザでの確認
-ブラウザで上記のURLにアクセスして、MCP InspectorのUIが表示されることを確認してください。
+### 1. Check via Web Browser
+Access the above URL in your browser and verify that the MCP Inspector UI is displayed.
 
-### 2. MCPサーバーの確認
-Inspector内で「test-watcher」サーバーが接続されていることを確認してください。以下の情報が表示されるはずです：
-- サーバー名: test-watcher
-- 利用可能なツール: 4つ
-- 利用可能なリソース: 2つ
+### 2. Check MCP Server
+Verify that the "test-watcher" server is connected within Inspector. The following information should be displayed:
+- Server name: test-watcher
+- Available tools: 4
+- Available resources: 2
 
-### 3. ツールのテスト
-Inspectorから直接ツールを呼び出してテストできます：
-- `get_status()` - テスト監視サービスの状態を確認
-- `start_watching()` - ファイル監視を開始
+### 3. Tool Testing
+You can test tools directly from Inspector:
+- `get_status()` - Check test watcher service status
+- `start_watching()` - Start file watching
 
-## 🔧 トラブルシューティング
+## 🔧 Troubleshooting
 
-### プロキシが動作していない場合
+### When Proxy is Not Running
 ```bash
-# プロキシを再起動
+# Restart the proxy
 pkill -f tcp_proxy.py
 python3 /home/node/src/auto-coder/tcp_proxy.py 6274 localhost 6274 &
 python3 /home/node/src/auto-coder/tcp_proxy.py 6277 localhost 6277 &
 ```
 
-### 接続できない場合
-1. プロキシプロセスが動作しているか確認
-2. ポートが他のプロセスで使用されていないか確認
-3. 防火墙の設定を確認
+### When Connection Fails
+1. Check if proxy processes are running
+2. Check if ports are not in use by other processes
+3. Check firewall settings
 
-## 📊 現在の状況
+## 📊 Current Status
 
-- **Inspector**: 動作中
-- **TCPプロキシ**: 動作中
-- **test-watcherサーバー**: 設定済み
-- **アクセス**: 0.0.0.0で可能
+- **Inspector**: Running
+- **TCP Proxy**: Running
+- **test-watcher Server**: Configured
+- **Access**: Available via 0.0.0.0
 
 ---
 
-**更新日時**: 2025-10-31
-**認証トークン**: 973ff60cac74430ba774a6b9bbe0d366232cb452202845a6d706420fcac2f474
+**Last Updated**: 2025-10-31
+**Auth Token**: 973ff60cac74430ba774a6b9bbe0d366232cb452202845a6d706420fcac2f474


### PR DESCRIPTION
Closes #145

Successfully translated ACCESS_GUIDE.md from Japanese to English. The 79-line document now includes access URLs, TCP proxy configuration, verification steps, and troubleshooting guide in English for better accessibility.