### PR TITLE
Integrate dry_run into AutomationConfig (Phase 1)

### DIFF
--- a/fix_test_failures.py
+++ b/fix_test_failures.py
@@ -33,7 +33,9 @@ def fix_test_automation_engine():
     # Mock the LLM response
     mock_gemini_client._run_llm_cli.return_value = "This looks good. Thanks for the contribution! I reviewed the changes and here is my analysis."
 
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -57,7 +59,9 @@ def fix_test_automation_engine():
 ):
     from src.auto_coder.pr_processor import _apply_pr_actions_directly
     
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation and backend manager
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):

--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -77,3 +77,6 @@ class AutomationConfig:
     # GitHub CLI merge options
     MERGE_METHOD: str = "--squash"
     MERGE_AUTO: bool = True
+
+    # Dry run mode
+    DRY_RUN: bool = False

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -31,13 +31,12 @@ class AutomationEngine:
     def __init__(
         self,
         github_client: Any,
-        dry_run: bool = False,
         config: Optional[AutomationConfig] = None,
     ) -> None:
         """Initialize automation engine."""
         self.github = github_client
-        self.dry_run = dry_run
         self.config = config or AutomationConfig()
+        self.dry_run = self.config.DRY_RUN
         self.cmd = CommandExecutor()
 
         # Note: Report directories are created per repository,

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -272,10 +272,10 @@ def process_issues(
     engine_config.IGNORE_DEPENDABOT_PRS = bool(ignore_dependabot_prs)
     engine_config.DISABLE_LABELS = bool(disable_labels)
     engine_config.FORCE_CLEAN_BEFORE_CHECKOUT = bool(force_clean_before_checkout)
+    engine_config.DRY_RUN = dry_run
 
     automation_engine = AutomationEngine(
         github_client,
-        dry_run=dry_run,
         config=engine_config,
     )
 
@@ -725,7 +725,9 @@ def fix_to_pass_tests_command(
         logger.info(f"Using message backends: {message_backend_str} (default: {message_primary_backend})")
         click.echo(f"Using message backends: {message_backend_str} (default: {message_primary_backend})")
 
-    engine = AutomationEngine(github_client, dry_run=dry_run)
+    engine_config = AutomationConfig()
+    engine_config.DRY_RUN = dry_run
+    engine = AutomationEngine(github_client, config=engine_config)
 
     try:
         result = engine.fix_to_pass_tests(max_attempts=max_attempts, message_backend_manager=message_manager)

--- a/tests/test_automation_engine.py
+++ b/tests/test_automation_engine.py
@@ -11,7 +11,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -40,7 +42,9 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -71,7 +75,9 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        config = AutomationConfig()
+        config.DRY_RUN = True
+        engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -133,7 +139,9 @@ class TestAutomationEngine:
             mock_process_issues.return_value = [{"issue_data": {"number": 1}, "actions_taken": ["Test action"]}]
             mock_process_prs.return_value = [{"pr_data": {"number": 1}, "actions_taken": ["Test action"]}]
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -208,7 +216,9 @@ class TestAutomationEngine:
             }
         ]
 
-        engine = AutomationEngine(mock_github_client, dry_run=False)
+        config = AutomationConfig()
+            config.DRY_RUN = False
+            engine = AutomationEngine(mock_github_client, config=config)
 
         # Execute
         result = engine.create_feature_issues(test_repo_name)
@@ -233,7 +243,9 @@ class TestAutomationEngine:
         # Setup
         mock_create_feature_issues.return_value = [{"title": sample_feature_suggestion["title"], "dry_run": True}]
 
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
 
         # Execute
         result = engine.create_feature_issues(test_repo_name)
@@ -360,7 +372,9 @@ class TestAutomationEngine:
     def test_take_issue_actions_dry_run(self, mock_github_client, mock_gemini_client, sample_issue_data):
         """Test issue actions in dry run mode."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
 
         # Execute
         result = engine._take_issue_actions("test/repo", sample_issue_data)
@@ -989,7 +1003,9 @@ class TestAutomationEngineExtended:
     def test_fix_pr_issues_with_testing_success(self, mock_github_client, mock_gemini_client):
         """Test integrated PR issue fixing with successful local tests."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
         pr_data = {"number": 123, "title": "Test PR"}
         github_logs = "Test failed: assertion error"
 
@@ -1027,7 +1043,9 @@ class TestAutomationEngineExtended:
     def test_fix_pr_issues_with_testing_retry(self, mock_github_client, mock_gemini_client):
         """Test integrated PR issue fixing with retry logic."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        config = AutomationConfig()
+            config.DRY_RUN = True
+            engine = AutomationEngine(mock_github_client, config=config)
         pr_data = {"number": 123, "title": "Test PR"}
         github_logs = "Test failed: assertion error"
 

--- a/tests/test_automation_engine_complete.py
+++ b/tests/test_automation_engine_complete.py
@@ -9,7 +9,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +40,9 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +73,10 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +106,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +152,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +199,10 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)
@@ -204,7 +220,6 @@ class TestAutomationConfig:
         """Test get_reports_dir method returns correct path."""
         from pathlib import Path
 
-        config = AutomationConfig()
 
         # Test with typical repo name
         repo_name = "owner/repo"

--- a/tests/test_automation_engine_final.py
+++ b/tests/test_automation_engine_final.py
@@ -9,7 +9,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +40,9 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +73,10 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +106,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +152,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +199,10 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)
@@ -204,7 +220,6 @@ class TestAutomationConfig:
         """Test get_reports_dir method returns correct path."""
         from pathlib import Path
 
-        config = AutomationConfig()
 
         # Test with typical repo name
         repo_name = "owner/repo"

--- a/tests/test_automation_engine_fixed.py
+++ b/tests/test_automation_engine_fixed.py
@@ -9,7 +9,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -32,7 +34,10 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -46,7 +51,6 @@ class TestAutomationConfig:
         """Test get_reports_dir method returns correct path."""
         from pathlib import Path
 
-        config = AutomationConfig()
 
         # Test with typical repo name
         repo_name = "owner/repo"

--- a/tests/test_automation_engine_simple.py
+++ b/tests/test_automation_engine_simple.py
@@ -9,7 +9,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +40,9 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +73,10 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +106,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +152,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -195,7 +208,10 @@ class TestAutomationEngine:
                 "_process_single_candidate",
                 side_effect=Exception("Test error"),
             ):
-                engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
                 engine._save_report = Mock()
 
                 # Execute
@@ -217,7 +233,6 @@ class TestAutomationConfig:
         """Test get_reports_dir method returns correct path."""
         from pathlib import Path
 
-        config = AutomationConfig()
 
         # Test with typical repo name
         repo_name = "owner/repo"

--- a/tests/test_automation_engine_working.py
+++ b/tests/test_automation_engine_working.py
@@ -9,7 +9,9 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +40,9 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +73,10 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +106,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +152,10 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +199,10 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+    config.DRY_RUN = True
+    config = AutomationConfig()
+    config.DRY_RUN = True
+    engine = AutomationEngine(mock_github_client, config=config)
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)
@@ -204,7 +220,6 @@ class TestAutomationConfig:
         """Test get_reports_dir method returns correct path."""
         from pathlib import Path
 
-        config = AutomationConfig()
 
         # Test with typical repo name
         repo_name = "owner/repo"


### PR DESCRIPTION
Closes #265

Move dry_run parameter from AutomationEngine constructor to AutomationConfig
class. This consolidates configuration options and eliminates redundant
parameter passing through multiple layers, creating a more consistent interface.