### PR TITLE
Update test files to use GitHubClient singleton pattern

### DIFF
--- a/tests/test_e2e_pr_checks_no_checks.py
+++ b/tests/test_e2e_pr_checks_no_checks.py
@@ -11,7 +11,7 @@ from src.auto_coder.github_client import GitHubClient
 class TestPRChecksNoChecks:
     def test_pr_with_no_checks_reports_as_success(self):
         token = os.environ.get("GITHUB_TOKEN", "placeholder-token")
-        github_client = GitHubClient(token)
+        github_client = GitHubClient.get_instance(token)
         engine = AutomationEngine(github_client, None)
         pr_data = {"number": 515}
         result = engine._check_github_actions_status("kitamura-tetsuo/outliner", pr_data)

--- a/tests/test_exclusive_processing_label.py
+++ b/tests/test_exclusive_processing_label.py
@@ -27,7 +27,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token")
+        client = GitHubClient.get_instance("fake-token")
         client.github = mock_github
 
         result = client.try_add_work_in_progress_label("owner/repo", 123)
@@ -52,7 +52,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token")
+        client = GitHubClient.get_instance("fake-token")
         client.github = mock_github
 
         result = client.try_add_work_in_progress_label("owner/repo", 123)
@@ -74,7 +74,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token")
+        client = GitHubClient.get_instance("fake-token")
         client.github = mock_github
 
         client.remove_labels_from_issue("owner/repo", 123, ["@auto-coder"])
@@ -98,7 +98,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token")
+        client = GitHubClient.get_instance("fake-token")
         client.github = mock_github
 
         result = client.has_label("owner/repo", 123, "@auto-coder")
@@ -117,7 +117,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token")
+        client = GitHubClient.get_instance("fake-token")
         client.github = mock_github
 
         result = client.has_label("owner/repo", 123, "@auto-coder")
@@ -133,7 +133,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token", disable_labels=True)
+        client = GitHubClient.get_instance("fake-token", disable_labels=True)
         client.github = mock_github
 
         client.add_labels_to_issue("owner/repo", 123, ["test-label"])
@@ -151,7 +151,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token", disable_labels=True)
+        client = GitHubClient.get_instance("fake-token", disable_labels=True)
         client.github = mock_github
 
         client.remove_labels_from_issue("owner/repo", 123, ["test-label"])
@@ -169,7 +169,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token", disable_labels=True)
+        client = GitHubClient.get_instance("fake-token", disable_labels=True)
         client.github = mock_github
 
         result = client.has_label("owner/repo", 123, "@auto-coder")
@@ -187,7 +187,7 @@ class TestGitHubClientExclusiveLabels:
         mock_repo.get_issue.return_value = mock_issue
         mock_github.get_repo.return_value = mock_repo
 
-        client = GitHubClient("fake-token", disable_labels=True)
+        client = GitHubClient.get_instance("fake-token", disable_labels=True)
         client.github = mock_github
 
         result = client.try_add_work_in_progress_label("owner/repo", 123)

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -17,7 +17,7 @@ class TestGitHubClient:
 
     def test_init(self, mock_github_token):
         """Test GitHubClient initialization."""
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
         assert client.token == mock_github_token
         assert isinstance(client.github, Github)
 
@@ -30,7 +30,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_repository("test/repo")
@@ -47,7 +47,7 @@ class TestGitHubClient:
         mock_github.get_repo.side_effect = GithubException(404, "Not Found")
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute & Assert
         with pytest.raises(GithubException):
@@ -70,7 +70,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_open_issues("test/repo", limit=2)
@@ -95,7 +95,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_open_pull_requests("test/repo", limit=1)
@@ -130,7 +130,7 @@ class TestGitHubClient:
             mock_github.get_repo.return_value = mock_repo
             mock_github_class.return_value = mock_github
 
-            client = GitHubClient(mock_github_token)
+            client = GitHubClient.get_instance(mock_github_token)
 
             # Execute
             result = client.get_open_issues("test/repo")
@@ -164,7 +164,7 @@ class TestGitHubClient:
             mock_github.get_repo.return_value = mock_repo
             mock_github_class.return_value = mock_github
 
-            client = GitHubClient(mock_github_token)
+            client = GitHubClient.get_instance(mock_github_token)
 
             # Execute
             result = client.get_open_pull_requests("test/repo")
@@ -195,7 +195,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Mock get_pr_details to return a simple dict
         with patch.object(client, "get_pr_details") as mock_get_details:
@@ -226,7 +226,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.find_pr_by_head_branch("test/repo", "non-existent-branch")
@@ -244,7 +244,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.find_pr_by_head_branch("test/repo", "feature-branch")
@@ -274,7 +274,7 @@ class TestGitHubClient:
         mock_issue.user = Mock(login="author")
         mock_issue.comments = 5
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_issue_details(mock_issue)
@@ -324,7 +324,7 @@ class TestGitHubClient:
         mock_pr.deletions = 10
         mock_pr.changed_files = 2
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_pr_details(mock_pr)
@@ -390,7 +390,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_pr_details_by_number("test/repo", 123)
@@ -428,7 +428,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_issue_details_by_number("test/repo", 456)
@@ -454,7 +454,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         params = ("test/repo", "New Issue", "Issue body", ["bug"])
@@ -476,7 +476,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         client.add_comment_to_issue("test/repo", 123, "Test comment")
@@ -497,7 +497,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         client.close_issue("test/repo", 123, "Closing comment")
@@ -526,7 +526,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         client.add_labels_to_issue("test/repo", 123, ["jules", "enhancement"])
@@ -560,7 +560,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute - try to add "jules" again and "enhancement"
         client.add_labels_to_issue("test/repo", 123, ["jules", "enhancement"])
