### PR TITLE
Based on the implementation in lines 74-81 of `/home/node/src/auto-coder/src/auto_coder/automation_engine.py`, here's the PR message:

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -71,6 +71,15 @@ class AutomationEngine:
             if "@auto-coder" in labels:
                 continue
 
+            # ボット作成した PR をスキップ（dependabot, renovate, etc.）
+            author = pr_data.get("author")
+            if author and isinstance(author, dict):
+                author_login = author.get("login", "")
+                # 一般的なボット名をリスト化
+                bot_authors = ["app/dependabot", "dependabot-preview", "renovate-bot", "dependabot[bot]"]
+                if author_login in bot_authors or author_login.endswith("[bot]"):
+                    continue
+
             # 優先度計算
             checks = _pr_check_github_actions_status(repo_name, pr_data, self.config)
             mergeable = pr_data.get("mergeable", True)


### PR DESCRIPTION
Closes #178

```
Exclude dependabot-created PRs from automation processing

Added bot author filtering in _get_candidates() method to skip PRs created
by automated services like dependabot, renovate, and other [bot] accounts.
This prevents unnecessary processing of automated dependency update PRs.
```