### PR TITLE
Use fully qualified remote refs (refs/remotes/origin/main) to avoid ambiguous references

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -168,7 +168,8 @@ features:
     - Auto-resume when on a non-main branch with an associated PR/Issue
     - label_management: Removed duplicate LabelManager usage from issue processing; LabelManager is now used only for PR processing to prevent concurrent processing. Added thread reentrancy detection to prevent deadlock scenarios in concurrent contexts. Added PR label wrapper methods (add_labels_to_pr/remove_labels_from_pr/has_label_on_pr). Fixed check-only exception handling in LabelManager to fail-open (returns True on error) and added pre-check to skip when label already exists.
     - git_operations: Enhanced git push failure resolution with LLM fallback that works even when commit message is not available
-    - branch_creation: "New issue branches are always created from origin/<default> (default: origin/main). When create_new=True, base_branch is required; checkout runs 'git fetch origin --prune --tags' and then 'git checkout -B <branch> <resolved-base-ref>' (prefers origin/<base_branch>, falls back to local). Logs explicitly show the resolved base ref used."
+    - branch_creation: "New issue branches are always created from refs/remotes/origin/<default> (default: refs/remotes/origin/main). When create_new=True, base_branch is required; checkout runs 'git fetch origin --prune --tags' and then 'git checkout -B <branch> <resolved-base-ref>' (prefers refs/remotes/origin/<base_branch>, falls back to local). Logs explicitly show the resolved base ref used."
+    - ref_handling: "Use fully qualified remote refs (refs/remotes/origin/<branch>) in Git operations to avoid ambiguous 'origin/<branch>' warnings and failures"
 
   dependency_management:
     - description: Automatic dependency checking for issue processing

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -791,7 +791,7 @@ class TestGitCheckoutBranch:
                 "git",
                 "rev-parse",
                 "--verify",
-                "origin/main",
+                "refs/remotes/origin/main",
             ]
             # Verify checkout command with -B flag and base ref (now at index 6)
             assert mock_cmd.run_command.call_args_list[6][0][0] == [
@@ -799,7 +799,7 @@ class TestGitCheckoutBranch:
                 "checkout",
                 "-B",
                 "new-feature",
-                "origin/main",
+                "refs/remotes/origin/main",
             ]
             # Verify push command (now at index 8)
             assert mock_cmd.run_command.call_args_list[8][0][0] == [
@@ -858,7 +858,7 @@ class TestGitCheckoutBranch:
                 "git",
                 "rev-parse",
                 "--verify",
-                "origin/main",
+                "refs/remotes/origin/main",
             ]
             # Verify checkout command with -B flag and base ref (now at index 4)
             assert mock_cmd.run_command.call_args_list[4][0][0] == [
@@ -866,7 +866,7 @@ class TestGitCheckoutBranch:
                 "checkout",
                 "-B",
                 "new-feature",
-                "origin/main",
+                "refs/remotes/origin/main",
             ]
             # Verify push command (now at index 6)
             assert mock_cmd.run_command.call_args_list[6][0][0] == [
@@ -945,7 +945,7 @@ class TestGitCheckoutBranch:
                 "git",
                 "rev-parse",
                 "--verify",
-                "origin/main",
+                "refs/remotes/origin/main",
             ]
             assert mock_cmd.run_command.call_args_list[4][0][0] == [
                 "git",


### PR DESCRIPTION
Context
- We observed warnings and failures such as:
  - "warning: refname 'origin/main' is ambiguous"
  - "fatal: ambiguous object name: 'origin/main'"
  These occur when short ref names match multiple refs (e.g., a local branch and a remote-tracking branch), causing Git to fail to resolve the target.

Changes
- Prefer fully qualified remote refs (refs/remotes/origin/<branch>) to avoid ambiguity:
  - git checkout branch creation bases now use refs/remotes/origin/<base> when available
  - get_commit_log resolves the base to a fully qualified remote ref and uses it for merge-base
  - migration fallback checkout uses refs/remotes/origin/main
- Tests updated to expect fully qualified remote refs
- Documentation updated (docs/client-features.yaml) to reflect the new policy and behavior

Expected outcome
- Eliminate ambiguous ref errors while creating branches and computing merge-bases
- More robust and explicit Git operations that are insensitive to duplicate or conflicting short ref names

Notes
- No dependency changes
- Behavior for listing remote branches remains unchanged (e.g., outputs like "origin/main")

