### PR TITLE
Looking at the completed translation work for Issue #146 Sub-Issue #4.3, here's the pull request message:

### DIFF
--- a/docs/BUNDLED_MCP_SERVER.md
+++ b/docs/BUNDLED_MCP_SERVER.md
@@ -1,176 +1,176 @@
-# バンドルされたMCPサーバー
+# Bundled MCP Server
 
-## 概要
+## Overview
 
-auto-coder v2025.10.23以降、カスタマイズされたGraphRAG MCPサーバーがパッケージにバンドルされています。
+Since auto-coder v2025.10.23, a customized GraphRAG MCP server is bundled with the package.
 
-## 変更内容
+## Changes
 
-### 以前（v2025.10.23より前）
+### Previous (before v2025.10.23)
 
-- `auto-coder graphrag setup-mcp`コマンドは`https://github.com/rileylemm/graphrag_mcp`をクローン
-- 汎用的なドキュメント検索用MCPサーバーを使用
-- ツール: `search_documentation`, `hybrid_search`
+- The `auto-coder graphrag setup-mcp` command cloned `https://github.com/rileylemm/graphrag_mcp`
+- Used a general-purpose documentation search MCP server
+- Tools: `search_documentation`, `hybrid_search`
 
-### 現在（v2025.10.23以降）
+### Current (v2025.10.23 and later)
 
-- `auto-coder graphrag setup-mcp`コマンドはバンドルされたカスタムMCPサーバーをコピー
-- TypeScript/JavaScriptコード分析専用MCPサーバーを使用
-- ツール: `find_symbol`, `get_call_graph`, `get_dependencies`, `impact_analysis`, `semantic_code_search`
+- The `auto-coder graphrag setup-mcp` command copies the bundled custom MCP server
+- Uses a TypeScript/JavaScript code analysis dedicated MCP server
+- Tools: `find_symbol`, `get_call_graph`, `get_dependencies`, `impact_analysis`, `semantic_code_search`
 
-## バンドルされたMCPサーバーの場所
+## Location of Bundled MCP Server
 
-### パッケージ内
+### Within Package
 
 ```
 src/auto_coder/mcp_servers/graphrag_mcp/
-├── FORK_INFO.md              # フォーク情報
-├── server.py                 # MCPサーバー本体
-├── main.py                   # エントリーポイント
-├── pyproject.toml            # 依存関係定義
-├── run_server.sh             # 起動スクリプト
+├── FORK_INFO.md              # Fork information
+├── server.py                 # MCP server main
+├── main.py                   # Entry point
+├── pyproject.toml            # Dependency definitions
+├── run_server.sh             # Startup script
 └── graphrag_mcp/
-    ├── code_analysis_tool.py # コード分析ツール実装
-    └── documentation_tool.py # 元のツール（未使用）
+    ├── code_analysis_tool.py # Code analysis tool implementation
+    └── documentation_tool.py # Original tools (unused)
 ```
 
-### インストール後
+### After Installation
 
 ```bash
-# pipx経由でインストールした場合
+# If installed via pipx
 pipx install auto-coder
 
-# setup-mcpコマンドでMCPサーバーをコピー
+# Setup MCP server using setup-mcp command
 auto-coder graphrag setup-mcp
 
-# デフォルトのコピー先
+# Default copy destination
 ~/graphrag_mcp/
 ```
 
-## 使用方法
+## Usage
 
-### 1. auto-coderのインストール
+### 1. Install auto-coder
 
 ```bash
-# pipx経由（推奨）
+# Via pipx (recommended)
 pipx install auto-coder
 
-# または pip経由
+# Or via pip
 pip install auto-coder
 ```
 
-### 2. GraphRAGサービスの起動
+### 2. Start GraphRAG Services
 
 ```bash
-# Neo4j + Qdrantを起動
+# Start Neo4j + Qdrant
 auto-coder graphrag start
 ```
 
-### 3. MCPサーバーのセットアップ
+### 3. Setup MCP Server
 
-#### 自動セットアップ（推奨）
+#### Automatic Setup (Recommended)
 
-**v2025.10.23以降、MCPサーバーは自動的にセットアップされます。**
+**Since v2025.10.23, the MCP server is automatically setup.**
 
-auto-coderを実行すると、`~/graphrag_mcp`ディレクトリが存在しない場合、自動的にセットアップが実行されます。
+When auto-coder is executed, if the `~/graphrag_mcp` directory does not exist, setup is automatically executed.
 
 ```bash
-# 通常のコマンドを実行するだけで自動セットアップされます
+# Normal command execution triggers automatic setup
 auto-coder run
 
-# または任意のコマンド
+# Or any command
 auto-coder process-issues
 ```
 
