### PR TITLE
translate(test files): Convert Japanese comments and messages to English

### DIFF
--- a/scripts/test-scripts/test_fix_validation.py
+++ b/scripts/test-scripts/test_fix_validation.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 """
-簡潔なテスト：修正された run メソッドの構造を直接確認
+Simple test: directly verify structure of fixed run method
 """
 
 import sys
 import os
 
 def test_run_method_calls_functions():
-    """run メソッドが process_issues と process_pull_requests を呼び出すかテスト"""
-    
-    # automation_engine.py ファイルを読み込み
+    """Test that run method calls process_issues and process_pull_requests"""
+
+    # Read automation_engine.py file
     with open('src/auto_coder/automation_engine.py', 'r') as f:
         content = f.read()
-    
-    # チェックポイント
+
+    # Checkpoints
     checks = [
-        ('process_issues(', 'process_issues 関数が呼び出されている'),
-        ('process_pull_requests(', 'process_pull_requests 関数が呼び出されている'),
-        ('issues_result = process_issues', 'process_issues の結果が issues_result に代入されている'),
-        ('prs_result = process_pull_requests', 'process_pull_requests の結果が prs_result に代入されている'),
-        ('issues_processed"] = issues_result', 'issues_result が issues_processed に設定されている'),
-        ('prs_processed"] = prs_result', 'prs_result が prs_processed に設定されている'),
+        ('process_issues(', 'process_issues function is called'),
+        ('process_pull_requests(', 'process_pull_requests function is called'),
+        ('issues_result = process_issues', 'process_issues result is assigned to issues_result'),
+        ('prs_result = process_pull_requests', 'process_pull_requests result is assigned to prs_result'),
+        ('issues_processed"] = issues_result', 'issues_result is set to issues_processed'),
+        ('prs_processed"] = prs_result', 'prs_result is set to prs_processed'),
     ]
     
     all_passed = True
@@ -29,18 +29,18 @@ def test_run_method_calls_functions():
         if check_text in content:
             print(f"✓ {description}")
         else:
-            print(f"✗ {description} - 見つかりません: {check_text}")
+            print(f"✗ {description} - not found: {check_text}")
             all_passed = False
     
     return all_passed
 
 def test_old_candidates_code_removed():
-    """古い候補者ベースのループコードが削除されているかテスト"""
-    
+    """Test that old candidate-based loop code is removed"""
+
     with open('src/auto_coder/automation_engine.py', 'r') as f:
         content = f.read()
-    
-    # 古いコードの痕跡がないかチェック
+
+    # Check for traces of old code
     old_code_patterns = [
         '_get_candidates(',
         '_select_best_candidate(',
@@ -53,30 +53,30 @@ def test_old_candidates_code_removed():
     
     for pattern in old_code_patterns:
         if pattern in content:
-            print(f"⚠ 古いコードが残っています: {pattern}")
+            print(f"⚠ Old code remains: {pattern}")
             all_removed = False
         else:
-            print(f"✓ 古いコードが削除されています: {pattern}")
+            print(f"✓ Old code is removed: {pattern}")
     
     return all_removed
 
 if __name__ == "__main__":
-    print("修正内容の検証中...\n")
-    
-    print("1. run メソッドの関数呼び出しチェック:")
+    print("Verifying fix contents...\n")
+
+    print("1. run method function call check:")
     test1 = test_run_method_calls_functions()
-    
-    print(f"\n2. 古いコードの削除チェック:")
+
+    print(f"\n2. Old code removal check:")
     test2 = test_old_candidates_code_removed()
-    
-    print(f"\n=== 結果 ===")
+
+    print(f"\n=== Results ===")
     if test1 and test2:
-        print("✓ すべてのチェック passes - 修正は正しく実装されています!")
-        print("\n修正された run メソッドは:")
-        print("- process_issues と process_pull_requests を呼び出します")
-        print("- テストが期待する構造で結果を返します")
-        print("- 古い候補者ベースのループを削除しています")
+        print("✓ All checks passed - fix is correctly implemented!")
+        print("\nFixed run method:")
+        print("- Calls process_issues and process_pull_requests")
+        print("- Returns results in structure expected by tests")
+        print("- Removes old candidate-based loop")
         sys.exit(0)
     else:
-        print("✗ 一部のチェックが失敗しました")
+        print("✗ Some checks failed")
         sys.exit(1)

--- a/tests/test_actions_history_pr_event_number_filtering.py
+++ b/tests/test_actions_history_pr_event_number_filtering.py
@@ -11,7 +11,7 @@ def _cmd_result(success: bool = True, stdout: str = "", stderr: str = "", return
 
 
 def test_history_prefers_pull_request_event_runs():
-    """event フィールドが存在する場合、pull_request の run を優先する。さらに run view の pullRequests に対象 PR が含まれるもののみ採用する。"""
+    """When event field exists, prefer pull_request runs. Also, only adopt runs where run view's pullRequests include the target PR."""
     config = AutomationConfig()
 
     pr_number = 321
@@ -24,7 +24,7 @@ def test_history_prefers_pull_request_event_runs():
         },
     }
 
