### PR TITLE
fix: Update LLM backend branch naming to issue-xx pattern

### DIFF
--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -574,7 +574,7 @@ def _force_checkout_pr_manually(repo_name: str, pr_data: Dict[str, Any], config:
 
     try:
         # Get PR branch information
-        branch_name = pr_data.get("head", {}).get("ref", f"pr-{pr_number}")
+        branch_name = pr_data.get("head", {}).get("ref", f"issue-{pr_number}")
 
         log_action(f"Attempting manual checkout of branch '{branch_name}' for PR #{pr_number}")
 


### PR DESCRIPTION
Closes #162

Fixed incorrect branch naming in pr_processor.py fallback logic. Changed the branch creation pattern from `pr-{number}` to `issue-{number}` to align with expected naming conventions. This resolves the root cause of unexpected `pr-xx` branch creation reported in the issue.