-#### 手動セットアップ
+#### Manual Setup
 
-手動でセットアップしたい場合は、以下のコマンドを実行します：
+If you want to manually setup, run the following commands:
 
 ```bash
-# バンドルされたMCPサーバーを~/graphrag_mcpにコピー
+# Copy bundled MCP server to ~/graphrag_mcp
 auto-coder graphrag setup-mcp
 
-# カスタムディレクトリにコピー
+# Copy to custom directory
 auto-coder graphrag setup-mcp --install-dir /path/to/custom/dir
 ```
 
-このコマンドは以下を実行します：
-1. バンドルされたMCPサーバーを指定ディレクトリにコピー
-2. `uv`を使用して依存関係をインストール
-3. `.env`ファイルを作成（Neo4j/Qdrant接続情報）
-4. 各バックエンド（Codex, Gemini, Qwen, Windsurf/Claude）の設定ファイルを自動更新
+This command performs the following:
+1. Copies the bundled MCP server to the specified directory
+2. Installs dependencies using `uv`
+3. Creates `.env` file (Neo4j/Qdrant connection information)
+4. Automatically updates configuration files for each backend (Codex, Gemini, Qwen, Windsurf/Claude)
 
-### 4. MCPサーバーの起動確認
+### 4. Verify MCP Server Startup
 
 ```bash
-# MCPサーバーを手動起動（テスト用）
+# Manually start MCP server (for testing)
 cd ~/graphrag_mcp
 uv run main.py
 
-# または起動スクリプトを使用
+# Or use startup script
 ./run_server.sh
 ```
 
-## カスタマイズ内容
+## Customization Details
 
-### フォーク元
+### Fork Source
 
-- オリジナル: https://github.com/rileylemm/graphrag_mcp
-- 用途: 汎用的なドキュメント検索
+- Original: https://github.com/rileylemm/graphrag_mcp
+- Purpose: General-purpose documentation search
 
-### カスタマイズ
+### Customizations
 
-1. **グラフスキーマの変更**
-   - 元: Document, Chunk, Category ノード
-   - 現在: File, Symbol（Function, Method, Class, Interface, Type）ノード
+1. **Graph Schema Changes**
+   - Original: Document, Chunk, Category nodes
+   - Current: File, Symbol (Function, Method, Class, Interface, Type) nodes
 
-2. **リレーションシップの変更**
-   - 元: PART_OF, RELATED_TO, HAS_CATEGORY
-   - 現在: CONTAINS, CALLS, EXTENDS, IMPLEMENTS, IMPORTS
+2. **Relationship Changes**
+   - Original: PART_OF, RELATED_TO, HAS_CATEGORY
+   - Current: CONTAINS, CALLS, EXTENDS, IMPLEMENTS, IMPORTS
 
-3. **ツールの追加**
-   - `find_symbol(fqname)`: シンボル検索
-   - `get_call_graph(symbol_id, direction, depth)`: 呼び出しグラフ分析
-   - `get_dependencies(file_path)`: 依存関係分析
-   - `impact_analysis(symbol_ids, max_depth)`: 影響範囲分析
-   - `semantic_code_search(query, limit, kind_filter)`: 意味的コード検索
+3. **Added Tools**
+   - `find_symbol(fqname)`: Symbol search
+   - `get_call_graph(symbol_id, direction, depth)`: Call graph analysis
+   - `get_dependencies(file_path)`: Dependency analysis
+   - `impact_analysis(symbol_ids, max_depth)`: Impact scope analysis
+   - `semantic_code_search(query, limit, kind_filter)`: Semantic code search
 
-4. **自己記述の強化**
-   - ツールdocstringにts-morph固有の情報を追加
-   - MCPリソースにコード分析ドメイン知識を追加
+4. **Enhanced Self-Documentation**
+   - Added ts-morph specific information to tool docstrings
+   - Added code analysis domain knowledge to MCP resources
 
-## 技術的な詳細
+## Technical Details
 
-### パッケージング
+### Packaging
 
-- `pyproject.toml`の`[tool.setuptools.package-data]`にMCPサーバーを追加
-- `MANIFEST.in`でMCPサーバーファイルを明示的に含める
-- pipx/pipインストール時に自動的にバンドル
+- Added MCP server to `[tool.setuptools.package-data]` in `pyproject.toml`
+- Explicitly included MCP server files in `MANIFEST.in`
+- Automatically bundled during pipx/pip installation
 
