### PR TITLE
docs: Translate Japanese in .mypy.ini configuration comments (Part 5)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,23 +1,23 @@
 [mypy]
 python_version = 3.11
-# src レイアウトに合わせた解決パス
+# Resolution path aligned with src layout
 mypy_path = src
-# pre-commit の pass_filenames との互換性を 위해 files を削除
-# 個別ファイルの mypy 実行では passed files が使用される
-# exclude でテストファイルや不要ファイルを除外
+# Remove files for compatibility with pre-commit's pass_filenames
+# Use passed files for individual file mypy execution
+# Exclude test files and unnecessary files with exclude
 exclude = tests/|.*\.py\.backup|build/|dist/|\.eggs/|\.mypy_cache/|\.tox/|\.venv/|graph_builder/|mcp_servers/
-# src をパッケージとして扱う前提の解決の曖昧さ回避
+# Avoid ambiguity in resolution assuming src is a package
 namespace_packages = true
 explicit_package_bases = true
 
-# 出力の見やすさ
+# Improve output readability
 pretty = true
 show_error_codes = true
 
-# サードパーティ内部まで解析せず、全体チェック継続を優先
+# Don't analyze third-party internals, prioritize overall check continuation
 follow_imports = silent
 
-# 既存の厳格設定は維持
+# Maintain existing strict settings
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True
@@ -37,7 +37,7 @@ ignore_missing_imports = False
 [mypy-tests.*]
 ignore_errors = True
 
-# 型スタブ未整備の代表的な外部ライブラリは欠損を許容
+# Allow missing type stubs for representative external libraries lacking them
 [mypy-github.*]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Closes #192

Translated 9 Japanese comments in .mypy.ini to English while preserving all configuration syntax, file structure, and UTF-8 encoding. The Makefile required no changes as it was already in English. This completes the configuration file translation effort.