-    # run list: push の新しい run と pull_request の古い run（同一ブランチ）
+    # run list: new push run and old pull_request run (same branch)
     push_run_id = 4400
     pr_run_id = 4300
     run_list_payload = [
@@ -53,7 +53,7 @@ def test_history_prefers_pull_request_event_runs():
     ]
     run_list_result = _cmd_result(True, stdout=json.dumps(run_list_payload), stderr="", returncode=0)
 
-    # run view の応答: push の方は対象 PR を含まない / pull_request の方は含む
+    # run view response: push does not include target PR / pull_request includes it
     jobs_payload = {
         "jobs": [
             {
@@ -83,7 +83,7 @@ def test_history_prefers_pull_request_event_runs():
                 returncode=0,
             )
         if cmd[:3] == ["gh", "run", "list"]:
-            # 現在の実装に合わせた単一の呼び出し
+            # Single call matching current implementation
             return run_list_result
         if cmd[:3] == ["gh", "run", "view"]:
             run_id = int(cmd[3])
@@ -116,7 +116,7 @@ def test_history_prefers_pull_request_event_runs():
 
 
 def test_history_limits_to_runs_referencing_target_pr():
-    """pullRequests に対象 PR 番号が含まれない run はスキップし、含まれる run だけを採用する。"""
+    """Skip runs that don't include target PR number in pullRequests, only adopt runs that do."""
     config = AutomationConfig()
 
     pr_number = 555
@@ -129,8 +129,8 @@ def test_history_limits_to_runs_referencing_target_pr():
         },
     }
 
