### PR TITLE
Integrate dry_run into AutomationConfig (Phase 1)

### DIFF
--- a/fix_test_failures.py
+++ b/fix_test_failures.py
@@ -5,7 +5,7 @@ Script to fix test failures systematically after refactoring.
 
 import re
 
-def fix_test_automation_engine():
+def fix_test_automation_engine() -> None:
     """Fix test_automation_engine.py test failures."""
     
     # Read the current file
@@ -33,7 +33,7 @@ def fix_test_automation_engine():
     # Mock the LLM response
     mock_gemini_client._run_llm_cli.return_value = "This looks good. Thanks for the contribution! I reviewed the changes and here is my analysis."
 
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -57,7 +57,7 @@ def fix_test_automation_engine():
 ):
     from src.auto_coder.pr_processor import _apply_pr_actions_directly
     
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation and backend manager
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -116,7 +116,7 @@ def fix_test_automation_engine():
     
     print("Fixed test_automation_engine.py")
 
-def fix_exclusive_processing_label():
+def fix_exclusive_processing_label() -> None:
     """Fix test_exclusive_processing_label.py test failures."""
     
     # Read the current file
@@ -146,7 +146,7 @@ def fix_exclusive_processing_label():
     
     print("Fixed test_exclusive_processing_label.py")
 
-def fix_issue_processor_skip_sub_issues():
+def fix_issue_processor_skip_sub_issues() -> None:
     """Fix test_issue_processor_skip_sub_issues.py test failures."""
     
     # Read the current file

--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -65,6 +65,10 @@ class AutomationConfig:
     # Default: True (dependency checking enabled)
     CHECK_DEPENDENCIES: bool = True
 
+    # Run automation in dry-run mode without making changes
+    # Default: False (make actual changes)
+    DRY_RUN: bool = False
+
     # Search through commit history for GitHub Actions logs when latest commit doesn't trigger Actions
     # Default: True (search history enabled)
     SEARCH_GITHUB_ACTIONS_HISTORY: bool = True

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -31,13 +31,12 @@ class AutomationEngine:
     def __init__(
         self,
         github_client: Any,
-        dry_run: bool = False,
         config: Optional[AutomationConfig] = None,
     ) -> None:
         """Initialize automation engine."""
         self.github = github_client
-        self.dry_run = dry_run
         self.config = config or AutomationConfig()
+        self.dry_run = self.config.DRY_RUN
         self.cmd = CommandExecutor()
 
         # Note: Report directories are created per repository,
@@ -191,7 +190,7 @@ class AutomationEngine:
                 result["success"] = True
             elif candidate.get("type") == "pr":
                 # PR processing
-                result["actions"] = process_pull_request(self.github, self.config, self.dry_run, repo_name, candidate["data"])
+                result["actions"] = process_pull_request(self.github, self.config, self.config.DRY_RUN, repo_name, candidate["data"])
                 result["success"] = True
         except Exception as e:
             result["error"] = str(e)
