### PR TITLE
Remove legacy code from client libraries (qwen, auggie, github)

### DIFF
--- a/src/auto_coder/auggie_client.py
+++ b/src/auto_coder/auggie_client.py
@@ -180,12 +180,15 @@ class AuggieClient(LLMClientBase):
             raise AutoCoderUsageLimitError(full_output)
         return full_output
 
-    def _run_gemini_cli(self, prompt: str) -> str:
-        """Compatibility shim for legacy call sites."""
-        return self._run_auggie_cli(prompt)
-
     def _run_llm_cli(self, prompt: str) -> str:
-        """BackendManager entry-point."""
+        """Execute LLM with the given prompt.
+
+        Args:
+            prompt: The prompt to send to the LLM
+
+        Returns:
+            The LLM's response as a string
+        """
         return self._run_auggie_cli(prompt)
 
     def check_mcp_server_configured(self, server_name: str) -> bool:

--- a/src/auto_coder/qwen_client.py
+++ b/src/auto_coder/qwen_client.py
@@ -316,14 +316,15 @@ class QwenClient(LLMClientBase):
 
         return providers
 
-    def _run_gemini_cli(self, prompt: str) -> str:
-        """Temporary alias for backward compatibility.
-        Prefer calling _run_qwen_cli going forward; this delegates to _run_qwen_cli.
-        """
-        return self._run_qwen_cli(prompt)
-
     def _run_llm_cli(self, prompt: str) -> str:
-        """Neutral alias: delegate to _run_qwen_cli (migration helper)."""
+        """Execute LLM with the given prompt.
+
+        Args:
+            prompt: The prompt to send to the LLM
+
+        Returns:
+            The LLM's response as a string
+        """
         return self._run_qwen_cli(prompt)
 
     # ----- Feature suggestion helpers (copy of GeminiClient behavior) -----


### PR DESCRIPTION
Closes #261

Removed backward compatibility aliases and shims from client libraries. Cleaned up temporary compatibility code in qwen_client.py including the _run_gemini_cli() method alias. This simplifies the codebase by removing deprecated functionality.