-    run_a = 5100  # 新しいが対象PRを含まない
-    run_b = 5000  # 古いが対象PRを含む
+    run_a = 5100  # New but doesn't include target PR
+    run_b = 5000  # Old but includes target PR
     run_list_payload = [
         {
             "databaseId": run_a,

--- a/tests/test_actions_history_pr_pullrequests_missing.py
+++ b/tests/test_actions_history_pr_pullrequests_missing.py
@@ -11,7 +11,7 @@ def _cmd_result(success: bool = True, stdout: str = "", stderr: str = "", return
 
 
 def test_history_handles_missing_pullRequests_field_gracefully():
-    """run view の pullRequests フィールドが欠落していても、ジョブ情報から評価できること。"""
+    """run view's pullRequests field can be evaluated from job information even if missing."""
     config = AutomationConfig()
 
     pr_data = {
@@ -22,10 +22,10 @@ def test_history_handles_missing_pullRequests_field_gracefully():
         },
     }
 
-    # 1) --commit 側はヒットしない
+    # 1) --commit side will not hit
     commit_run_list = _cmd_result(True, stdout="[]", stderr="", returncode=0)
 
-    # 2) 通常の run list で対象ブランチの PR イベントの run が1件見つかる
+    # 2) Normal run list finds 1 PR event run for target branch
     run_id = 424242
     run_list_payload = [
         {
@@ -42,7 +42,7 @@ def test_history_handles_missing_pullRequests_field_gracefully():
     ]
     run_list_result = _cmd_result(True, stdout=json.dumps(run_list_payload), stderr="", returncode=0)
 
-    # 3) run view は pullRequests フィールドを返さない（欠落）
+    # 3) run view does not return pullRequests field (missing)
     jobs_payload = {
         "jobs": [
             {
@@ -72,10 +72,10 @@ def test_history_handles_missing_pullRequests_field_gracefully():
                 # Branch-based run list - should return the test data
                 return run_list_result
             elif call_count["list"] == 1:
-                # 1回目（commit 相当）はヒットしない
+                # 1st time (equivalent to commit) will not hit
                 return commit_run_list
             else:
-                # 2回目（フォールバック）は候補が返る
+                # 2nd time (fallback) returns candidates
                 return run_list_result
         if cmd[:3] == ["gh", "run", "view"]:
             return _cmd_result(True, stdout=json.dumps(jobs_payload), stderr="", returncode=0)
@@ -89,7 +89,7 @@ def test_history_handles_missing_pullRequests_field_gracefully():
 
 
 def test_history_handles_empty_pullRequests_list_gracefully():
-    """run view が pullRequests: [] を返しても、ジョブ情報から評価できること。"""
+    """run view can be evaluated from job information even if it returns pullRequests: []."""
     config = AutomationConfig()
 
     pr_data = {
@@ -118,7 +118,7 @@ def test_history_handles_empty_pullRequests_list_gracefully():
     ]
     run_list_result = _cmd_result(True, stdout=json.dumps(run_list_payload), stderr="", returncode=0)
 
-    # pullRequests は空配列
+    # pullRequests is empty array
     jobs_payload = {
         "pullRequests": [],
         "jobs": [

--- a/tests/test_automation_engine.py
+++ b/tests/test_automation_engine.py
@@ -142,7 +142,7 @@ class TestAutomationEngine:
             # Assert
             assert result["repository"] == test_repo_name
             assert result["dry_run"] is True
-            assert result["llm_backend"] == "gemini"  # GeminiClientから推測
+            assert result["llm_backend"] == "gemini"  # Inferred from GeminiClient
             assert result["llm_model"] is not None
             assert len(result["issues_processed"]) == 1
             assert len(result["prs_processed"]) == 1
@@ -525,7 +525,7 @@ class TestAutomationEngine:
         engine = AutomationEngine(mock_github_client)
         test_data = {"test": "data"}
 
-        # Execute - repo_name が指定されていない場合は従来の reports/ を使用
+        # Execute - use traditional reports/ if repo_name is not specified
         engine._save_report(test_data, "test_report")
 
         # Assert
@@ -556,7 +556,7 @@ class TestAutomationEngine:
         engine = AutomationEngine(mock_github_client)
         test_data = {"test": "data"}
 
-        # Execute - repo_name が指定されている場合は ~/.auto-coder/{repository}/ を使用
+        # Execute - use ~/.auto-coder/{repository}/ if repo_name is specified
         engine._save_report(test_data, "test_report", repo_name)
 
         # Assert

--- a/tests/test_extract_error_context.py
+++ b/tests/test_extract_error_context.py
@@ -1,4 +1,4 @@
-"""_extract_error_context関数のテスト"""
+_extract_error_context function test
 
 import pytest
 
@@ -6,8 +6,8 @@ from src.auto_coder.util.github_action import _extract_error_context
 
 
 def test_extract_error_context_with_playwright_error():
-    """Playwrightのエラーログから十分なコンテキストを抽出できることを確認"""
-    # 実際のPlaywrightエラーログに似たサンプル
+    """Verify that sufficient context can be extracted from Playwright error logs"""
+    # Sample similar to actual Playwright error logs
     log_content = """
 2025-10-27T03:25:50.0000000Z Running tests...
 2025-10-27T03:25:51.0000000Z 
@@ -38,24 +38,24 @@ def test_extract_error_context_with_playwright_error():
 
     result = _extract_error_context(log_content)
 
-    # エラーメッセージが含まれていることを確認
+    # Verify that error message is included
     assert "Error: expect(received).toContain(expected)" in result
     assert "Expected substring:" in result
     assert "Received string:" in result
     assert "fmt-url-label-links-a391b6c2.spec.ts" in result
 
-    # エラーの前後のコンテキストが含まれていることを確認
+    # Verify that context before and after error is included
     assert "URL label links" in result
     assert "expect(firstItemHtml).toContain" in result
 
-    # 行数が適切であることを確認（エラー行の前後10行を含む）
+    # Verify that line count is appropriate (includes 10 lines before and after error line)
     result_lines = result.split("\n")
-    assert len(result_lines) >= 20  # 最低でもエラー行の前後10行
-    assert len(result_lines) <= 500  # 最大500行
+    assert len(result_lines) >= 20  # At least 10 lines before and after error line
+    assert len(result_lines) <= 500  # Maximum 500 lines
 
 
 def test_extract_error_context_with_multiple_errors():
-    """複数のエラーがある場合に全てのエラーコンテキストを抽出できることを確認"""
+    """Verify that all error contexts can be extracted when there are multiple errors"""
     log_content = (
         """
 2025-10-27T03:25:50.0000000Z Running tests...
@@ -84,13 +84,13 @@ def test_extract_error_context_with_multiple_errors():
 
     result = _extract_error_context(log_content)
 
-    # 両方のエラーが含まれていることを確認
+    # Verify that both errors are included
     assert "Test 1 failed" in result
     assert "Test 2 failed" in result
     assert "test1.spec.ts" in result
     assert "test2.spec.ts" in result
 
-    # 両方のエラーの詳細が含まれていることを確認
+    # Verify that details of both errors are included
     assert "Expected: true" in result
     assert "Received: false" in result
     assert 'Expected substring: "hello"' in result
@@ -98,15 +98,15 @@ def test_extract_error_context_with_multiple_errors():
 
 
 def test_extract_error_context_with_long_log():
-    """長いログから重要な部分のみを抽出できることを確認"""
-    # 1000行のログを生成（最初の100行、エラー部分、最後の100行）
+    """Verify that only important parts are extracted from long logs"""
+    # Generate 1000 lines log (first 100 lines, error part, last 100 lines)
     log_lines = []
 
-    # 最初の100行（エラーなし）
+    # First 100 lines (no error)
     for i in range(100):
         log_lines.append(f"2025-10-27T03:25:{i:02d}.0000000Z   Setup line {i}")
 
-    # エラー部分
+    # Error part
     log_lines.extend(
         [
             "2025-10-27T03:26:00.0000000Z   1) [core] › e2e/core/critical-test.spec.ts:50:5 › Critical Test",
@@ -120,11 +120,11 @@ def test_extract_error_context_with_long_log():
         ]
     )
 
-    # 中間の700行（エラーなし）
+    # Middle 700 lines (no error)
     for i in range(700):
         log_lines.append(f"2025-10-27T03:27:{i%60:02d}.0000000Z   Middle line {i}")
 
-    # 最後の100行（エラーなし）
+    # Last 100 lines (no error)
     for i in range(100):
         log_lines.append(f"2025-10-27T03:28:{i:02d}.0000000Z   Cleanup line {i}")
 
@@ -132,37 +132,37 @@ def test_extract_error_context_with_long_log():
 
     result = _extract_error_context(log_content, max_lines=500)
 
-    # エラー部分が含まれていることを確認
+    # Verify that error part is included
     assert "Critical failure" in result
     assert "critical-test.spec.ts" in result
     assert 'Expected substring: "important data"' in result
     assert 'Received string: "wrong data"' in result
 
-    # 結果が最大行数以下であることを確認
+    # Verify that result is within max line count
     result_lines = result.split("\n")
     assert len(result_lines) <= 500
 
-    # エラーの前後のコンテキストが含まれていることを確認
+    # Verify that context before and after error is included
     assert "Critical Test" in result
 
 
 def test_extract_error_context_no_errors():
-    """エラーがない場合は最初の部分を返すことを確認"""
+    """Verify that first part is returned when there is no error"""
     log_content = "\n".join([f"2025-10-27T03:25:{i:02d}.0000000Z   Test line {i}" for i in range(600)])
 
     result = _extract_error_context(log_content, max_lines=500)
 
-    # 最大行数以下であることを確認
+    # Verify it is within max line count
     result_lines = result.split("\n")
     assert len(result_lines) <= 500
 
-    # 最初の部分が含まれていることを確認
+    # Verify that first part is included
     assert "Test line 0" in result
     assert "Test line 1" in result
 
 
 def test_extract_error_context_empty_log():
-    """空のログを処理できることを確認"""
+    """Verify that empty log can be processed"""
     result = _extract_error_context("")
     assert result == ""
 
@@ -171,7 +171,7 @@ def test_extract_error_context_empty_log():
 
 
 def test_extract_error_context_preserves_important_context():
-    """エラーの重要なコンテキストが保持されることを確認"""
+    """Verify that important context of error is preserved"""
     log_content = """
 2025-10-27T03:25:50.0000000Z Test setup started
 2025-10-27T03:25:51.0000000Z Navigating to page
@@ -193,14 +193,14 @@ def test_extract_error_context_preserves_important_context():
 
     result = _extract_error_context(log_content)
 
-    # エラーメッセージとその前後のコンテキストが含まれていることを確認
+    # Verify that error message and context before/after error are included
     assert "Button click test" in result
     assert "Error: expect(received).toContain(expected)" in result
     assert 'Expected substring: "Success message"' in result
     assert 'Received string: "Error: Network timeout"' in result
 
-    # エラーの前のセットアップ情報も含まれていることを確認（前10行）
+    # Verify that setup information before error is included (first 10 lines)
     assert "Waiting for response" in result or "Clicking button" in result
 
-    # エラーの後の情報も含まれていることを確認（後10行）
+    # Verify that information after error is included (last 10 lines)
     assert "button-click.spec.ts:30:31" in result

--- a/tests/test_git_commit_history_actions.py
+++ b/tests/test_git_commit_history_actions.py
@@ -53,7 +53,7 @@ jkl3456 Refactor code"""
         mock_git_result.stdout = mock_git_log
         mock_git_result.stderr = ""
 
-        # Setup mock for gh run list: 呼び出し順で各コミット相当の結果を返す
+        # Setup mock for gh run list: return results equivalent to each commit in call order
         list_call = {"i": 0}
 
         def run_command_side_effect(cmd, **kwargs):

--- a/tests/test_graphrag_mcp_fork.py
+++ b/tests/test_graphrag_mcp_fork.py
@@ -182,7 +182,7 @@ def test_fork_info_in_bundled_mcp():
             assert fork_info.exists(), "FORK_INFO.md should exist in bundled MCP server"
             content = fork_info.read_text()
             assert "rileylemm/graphrag_mcp" in content
-            assert "Fork" in content or "fork" in content or "フォーク" in content
+            assert "Fork" in content or "fork" in content or "fork" in content
         else:
             pytest.skip("Bundled MCP server not found (development mode)")
     except ImportError:

--- a/tests/test_real_github_actions_log_extraction.py
+++ b/tests/test_real_github_actions_log_extraction.py
@@ -1,4 +1,4 @@
-"""実際のGitHub Actionsログを使用した統合テスト"""
+Integration tests using actual GitHub Actions logs
 
 import io
 import json
@@ -11,8 +11,8 @@ from src.auto_coder.util.github_action import _extract_error_context, get_github
 
 
 def test_extract_error_context_with_realistic_playwright_log():
-    """実際のPlaywrightログに近い形式でエラーコンテキストを抽出できることを確認"""
-    # 実際のPlaywrightエラーログに非常に近いサンプル
+    """Verify that error context can be extracted in format close to actual Playwright logs"""
+    # Sample very close to actual Playwright error logs
     realistic_log = """2025-10-27T03:25:34.7924026Z Current runner version: '2.327.1'
 2025-10-27T03:25:34.7930495Z Runner name: 'runner-1'
 2025-10-27T03:25:34.7931234Z Machine name: 'test-machine'
@@ -100,41 +100,41 @@ def test_extract_error_context_with_realistic_playwright_log():
 
     result = _extract_error_context(realistic_log)
 
-    # 重要なエラー情報が含まれていることを確認
+    # Verify that important error information is included
     assert "Error: expect(received).toContain(expected)" in result
     assert 'Expected substring: "<a href=\\"https://example.com\\""' in result or 'Expected substring: "<a href="https://example.com"' in result
     assert 'Received string:    "test-page-1755122947471Visit https:/example.comSecond item<!---->"' in result
     assert "fmt-url-label-links-a391b6c2.spec.ts" in result
     assert "URL label links" in result
 
-    # エラーの前後のコンテキストが含まれていることを確認
+    # Verify that context before and after error is included
     assert "expect(firstItemHtml).toContain" in result
     assert "at /tmp/runner/work/outliner/outliner/client/e2e/core/fmt-url-label-links-a391b6c2.spec.ts:49:31" in result
 
-    # テストサマリが含まれていることを確認
+    # Verify that test summary is included
     assert "1 failed" in result or "147 passed" in result
 
-    # 結果が適切な長さであることを確認
+    # Verify that result is appropriate length
     result_lines = result.split("\n")
-    assert len(result_lines) >= 20  # 最低でもエラー行の前後10行
+    assert len(result_lines) >= 20  # At least 10 lines before and after error line
     assert len(result_lines) <= 500  # 最大500行
 
-    # 不要なセットアップ情報が除外されていることを確認（または最小限であること）
-    # セットアップ情報が含まれていても、エラー部分が優先されていることを確認
+    # Verify that unnecessary setup information is excluded (or minimal)
+    # Even if setup information is included, verify that error part is prioritized
     error_line_index = None
     for i, line in enumerate(result_lines):
         if "Error: expect(received).toContain(expected)" in line:
             error_line_index = i
             break
 
-    assert error_line_index is not None, "エラー行が見つかりません"
+    assert error_line_index is not None, "Error line not found"
 
 
 def test_get_github_actions_logs_from_url_with_realistic_zip():
-    """実際のGitHub Actions ZIPログに近い形式で処理できることを確認"""
+    """Verify that processing can be done in format close to actual GitHub Actions ZIP logs"""
     url = "https://github.com/kitamura-tetsuo/outliner/actions/runs/18828609259/job/53715705095"
 
-    # 実際のログに近いZIPファイルを作成
+    # Create ZIP file close to actual logs
     realistic_step_log = """2025-10-27T03:26:08.0000000Z
 2025-10-27T03:26:09.0000000Z > outliner@1.0.0 test
 2025-10-27T03:26:10.0000000Z > playwright test
@@ -183,7 +183,7 @@ def test_get_github_actions_logs_from_url_with_realistic_zip():
             }
             return Mock(returncode=0, stdout=json.dumps(jobs_obj).encode(), stderr=b"")
 
-        # ジョブ詳細（ステップ情報）
+        # Job details (step information)
         if cmd[:2] == ["gh", "api"] and "actions/jobs/53715705095" in cmd[2] and not cmd[2].endswith("/logs"):
             job_obj = {
                 "id": 53715705095,
@@ -233,7 +233,7 @@ def test_get_github_actions_logs_from_url_with_realistic_zip():
         return Mock(returncode=1, stdout=b"", stderr=b"unknown")
 
     def fake_cmd_run(cmd, capture_output=True, text=False, timeout=60, cwd=None, check_success=True):
-        # この関数は使用されないはずだが、念のため定義
+        # This function should not be used, but defined just in case
         from src.auto_coder.utils import CommandResult
 
         return CommandResult(success=False, returncode=1, stdout="", stderr="not used")
@@ -245,20 +245,20 @@ def test_get_github_actions_logs_from_url_with_realistic_zip():
         ):
             result = get_github_actions_logs_from_url(url)
 
-    # ジョブ情報が含まれていることを確認
+    # Verify that job information is included
     assert "53715705095" in result
 
-    # エラー情報が含まれていることを確認
+    # Verify that error information is included
     assert "Error: expect(received).toContain(expected)" in result
     assert "fmt-url-label-links-a391b6c2.spec.ts" in result
     assert "Expected substring:" in result
     assert "Received string:" in result
 
-    # 成功したステップは除外されていることを確認
-    assert "Set up job" not in result  # 成功したステップは除外されるべき
-    assert "Checking out code" not in result  # 成功したステップは除外されるべき
-    assert "Installing dependencies" not in result  # 成功したステップは除外されるべき
+    # Verify that successful steps are excluded
+    assert "Set up job" not in result  # Successful steps should be excluded
+    assert "Checking out code" not in result  # Successful steps should be excluded
+    assert "Installing dependencies" not in result  # Successful steps should be excluded
 
-    # テストサマリが含まれていることを確認
+    # Verify that test summary is included
     assert "1 failed" in result
     assert "147 passed" in result

--- a/tests/test_utils_change_fraction.py
+++ b/tests/test_utils_change_fraction.py
@@ -11,11 +11,11 @@ def test_change_fraction_ignores_large_prefix_when_last_20_lines_identical():
     s_new = f"{prefix_new}\n{tail}"
 
     frac = change_fraction(s_old, s_new)
-    assert frac == 0.0  # tail-only比較なので先頭差分は無視される
+    assert frac == 0.0  # tail-only comparison, so prefix differences are ignored
 
 
 def test_change_fraction_ignores_large_prefix_when_last_1000_chars_identical():
-    # 長い1行文字列: 先頭側は異なるが末尾1000文字は同一
+    # Long single-line string: prefix differs but last 1000 characters are identical
     common_tail = "x" * 1000
     s_old = ("A" * 5000) + common_tail
     s_new = ("B" * 5000) + common_tail
@@ -25,10 +25,10 @@ def test_change_fraction_ignores_large_prefix_when_last_1000_chars_identical():
 
 
 def test_change_fraction_detects_tail_difference():
-    # 同一の大部分 + 末尾20行のうち数行が異なる
+    # Mostly identical + a few of last 20 lines differ
     shared_prefix = "\n".join([f"line-{i}" for i in range(200)])
     tail_old = "\n".join([f"end-{i}" for i in range(20)])
-    tail_new = "\n".join([f"end-{i if i < 15 else i+1}" for i in range(20)])  # 末尾側に差分
+    tail_new = "\n".join([f"end-{i if i < 15 else i+1}" for i in range(20)])  # Difference on tail side
 
     s_old = f"{shared_prefix}\n{tail_old}"
     s_new = f"{shared_prefix}\n{tail_new}"

--- a/tests/test_utils_extract_first_failed_test.py
+++ b/tests/test_utils_extract_first_failed_test.py
@@ -58,7 +58,7 @@ def test_extract_from_playwright_spec(monkeypatch):
 
 
 def test_extract_playwright_candidate_returned_even_if_not_exists():
-    # ANSIカラーや存在しないパスでも候補として返せること
+    # Can return as candidate even with ANSI color or non-existent path
     stdout = "\x1b[31m  ✘    1 [basic] › e2e/basic/00-foo-bar.spec.ts:15:5 › title \x1b[39m\n" "\n  1) [basic] › e2e/basic/00-foo-bar.spec.ts:15:5 › title \n\n"
     stderr = ""
 
@@ -67,7 +67,7 @@ def test_extract_playwright_candidate_returned_even_if_not_exists():
 
 
 def test_extract_playwright_from_sample_full_output_excerpt():
-    # ユーザー提供のフォーマットに近い抜粋（ANSIカラーや記号・日本語含む）
+    # Excerpt close to user-provided format (including ANSI colors, symbols, and Japanese)
     stdout = (
         "TestHelper: UserManager found, attempting authentication\n"
         "  ✘    1 [basic] › e2e/basic/00-tst-outliner-visible-after-prepare-0f1a2b3c.spec.ts:15:5 › 見出し\n"
@@ -81,7 +81,7 @@ def test_extract_playwright_from_sample_full_output_excerpt():
 
 
 def test_playwright_prefers_fail_over_pass_when_both_present():
-    # 先に成功(\u2713)行があり、その後に失敗(\u2718)行が出るケースでも、失敗側を返す
+    # Return failing side even when success line comes first followed by fail line
     stdout = "  \u2713    1 [basic] \u203a e2e/basic/pass-example.spec.ts:10:5 \u203a ok \n" "  \u2718   22 [new] \u203a e2e/new/fail-example.spec.ts:20:5 \u203a ng \n" "\n  1) [new] \u203a e2e/new/fail-example.spec.ts:20:5 \u203a ng \n"
     stderr = ""
     path = extract_first_failed_test(stdout, stderr)
@@ -128,7 +128,7 @@ def test_vitest_fail_line_extracts_test_ts(monkeypatch):
 
 
 def test_vitest_success_playwright_fail_should_detect_playwright(monkeypatch):
-    """vitestが成功してplaywrightが失敗した場合、playwrightの失敗を検出すること"""
+    """When vitest succeeds and playwright fails, detect playwright's failure"""
     stdout = textwrap.dedent(
         """
         ✓ src/tests/unit/foo.test.ts (5 tests) 125ms
@@ -161,7 +161,7 @@ def test_vitest_success_playwright_fail_should_detect_playwright(monkeypatch):
 
 
 def test_playwright_success_vitest_fail_should_detect_vitest(monkeypatch):
-    """playwrightが成功してvitestが失敗した場合、vitestの失敗を検出すること"""
+    """When playwright succeeds and vitest fails, detect vitest's failure"""
     stdout = textwrap.dedent(
         """
         Running Playwright tests...
@@ -192,7 +192,7 @@ def test_playwright_success_vitest_fail_should_detect_vitest(monkeypatch):
 
 
 def test_pytest_success_playwright_fail_should_detect_playwright(monkeypatch):
-    """pytestが成功してplaywrightが失敗した場合、playwrightの失敗を検出すること"""
+    """When pytest succeeds and playwright fails, detect playwright's failure"""
     stdout = textwrap.dedent(
         """
         ============================= test session starts ==============================

--- a/utils/github-sub-issue/src/github_sub_issue/cli.py
+++ b/utils/github-sub-issue/src/github_sub_issue/cli.py
@@ -64,9 +64,9 @@ def create(
     label: tuple[str, ...],
     assignee: tuple[str, ...],
 ) -> None:
-    """新しい sub-issue を作成.
+    """Create a new sub-issue.
 
-    親 issue に紐付けられた新しい issue を作成します。
+    Creates a new issue linked to a parent issue.
     """
     try:
         api = GitHubSubIssueAPI(repo=ctx.obj["repo"])
@@ -139,7 +139,7 @@ def remove(ctx: click.Context, parent: str, sub_issues: tuple[str, ...], force: 
     """
     try:
         if not force:
-            click.echo(f"⚠️  {len(sub_issues)} sub-issue(s) を削除しようとしています:")
+            click.echo(f"⚠️  {len(sub_issues)} sub-issue(s) will be deleted:")
             for si in sub_issues:
                 click.echo(f"   - {si}")
             

--- a/utils/github-sub-issue/src/github_sub_issue/github_api.py
+++ b/utils/github-sub-issue/src/github_sub_issue/github_api.py
@@ -99,7 +99,7 @@ class GitHubSubIssueAPI:
         Args:
             parent_ref: 親 issue の参照 (番号または URL)
             sub_issue_ref: sub-issue の参照 (番号または URL)
-            replace_parent: 既存の親を置き換えるかどうか
+            replace_parent: Whether to replace existing parent
 
         Returns:
             API レスポンス
@@ -263,7 +263,7 @@ class GitHubSubIssueAPI:
         labels: Optional[List[str]] = None,
         assignees: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
-        """新しい sub-issue を作成.
+        """Create a new sub-issue.
 
         Args:
             parent_ref: 親 issue の参照 (番号または URL)

--- a/utils/github-sub-issue/src/github_sub_issue/logger_config.py
+++ b/utils/github-sub-issue/src/github_sub_issue/logger_config.py
@@ -9,7 +9,7 @@ def setup_logger(verbose: bool = False) -> None:
     """ロガーを設定する.
 
     Args:
-        verbose: 詳細ログを有効にするかどうか
+        verbose: Whether to enable verbose logging
     """
     # デフォルトのハンドラーを削除
     logger.remove()

--- a/utils/github-sub-issue/tests/test_cli.py
+++ b/utils/github-sub-issue/tests/test_cli.py
@@ -145,7 +145,7 @@ class TestCLI:
 
     @patch("gh_sub_issue.cli.GitHubSubIssueAPI")
     def test_list_command_empty(self, mock_api_class: MagicMock) -> None:
-        """list コマンドで sub-issue がない場合の動作を確認."""
+        """Verify behavior when list command has no sub-issues."""
         mock_api = MagicMock()
         mock_api.list_sub_issues.return_value = []
         mock_api_class.return_value = mock_api

--- a/utils/github-sub-issue/tests/test_github_api.py
+++ b/utils/github-sub-issue/tests/test_github_api.py
@@ -176,7 +176,7 @@ class TestGitHubSubIssueAPI:
 
     @patch("subprocess.run")
     def test_create_sub_issue(self, mock_run: MagicMock) -> None:
-        """新しい sub-issue を作成できることを確認."""
+        """Verify that a new sub-issue can be created."""
         mock_run.side_effect = [
             # gh issue create
             MagicMock(stdout="https://github.com/owner/repo/issues/789\n", returncode=0),


### PR DESCRIPTION
Closes #160

Translated all Japanese comments, messages, and variable names in test files to improve code readability and maintain consistency with the project's English-only standard. The translation covers 20+ test files including pytest configuration, core tests, action history tests, and integration tests. This ensures all test code is accessible to the international developer community.