### PR TITLE
docs: Translate setup guides from Japanese to English (#148)

### DIFF
--- a/MCP_PDB_SETUP.md
+++ b/MCP_PDB_SETUP.md
@@ -1,27 +1,27 @@
-# MCP-PDB セットアップ完了
+# MCP-PDB Setup Complete
 
-## 概要
-MCP-PDB（Model Context Protocol Python Debugger）ツールがこのワークスペースで利用可能になりました。
-このツールはPythonデバッガー（pdb）をMCP経由でClaude等のLLMから利用できるようにします。
+## Overview
+The MCP-PDB (Model Context Protocol Python Debugger) tool is now available in this workspace.
+This tool enables Python debugger (pdb) to be used via MCP from LLMs such as Claude.
 
-## セットアップ状況
+## Setup Status
 
-### ✅ 完了した作業
-1. **Python 3.13のインストール**: MCP-PDBはPython 3.13以上が必要
-2. **MCP-PDBツールのインストール**: uvを使用してインストール完了
-3. **サーバーの起動**: MCP-PDBサーバーが正常に起動中
-4. **動作確認**: テストファイルでPythonコードの実行を確認
+### ✅ Completed Tasks
+1. **Python 3.13 Installation**: MCP-PDB requires Python 3.13 or higher
+2. **MCP-PDB Tool Installation**: Installation completed using uv
+3. **Server Startup**: MCP-PDB server is running normally
+4. **Functionality Verification**: Confirmed Python code execution with test files
 
-### 🔧 現在の状態
-- **MCP-PDBサーバー**: 実行中（Terminal ID: 57）
-- **Python実行環境**: Python 3.13.6
-- **作業ディレクトリ**: `/home/ubuntu/src/auto-coder`
-- **テストファイル**: `test_debug_sample.py` 作成済み
+### 🔧 Current Status
+- **MCP-PDB Server**: Running (Terminal ID: 57)
+- **Python Runtime Environment**: Python 3.13.6
+- **Working Directory**: `/home/ubuntu/src/auto-coder`
+- **Test File**: `test_debug_sample.py` created
 
-## 利用方法
+## Usage
 
-### 1. Windsurf での設定
-settings.json に以下を追加：
+### 1. Windsurf Configuration
+Add the following to settings.json:
 
 ```json
 {
@@ -41,71 +41,71 @@ settings.json に以下を追加：
 }
 ```
 
-### 2. Claude Code での設定
-以下のコマンドを実行：
+### 2. Claude Code Configuration
+Run the following command:
 
 ```bash
 claude mcp add mcp-pdb -- uv run --python 3.13 --with mcp-pdb mcp-pdb
 ```
 
-### 3. 利用可能なツール
+### 3. Available Tools
 
-| ツール | 説明 |
-|--------|------|
-| `start_debug(file_path, use_pytest, args)` | Pythonファイルのデバッグセッションを開始 |
-| `send_pdb_command(command)` | 実行中のPDBインスタンスにコマンドを送信 |
-| `set_breakpoint(file_path, line_number)` | 特定の行にブレークポイントを設定 |
-| `clear_breakpoint(file_path, line_number)` | 特定の行のブレークポイントをクリア |
-| `list_breakpoints()` | 現在のブレークポイントを一覧表示 |
-| `restart_debug()` | 現在のデバッグセッションを再開 |
-| `examine_variable(variable_name)` | 変数の詳細情報を取得 |
-| `get_debug_status()` | デバッグセッションの現在の状態を表示 |
-| `end_debug()` | 現在のデバッグセッションを終了 |
+| Tool | Description |
+|------|-------------|
+| `start_debug(file_path, use_pytest, args)` | Start a debug session for a Python file |
+| `send_pdb_command(command)` | Send a command to the running PDB instance |
+| `set_breakpoint(file_path, line_number)` | Set a breakpoint at a specific line |
+| `clear_breakpoint(file_path, line_number)` | Clear the breakpoint at a specific line |
+| `list_breakpoints()` | List all current breakpoints |
+| `restart_debug()` | Restart the current debug session |
+| `examine_variable(variable_name)` | Get detailed information about a variable |
+| `get_debug_status()` | Show the current status of the debug session |
+| `end_debug()` | End the current debug session |
 
-### 4. よく使用するPDBコマンド
+### 4. Common PDB Commands
 
-| コマンド | 説明 |
-|----------|------|
-| `n` | 次の行（ステップオーバー） |
-| `s` | 関数内にステップイン |
-| `c` | 実行を継続 |
-| `r` | 現在の関数から戻る |
-| `p variable` | 変数の値を表示 |
-| `pp variable` | 変数を整形して表示 |
-| `l` | ソースコードを表示 |
-| `q` | デバッグを終了 |
+| Command | Description |
+|---------|-------------|
+| `n` | Next line (step over) |
+| `s` | Step into function |
+| `c` | Continue execution |
+| `r` | Return from current function |
+| `p variable` | Print variable value |
+| `pp variable` | Pretty-print variable |
+| `l` | List source code |
+| `q` | Quit debugging |
 
-## テスト用ファイル
+## Test File
 
-`test_debug_sample.py` が作成されており、以下の機能をテストできます：
-- 階乗計算関数
-- フィボナッチ数列計算関数
-- エラーハンドリング
+`test_debug_sample.py` has been created and can be used to test the following features:
+- Factorial calculation function
+- Fibonacci sequence calculation function
+- Error handling
 
-## 注意事項
+## Notes
 
-⚠️ **セキュリティ警告**: このツールはPythonコードをデバッガー経由で実行します。信頼できる環境でのみ使用してください。
+⚠️ **Security Warning**: This tool executes Python code through a debugger. Only use in trusted environments.
 
-## サーバー管理
+## Server Management
 
-### サーバーの状態確認
+### Check Server Status
 ```bash
-# プロセス一覧を確認
+# Check process list
 ps aux | grep mcp-pdb
 ```
 
-### サーバーの停止（必要な場合）
-現在実行中のMCP-PDBサーバーを停止する場合は、Terminal ID 57のプロセスを終了してください。
+### Stop Server (if needed)
+To stop the currently running MCP-PDB server, terminate the process with Terminal ID 57.
 
-### サーバーの再起動
+### Restart Server
 ```bash
 uv run --python 3.13 --with mcp-pdb mcp-pdb
 ```
 
-## 次のステップ
+## Next Steps
 
-1. **IDE設定**: WindsurfまたはClaude Codeで上記の設定を追加
-2. **接続確認**: MCPサーバーとの接続を確認
-3. **デバッグ開始**: `start_debug()` ツールを使用してデバッグセッションを開始
+1. **IDE Configuration**: Add the above settings in Windsurf or Claude Code
+2. **Connection Verification**: Verify connection to the MCP server
+3. **Start Debugging**: Use the `start_debug()` tool to begin a debug session
 
-MCP-PDBツールが正常にセットアップされ、Pythonコードのデバッグが可能になりました。
+The MCP-PDB tool has been successfully set up and Python code debugging is now available.

--- a/OPENROUTER_SETUP.md
+++ b/OPENROUTER_SETUP.md
@@ -1,12 +1,12 @@
-# OpenRouter設定ガイド
+# OpenRouter Setup Guide
 
-## 概要
-Codex CLIでOpenRouter経由でQwen3 Coderを使用するための設定が完了しました。
+## Overview
+Configuration has been completed to use Qwen3 Coder via OpenRouter with the Codex CLI.
 
-## 設定内容
+## Configuration Details
 
-### 1. 環境変数の設定
-以下の環境変数が`~/.bashrc`に追加されました：
+### 1. Environment Variables
+The following environment variables have been added to `~/.bashrc`:
 
 ```bash
 export OPENAI_API_KEY="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"
@@ -14,8 +14,8 @@ export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 export OPENAI_MODEL="qwen/qwen3-coder:free"
 ```
 
-### 2. Codex設定ファイル（~/.codex/config.toml）
-以下の設定が追加されました：
+### 2. Codex Configuration File (~/.codex/config.toml)
+The following configuration has been added:
 
 ```toml
 model = "qwen/qwen3-coder:free"
@@ -28,14 +28,14 @@ base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENAI_API_KEY"
 ```
 
-## 使用方法
+## Usage
 
-### 現在のセッションで環境変数を有効化
+### Enable Environment Variables in Current Session
 ```bash
 source ~/.bashrc
 ```
 
-または
+Or
 
 ```bash
 export OPENAI_API_KEY="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"
@@ -43,59 +43,59 @@ export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 export OPENAI_MODEL="qwen/qwen3-coder:free"
 ```
 
-### Codex CLIの実行
-設定が完了したので、通常通りCodexを使用できます：
+### Running Codex CLI
+With the configuration complete, you can now use Codex normally:
 
 ```bash
 codex "Hello, how are you?"
 ```
 
-または
+Or
 
 ```bash
 codex exec "Write a Python function to calculate fibonacci numbers"
 ```
 
-## 設定の確認
+## Verifying Configuration
 
-### 環境変数の確認
+### Verify Environment Variables
 ```bash
 env | grep OPENAI
 ```
 
-### Codex設定の確認
+### Verify Codex Configuration
 ```bash
 cat ~/.codex/config.toml
 ```
 
-### Codexバージョンの確認
+### Verify Codex Version
 ```bash
 codex --version
 ```
 
-## バックアップ
-元の設定ファイルは以下にバックアップされています：
+## Backup
+The original configuration file has been backed up at:
 - `~/.codex/config.toml.backup`
 
-## トラブルシューティング
+## Troubleshooting
 
-### 設定が反映されない場合
-1. 新しいターミナルセッションを開く
-2. または `source ~/.bashrc` を実行
+### If Configuration Is Not Applied
+1. Open a new terminal session
+2. Or run `source ~/.bashrc`
 
-### モデルプロバイダーを変更したい場合
-`~/.codex/config.toml`の以下の行を編集：
+### To Change Model Provider
+Edit the following line in `~/.codex/config.toml`:
 ```toml
-model_provider = "openrouter"  # 他のプロバイダーに変更可能
+model_provider = "openrouter"  # Can be changed to other providers
 ```
 
-### 別のモデルを使用したい場合
-`~/.codex/config.toml`の以下の行を編集：
+### To Use Different Model
+Edit the following line in `~/.codex/config.toml`:
 ```toml
-model = "qwen/qwen3-coder:free"  # 他のOpenRouterモデルに変更可能
+model = "qwen/qwen3-coder:free"  # Can be changed to other OpenRouter models
 ```
 
-## 参考リンク
+## Reference Links
 - [Codex CLI Configuration Documentation](https://developers.openai.com/codex/local-config/)
 - [OpenRouter Models](https://openrouter.ai/models)
 - [Codex GitHub Repository](https://github.com/openai/codex)


### PR DESCRIPTION
## Summary
Translate setup guide files from Japanese to English for better accessibility.

## Changes
- Translated `OPENROUTER_SETUP.md` from Japanese to English
- Translated `MCP_PDB_SETUP.md` from Japanese to English

Both documentation files are now fully in English, covering:
- OpenRouter configuration with Codex CLI
- MCP-PDB setup and usage instructions

## Test plan
- [x] Reviewed translation for accuracy
- [x] Verified markdown formatting is preserved
- [x] Confirmed all code blocks and examples are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>