### PR TITLE
Enable PR Tests workflow for all branches

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,6 @@ name: PR Tests
 
 'on':
   pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #222

Removed branch restriction in `.github/workflows/pr-tests.yml` to allow the PR Tests workflow to run on pull requests targeting any branch, not just main. This ensures comprehensive testing coverage throughout the development process and catches bugs early, regardless of which branch is being merged.