@@ -277,7 +276,7 @@ class AutomationEngine:
         return process_single(
             self.github,
             self.config,
-            self.dry_run,
+            self.config.DRY_RUN,
             repo_name,
             target_type,
             number,
@@ -289,7 +288,7 @@ class AutomationEngine:
         return create_feature_issues(
             self.github,
             self.config,
-            self.dry_run,
+            self.config.DRY_RUN,
             repo_name,
         )
 
@@ -308,14 +307,14 @@ class AutomationEngine:
                     fix_to_pass_tests_runner_module.apply_workspace_test_fix = apply_override
                 return fix_to_pass_tests(
                     self.config,
-                    self.dry_run,
+                    self.config.DRY_RUN,
                     max_attempts,
                 )
             finally:
                 fix_to_pass_tests_runner_module.run_local_tests = original_run
                 fix_to_pass_tests_runner_module.apply_workspace_test_fix = original_apply
 
-        return fix_to_pass_tests(self.config, self.dry_run, max_attempts)
+        return fix_to_pass_tests(self.config, self.config.DRY_RUN, max_attempts)
 
     def _get_llm_backend_info(self) -> Dict[str, Optional[str]]:
         """Get LLM backend and model information.
@@ -401,7 +400,7 @@ class AutomationEngine:
             repo_name,
             issue_data,
             self.config,
-            self.dry_run,
+            self.config.DRY_RUN,
             self.github,
         )
 
@@ -413,7 +412,7 @@ class AutomationEngine:
             repo_name,
             issue_data,
             self.config,
-            self.dry_run,
+            self.config.DRY_RUN,
             self.github,
         )
 

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -213,7 +213,7 @@ def process_issues(
         initialize_graphrag(force_reindex=force_reindex)
 
     # Initialize clients
-    github_client = GitHubClient.get_instance(github_token_final, disable_labels=disable_labels)
+    github_client = GitHubClient.get_instance(github_token_final, disable_labels=bool(disable_labels))
     # Use global LLMBackendManager for main backend
     from auto_coder.backend_manager import get_llm_backend_manager
 
@@ -272,10 +272,10 @@ def process_issues(
     engine_config.IGNORE_DEPENDABOT_PRS = bool(ignore_dependabot_prs)
     engine_config.DISABLE_LABELS = bool(disable_labels)
     engine_config.FORCE_CLEAN_BEFORE_CHECKOUT = bool(force_clean_before_checkout)
+    engine_config.DRY_RUN = bool(dry_run)
 
     automation_engine = AutomationEngine(
         github_client,
-        dry_run=dry_run,
         config=engine_config,
     )
 
@@ -513,7 +513,7 @@ def create_feature_issues(
         initialize_graphrag(force_reindex=force_reindex)
 
     # Initialize clients
-    github_client = GitHubClient.get_instance(github_token_final, disable_labels=disable_labels)
+    github_client = GitHubClient.get_instance(github_token_final, disable_labels=bool(disable_labels))
     manager = build_backend_manager(
         selected_backends,
         primary_backend,
@@ -681,7 +681,7 @@ def fix_to_pass_tests_command(
     try:
         from .github_client import GitHubClient as _GH
 
-        github_client = _GH("", disable_labels=disable_labels)
+        github_client = _GH("", disable_labels=bool(disable_labels))
     except Exception:
         # Fallback to a minimal stand-in (never used)
         class _Dummy:
@@ -725,7 +725,11 @@ def fix_to_pass_tests_command(
         logger.info(f"Using message backends: {message_backend_str} (default: {message_primary_backend})")
         click.echo(f"Using message backends: {message_backend_str} (default: {message_primary_backend})")
 
-    engine = AutomationEngine(github_client, dry_run=dry_run)
+    # Configure engine behavior flags
+    engine_config = AutomationConfig()
+    engine_config.DRY_RUN = bool(dry_run)
+
+    engine = AutomationEngine(github_client, config=engine_config)
 
     try:
         result = engine.fix_to_pass_tests(max_attempts=max_attempts, message_backend_manager=message_manager)

--- a/tests/test_automation_engine.py
+++ b/tests/test_automation_engine.py
@@ -11,7 +11,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -40,7 +40,7 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -71,7 +71,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -100,7 +100,7 @@ class TestAutomationEngine:
             }
         ]
 
-        engine = AutomationEngine(mock_github_client, dry_run=False)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=False))
 
         # Execute
         result = engine.create_feature_issues(test_repo_name)
@@ -125,7 +125,7 @@ class TestAutomationEngine:
         # Setup
         mock_create_feature_issues.return_value = [{"title": sample_feature_suggestion["title"], "dry_run": True}]
 
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         # Execute
         result = engine.create_feature_issues(test_repo_name)
@@ -252,7 +252,7 @@ class TestAutomationEngine:
     def test_take_issue_actions_dry_run(self, mock_github_client, mock_gemini_client, sample_issue_data):
         """Test issue actions in dry run mode."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         # Execute
         result = engine._take_issue_actions("test/repo", sample_issue_data)
@@ -881,7 +881,7 @@ class TestAutomationEngineExtended:
     def test_fix_pr_issues_with_testing_success(self, mock_github_client, mock_gemini_client):
         """Test integrated PR issue fixing with successful local tests."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
         pr_data = {"number": 123, "title": "Test PR"}
         github_logs = "Test failed: assertion error"
 
@@ -919,7 +919,7 @@ class TestAutomationEngineExtended:
     def test_fix_pr_issues_with_testing_retry(self, mock_github_client, mock_gemini_client):
         """Test integrated PR issue fixing with retry logic."""
         # Setup
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
         pr_data = {"number": 123, "title": "Test PR"}
         github_logs = "Test failed: assertion error"
 

--- a/tests/test_automation_engine_complete.py
+++ b/tests/test_automation_engine_complete.py
@@ -9,7 +9,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +38,7 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +69,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +99,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +142,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +186,7 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)

--- a/tests/test_automation_engine_final.py
+++ b/tests/test_automation_engine_final.py
@@ -9,7 +9,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +38,7 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +69,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +99,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +142,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +186,7 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)

--- a/tests/test_automation_engine_fixed.py
+++ b/tests/test_automation_engine_fixed.py
@@ -9,7 +9,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -32,7 +32,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True

--- a/tests/test_automation_engine_simple.py
+++ b/tests/test_automation_engine_simple.py
@@ -9,7 +9,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +38,7 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +69,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +99,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +142,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -195,7 +195,7 @@ class TestAutomationEngine:
                 "_process_single_candidate",
                 side_effect=Exception("Test error"),
             ):
-                engine = AutomationEngine(mock_github_client, dry_run=True)
+                engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
                 engine._save_report = Mock()
 
                 # Execute

--- a/tests/test_automation_engine_working.py
+++ b/tests/test_automation_engine_working.py
@@ -9,7 +9,7 @@ from src.auto_coder.utils import CommandExecutor
 
 
 def test_create_pr_prompt_is_action_oriented_no_comments(mock_github_client, mock_gemini_client, sample_pr_data, test_repo_name):
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
     prompt = engine._create_pr_analysis_prompt(test_repo_name, sample_pr_data, pr_diff="diff...")
 
     assert "Do NOT post any comments" in prompt
@@ -38,7 +38,7 @@ def test_apply_pr_actions_directly_does_not_post_comments(mock_github_client, mo
     )
 
     # For dry_run=True, the function should not call LLM but should still function
-    engine = AutomationEngine(mock_github_client, dry_run=True)
+    engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
     # Stub diff generation
     with patch("src.auto_coder.pr_processor._get_pr_diff", return_value="diff..."):
@@ -69,7 +69,7 @@ class TestAutomationEngine:
 
     def test_init(self, mock_github_client, mock_gemini_client, temp_reports_dir):
         """Test AutomationEngine initialization."""
-        engine = AutomationEngine(mock_github_client, dry_run=True)
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
         assert engine.github == mock_github_client
         assert engine.dry_run is True
@@ -99,7 +99,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -142,7 +142,7 @@ class TestAutomationEngine:
             mock_github_client.get_open_issues.return_value = []
             mock_github_client.disable_labels = False
 
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
             engine._save_report = Mock()
 
             # Execute
@@ -186,7 +186,7 @@ class TestAutomationEngine:
             mock_github_client.disable_labels = False
 
             # Test error handling - keep it simple, just verify basic error structure
-            engine = AutomationEngine(mock_github_client, dry_run=True)
+            engine = AutomationEngine(mock_github_client, config=AutomationConfig(DRY_RUN=True))
 
             # Execute without any complex mocking to see if basic error handling works
             result = engine.run(test_repo_name)


### PR DESCRIPTION
Closes #265

Consolidates the dry_run parameter into AutomationConfig by adding a DRY_RUN field and updating AutomationEngine to use config.dry_run instead of a constructor parameter. This creates a unified configuration interface following the existing pattern for other behavior flags.