-### セットアップフロー
+### Setup Flow
 
 ```python
 # src/auto_coder/cli_commands_graphrag.py
 
 def run_graphrag_setup_mcp_programmatically(...):
-    # 1. パッケージ内のMCPサーバーを検索
+    # 1. Find MCP server within package
     import auto_coder
     package_dir = Path(auto_coder.__file__).parent
     bundled_mcp = package_dir / "mcp_servers" / "graphrag_mcp"
-    
-    # 2. インストール先にコピー
+
+    # 2. Copy to installation destination
     shutil.copytree(bundled_mcp, install_path)
-    
-    # 3. 依存関係をインストール
+
+    # 3. Install dependencies
     subprocess.run(["uv", "sync"], cwd=install_path)
-    
-    # 4. .envファイルを作成
-    # 5. バックエンド設定を更新
+
+    # 4. Create .env file
+    # 5. Update backend configurations
 ```
 
-### ts-morphとの統合
+### Integration with ts-morph
 
-MCPサーバーは`src/auto_coder/graph_builder/`のts-morphスキャナーが生成するグラフ構造に対応：
+The MCP server corresponds to the graph structure generated by the ts-morph scanner in `src/auto_coder/graph_builder/`:
 
 ```typescript
 // src/auto_coder/graph_builder/src/types.ts
@@ -191,58 +191,57 @@ export interface CodeNode {
 }
 ```
 
-## トラブルシューティング
+## Troubleshooting
 
-### MCPサーバーが見つからない
+### MCP Server Not Found
 
 ```bash
-# パッケージが正しくインストールされているか確認
+# Verify package is correctly installed
 python -c "import auto_coder; from pathlib import Path; print(Path(auto_coder.__file__).parent / 'mcp_servers' / 'graphrag_mcp')"
 
-# 再インストール
+# Reinstall
 pipx reinstall auto-coder
 ```
 
-### setup-mcpが失敗する
+### setup-mcp Fails
 
 ```bash
-# uvがインストールされているか確認
+# Verify uv is installed
 uv --version
 
-# uvをインストール
+# Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 既存のディレクトリを削除して再実行
+# Delete existing directory and retry
 rm -rf ~/graphrag_mcp
 auto-coder graphrag setup-mcp
 ```
 
-### MCPサーバーが起動しない
+### MCP Server Won't Start
 
 ```bash
-# 依存関係を再インストール
+# Reinstall dependencies
 cd ~/graphrag_mcp
 uv sync
 
-# Neo4j/Qdrantが起動しているか確認
+# Verify Neo4j/Qdrant are running
 auto-coder graphrag status
 
-# .envファイルを確認
+# Check .env file
 cat ~/graphrag_mcp/.env
 ```
 
-## 参照
+## References
 
-- フォーク情報: `src/auto_coder/mcp_servers/graphrag_mcp/FORK_INFO.md`
-- 機能ドキュメント: `docs/client-features.yaml` (external_dependencies.graphrag_mcp)
-- セットアップコマンド: `src/auto_coder/cli_commands_graphrag.py`
-- テスト: `tests/test_graphrag_mcp_fork.py`
+- Fork information: `src/auto_coder/mcp_servers/graphrag_mcp/FORK_INFO.md`
+- Feature documentation: `docs/client-features.yaml` (external_dependencies.graphrag_mcp)
+- Setup commands: `src/auto_coder/cli_commands_graphrag.py`
+- Tests: `tests/test_graphrag_mcp_fork.py`
 
-## 今後の拡張
+## Future Extensions
 
-1. **他言語対応**: Python, Go, Rustのサポート追加
-2. **高度なクエリ**: アーキテクチャ分析、デッドコード検出
-3. **増分更新**: 大規模コードベースの最適化
-4. **キャッシング**: 頻繁なクエリのキャッシュ
-5. **可視化**: コールグラフの可視化ツール
-
+1. **Multi-Language Support**: Add support for Python, Go, Rust
+2. **Advanced Queries**: Architecture analysis, dead code detection
+3. **Incremental Updates**: Optimization for large codebases
+4. **Caching**: Cache frequent queries
+5. **Visualization**: Call graph visualization tools


### PR DESCRIPTION
Closes #146

**docs: Translate BUNDLED_MCP_SERVER.md from Japanese to English**

Translated the complete BUNDLED_MCP_SERVER.md documentation from Japanese to English, covering the bundled MCP server overview, installation procedures, usage instructions, and version changes. This ensures the documentation is accessible to English-speaking users and aligns with the project's internationalization efforts.