### PR TITLE
Based on the changes summary provided, here's the pull request message:

### DIFF
--- a/PROGRESS_DECORATORS_README.md
+++ b/PROGRESS_DECORATORS_README.md
@@ -1,18 +1,18 @@
 # Progress Decorators for Auto-Coder
 
-このドキュメントは、`ProgressStage()`コンテキストマネージャーと同等の機能を提供するデコレーターについて説明します。
+This document describes decorators that provide equivalent functionality to the `ProgressStage()` context manager.
 
-## 概要
+## Overview
 
-`src/auto_coder/progress_decorators.py` には、メソッドの実行中に自動でプログレス管理を行うデコレーターが実装されています。これらは `ProgressStage` コンテキストマネージャーと同じ機能を提供しますが、デコレーターとして使用できます。
+`src/auto_coder/progress_decorators.py` implements decorators that automatically manage progress during method execution. These provide the same functionality as the `ProgressStage` context manager but can be used as decorators.
 
-## デコレーターの種類
+## Decorator Types
 
 ### 1. `@progress_stage`
 
-最も柔軟なデコレーターで、ProgressStageコンテキストマネージャーと同等の引数を受け付けます。
+The most flexible decorator, accepting the same arguments as the ProgressStage context manager.
 
-#### 使用例
+#### Usage Examples
 
 ```python
 from src.auto_coder.progress_decorators import progress_stage
@@ -20,35 +20,35 @@ from src.auto_coder.progress_decorators import progress_stage
 class MyProcessor:
     @progress_stage()
     def process_simple(self):
-        # 自動生成されたステージ名（"Process Simple"）を使用
+        # Uses automatically generated stage name ("Process Simple")
         pass
-    
+
     @progress_stage("Custom Stage Name")
     def process_with_custom_name(self):
-        # カスタムステージ名
+        # Custom stage name
         pass
-    
+
     @progress_stage("PR", 123, "Analyzing")
     def analyze_pr(self):
-        # PRコンテキスト付き
+        # With PR context
         pass
-    
+
     @progress_stage("Issue", 456, "Processing", [789], "feature-branch")
     def process_issue_with_context(self):
-        # フルコンテキスト情報付き
+        # With full context information
         pass
 ```
 
-#### 引数の仕様
+#### Argument Specifications
 
-- `()`: メソッド名を自動生成（`method_name → Method Name`）
-- `("stage_name")`: カスタムステージ名
-- `("item_type", item_number, "stage_name")`: アイテム情報とステージ
-- `("item_type", item_number, "stage_name", related_issues, branch_name)`: フルコンテキスト
+- `()`: Automatically generates method name (`method_name → Method Name`)
+- `("stage_name")`: Custom stage name
+- `("item_type", item_number, "stage_name")`: Item information and stage
+- `("item_type", item_number, "stage_name", related_issues, branch_name)`: Full context
 
 ### 2. `@progress_method`
 
- よりシンプルな構文を提供する代替デコレーターです。
+An alternative decorator that provides a simpler syntax.
 
 ```python
 from src.auto_coder.progress_decorators import progress_method
@@ -56,18 +56,18 @@ from src.auto_coder.progress_decorators import progress_method
 class MyProcessor:
     @progress_method()
     def my_method(self):
-        # メソッド名をステージ名として使用
+        # Uses method name as stage name
         pass
-    
+
     @progress_method("Custom Stage")
     def another_method(self):
-        # カスタムステージ名
+        # Custom stage name
         pass
 ```
 
 ### 3. `@progress_context_item`
 
-アイテムコンテキストを設定し、自動的にクリアするデコレーターです。
+A decorator that sets item context and automatically clears it.
 
 ```python
 from src.auto_coder.progress_decorators import progress_context_item
@@ -75,13 +75,13 @@ from src.auto_coder.progress_decorators import progress_context_item
 class MyProcessor:
     @progress_context_item("PR", 123, "Analyzing")
     def analyze_pr(self):
-        # PRコンテキスト設定、実行後に自動クリア
+        # PR context set, automatically cleared after execution
         pass
 ```
 
-### 4. `ProgressStageDecorator` クラス
+### 4. `ProgressStageDecorator` Class
 
-クラスベースデコレーターで、より複雑なシナリオに対応できます。
+A class-based decorator that can handle more complex scenarios.
 
 ```python
 from src.auto_coder.progress_decorators import ProgressStageDecorator
@@ -90,54 +90,54 @@ class MyProcessor:
     @ProgressStageDecorator("Processing")
     def process_item(self):
         pass
-        
+
     @ProgressStageDecorator("PR", 123, "Analyzing")
     def analyze_pr(self):
         pass
 ```
 
-## ProgressStage との比較
+## Comparison with ProgressStage
 