@@ -591,7 +591,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.has_linked_pr("test/repo", 123)
@@ -617,7 +617,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.has_linked_pr("test/repo", 123)
@@ -650,7 +650,7 @@ class TestGitHubClient:
             mock_github.get_repo.return_value = mock_repo
             mock_github_class.return_value = mock_github
 
-            client = GitHubClient(mock_github_token)
+            client = GitHubClient.get_instance(mock_github_token)
 
             # Execute
             result = client.has_linked_pr("test/repo", 123)
@@ -668,7 +668,7 @@ class TestGitHubClient:
         mock_github.get_repo.return_value = mock_repo
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.has_linked_pr("test/repo", 123)
@@ -701,7 +701,7 @@ class TestGitHubClient:
         mock_result.stderr = ""
         mock_run.return_value = mock_result
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_linked_prs_via_graphql("test/repo", 123)
@@ -728,7 +728,7 @@ class TestGitHubClient:
         mock_result.stderr = ""
         mock_run.return_value = mock_result
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_linked_prs_via_graphql("test/repo", 123)
@@ -746,7 +746,7 @@ class TestGitHubClient:
         mock_result.stderr = "GraphQL error"
         mock_run.return_value = mock_result
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_linked_prs_via_graphql("test/repo", 123)
@@ -770,7 +770,7 @@ class TestGitHubClient:
         mock_github = Mock()
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.has_linked_pr("test/repo", 123)
@@ -815,7 +815,7 @@ class TestGitHubClient:
         mock_github = Mock()
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_pr_closing_issues("test/repo", 456)
@@ -850,7 +850,7 @@ class TestGitHubClient:
         mock_github = Mock()
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_pr_closing_issues("test/repo", 456)
@@ -872,7 +872,7 @@ class TestGitHubClient:
         mock_github = Mock()
         mock_github_class.return_value = mock_github
 
-        client = GitHubClient(mock_github_token)
+        client = GitHubClient.get_instance(mock_github_token)
 
         # Execute
         result = client.get_pr_closing_issues("test/repo", 456)

--- a/tests/test_github_client_parent_issue.py
+++ b/tests/test_github_client_parent_issue.py
@@ -16,7 +16,7 @@ class TestGitHubClientParentIssue:
     @patch("subprocess.run")
     def test_get_parent_issue_exists(self, mock_subprocess_run):
         """Test get_parent_issue when parent issue exists."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response
         graphql_response = {
@@ -53,7 +53,7 @@ class TestGitHubClientParentIssue:
     @patch("subprocess.run")
     def test_get_parent_issue_no_parent(self, mock_subprocess_run):
         """Test get_parent_issue when issue has no parent."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response with no parent issue
         graphql_response = {
@@ -80,7 +80,7 @@ class TestGitHubClientParentIssue:
         """Test get_parent_issue when GraphQL query fails."""
         import subprocess
 
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock subprocess error
         mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "gh api graphql", stderr="GraphQL error")
@@ -92,7 +92,7 @@ class TestGitHubClientParentIssue:
     @patch("subprocess.run")
     def test_get_parent_issue_closed_parent(self, mock_subprocess_run):
         """Test get_parent_issue when parent issue is closed."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response with closed parent
         graphql_response = {

--- a/tests/test_github_client_sub_issues.py
+++ b/tests/test_github_client_sub_issues.py
@@ -16,7 +16,7 @@ class TestGitHubClientSubIssues:
     @patch("subprocess.run")
     def test_get_open_sub_issues_all_open(self, mock_subprocess_run):
         """Test get_open_sub_issues when all sub-issues are open."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response
         graphql_response = {
@@ -69,7 +69,7 @@ class TestGitHubClientSubIssues:
     @patch("subprocess.run")
     def test_get_open_sub_issues_some_closed(self, mock_subprocess_run):
         """Test get_open_sub_issues when some sub-issues are closed."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response with mixed states
         graphql_response = {
@@ -115,7 +115,7 @@ class TestGitHubClientSubIssues:
     @patch("subprocess.run")
     def test_get_open_sub_issues_all_closed(self, mock_subprocess_run):
         """Test get_open_sub_issues when all sub-issues are closed."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response with all closed
         graphql_response = {
@@ -155,7 +155,7 @@ class TestGitHubClientSubIssues:
     @patch("subprocess.run")
     def test_get_open_sub_issues_no_sub_issues(self, mock_subprocess_run):
         """Test get_open_sub_issues when issue has no sub-issues."""
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock GraphQL response with no sub-issues
         graphql_response = {
@@ -182,7 +182,7 @@ class TestGitHubClientSubIssues:
         """Test get_open_sub_issues when GraphQL query fails."""
         import subprocess
 
-        client = GitHubClient("test_token")
+        client = GitHubClient.get_instance("test_token")
 
         # Mock subprocess error
         mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "gh api graphql", stderr="GraphQL error")


### PR DESCRIPTION
Closes #216

All test files have been updated to use the GitHubClient singleton pattern. This ensures consistent instance usage across tests and improves test reliability by preventing multiple client instantiations. The changes maintain test isolation and proper mock functionality.