-### ProgressStage (コンテキストマネージャー)
+### ProgressStage (Context Manager)
 ```python
 from src.auto_coder.progress_footer import ProgressStage
 
 def my_function():
     with ProgressStage("PR", 123, "Analyzing"):
-        # 処理実行
+        # Execute processing
         pass
 ```
 
-### progress_stage デコレーター
+### progress_stage Decorator
 ```python
 from src.auto_coder.progress_decorators import progress_stage
 
 class MyProcessor:
     @progress_stage("PR", 123, "Analyzing")
     def my_method(self):
-        # 処理実行（自動的にプログレス管理）
+        # Execute processing (automatically managed progress)
         pass
 ```
 
-## ネストされたデコレーター
+## Nested Decorators
 
-デコレーターは正常にネストでき、内側のデコレーターが外側のデコレーターのステージスタックに追加されます。
+Decorators can be nested properly, with inner decorators being added to the outer decorator's stage stack.
 
 ```python
 class MyProcessor:
     @progress_stage("Outer Operation")
     def outer_operation(self):
-        # 外側ステージ: [PR #123] Outer Operation
-        
-        self.analyze_pr()  # 内側ステージ: [PR #123] Outer Operation / Analyzing
-        self.process_simple()  # 内側ステージ: [PR #123] Outer Operation / Process Simple
-        
-        # 外側ステージに復帰: [PR #123] Outer Operation
+        # Outer stage: [PR #123] Outer Operation
+
+        self.analyze_pr()  # Inner stage: [PR #123] Outer Operation / Analyzing
+        self.process_simple()  # Inner stage: [PR #123] Outer Operation / Process Simple
+
+        # Returns to outer stage: [PR #123] Outer Operation
 ```
 
-## 実用的な使用例
+## Practical Usage Examples
 
-### GitHub Issue プロセッサーでの使用
+### Usage in GitHub Issue Processor
 
 ```python
 from src.auto_coder.progress_decorators import progress_stage
@@ -145,25 +145,25 @@ from src.auto_coder.progress_decorators import progress_stage
 class IssueProcessor:
     @progress_stage("Issue", 1, "Analyzing")
     def analyze_issue(self, issue):
-        # Issueの分析処理
+        # Issue analysis processing
         self.validate_issue(issue)
         self.create_branch(issue)
-    
+
     @progress_stage("Issue", 1, "Implementing")
     def implement_fix(self, issue):
-        # 修正実装
+        # Fix implementation
         self.modify_code(issue)
         self.run_tests()
-    
+
     @progress_stage("Issue", 1, "Creating PR")
     def create_pull_request(self, issue):
-        # PR作成
+        # Create PR
         self.commit_changes()
         self.push_branch()
         self.create_pr()
 ```
 
-### PR プロセッサーでの使用
+### Usage in PR Processor
 
 ```python
 from src.auto_coder.progress_decorators import progress_stage, progress_context_item
@@ -171,28 +171,28 @@ from src.auto_coder.progress_decorators import progress_stage, progress_context_
 class PRProcessor:
     @progress_stage("PR", 123, "Validating")
     def validate_pr(self, pr):
-        # PRの検証
+        # PR validation
         self.check_tests(pr)
         self.check_conflicts(pr)
-    
+
     @progress_context_item("PR", 123, "Merging")
     def merge_pr(self, pr):
-        # PRのマージ（完了後に自動クリア）
+        # PR merge (automatically cleared after completion)
         self.merge_branch(pr)
         self.close_issue(pr)
 ```
 
-## エラーハンドリング
+## Error Handling
 
-デコレーターは自動的に `try/finally` ブロックで包装されているため、メthylodが例外を発生させた場合でも、プログレスステージは適切にクリアされます。
+Decorators are automatically wrapped in `try/finally` blocks, so even if a method raises an exception, the progress stage is properly cleared.
 
 ```python
 @progress_stage("PR", 123, "Analyzing")
 def risky_method(self):
-    # 例外が発生しても、プログレスステージは適切にポップされる
-    raise ValueError("何か問題が発生しました")
+    # Even if an exception occurs, the progress stage is properly popped
+    raise ValueError("Something went wrong")
 ```
 
-## まとめ
+## Summary
 
-これらのデコレーターは、ProgressStageコンテキストマネージャーと同等の機能を提供し、メthylodデコレーターとしてより簡潔に使用できます。複雑なネストされた操作や自動的なエラーハンドリングも適切に処理されます。
+These decorators provide equivalent functionality to the ProgressStage context manager and can be used more concisely as method decorators. Complex nested operations and automatic error handling are also properly handled.


### PR DESCRIPTION
Closes #149

docs: Translate PROGRESS_DECORATORS_README.md from Japanese to English

Translated PROGRESS_DECORATORS_README.md from Japanese to English. The documentation covers progress decorator types, usage examples, and comparisons with ~197 lines of content. This makes the documentation accessible to English-speaking developers.