### PR TITLE
Fix label manager logging and scope GraphRAG updates in test watcher

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -166,7 +166,7 @@ features:
     - Skips issues when 5+ open issues without sub-issues are present
     - Single-item processing via --only (URL or number)
     - Auto-resume when on a non-main branch with an associated PR/Issue
-    - label_management: Removed duplicate LabelManager usage from issue processing; LabelManager is now used only for PR processing to prevent concurrent processing. Added thread reentrancy detection to prevent deadlock scenarios in concurrent contexts. Added PR label wrapper methods (add_labels_to_pr/remove_labels_from_pr/has_label_on_pr). Fixed check-only exception handling in LabelManager to fail-open (returns True on error) and added pre-check to skip when label already exists.
+    - label_management: Removed duplicate LabelManager usage from issue processing; LabelManager is now used only for PR processing to prevent concurrent processing. Added thread reentrancy detection to prevent deadlock scenarios in concurrent contexts. Added PR label wrapper methods (add_labels_to_pr/remove_labels_from_pr/has_label_on_pr). Fixed check-only exception handling in LabelManager to fail-open (returns True on error) and added pre-check to skip when label already exists. Ensured remove_labels is always called with the correct item_type ("issue" vs "pr") so GitHub logs and API paths stay consistent.
     - git_operations: "Enhanced git commit/push failure resolution: unknown commit errors trigger LLM remediation; after LLM, code retries commit and treats as success when nothing is left to commit. Push fallback via LLM remains and works even without commit message."
     - branch_creation: "New issue branches are always created from refs/remotes/origin/<default> (default: refs/remotes/origin/main). When create_new=True, base_branch is required; checkout runs 'git fetch origin --prune --tags' and then 'git checkout -B <branch> <resolved-base-ref>' (prefers refs/remotes/origin/<base_branch>, falls back to local). Logs explicitly show the resolved base ref used."
     - ref_handling: "Use fully qualified remote refs (refs/remotes/origin/<branch>) in Git operations to avoid ambiguous 'origin/<branch>' warnings and failures"
@@ -209,6 +209,7 @@ features:
     concurrency:
       - "Run-on-change spawns daemon threads for Playwright and GraphRAG update"
       - "GraphRAG retry timers are daemonized"
+      - "GraphRAG index updates in TestWatcherTool are scoped to project_root, keeping pytest flows fast on temporary project trees"
 
   logging:
     library: loguru

--- a/src/auto_coder/label_manager.py
+++ b/src/auto_coder/label_manager.py
@@ -219,7 +219,13 @@ class LabelManager:
             # Remove the label with retry logic
             for attempt in range(self.max_retries):
                 try:
-                    self.github_client.remove_labels(self.repo_name, self.item_number, [self.label_name])
+                    # Respect the item type ("issue" vs "pr") so logs and GitHub API paths are consistent
+                    self.github_client.remove_labels(
+                        self.repo_name,
+                        self.item_number,
+                        [self.label_name],
+                        self.item_type,
+                    )
                     logger.info(f"Removed '{self.label_name}' label from {self.item_type} #{self.item_number}")
                     return
 

--- a/src/auto_coder/mcp_servers/test_watcher/test_watcher_tool.py
+++ b/src/auto_coder/mcp_servers/test_watcher/test_watcher_tool.py
@@ -320,7 +320,7 @@ class TestWatcherTool:
         try:
             from auto_coder.graphrag_index_manager import GraphRAGIndexManager
 
-            manager = GraphRAGIndexManager()
+            manager = GraphRAGIndexManager(repo_path=str(self.project_root))
 
             # Use smart update for better performance
             if hasattr(manager, "smart_update_trigger"):
@@ -378,7 +378,7 @@ class TestWatcherTool:
         try:
             from auto_coder.graphrag_index_manager import GraphRAGIndexManager
 
-            manager = GraphRAGIndexManager()
+            manager = GraphRAGIndexManager(repo_path=str(self.project_root))
             # Use lightweight check to avoid heavy operations during retries
             if hasattr(manager, "lightweight_update_check"):
                 success = manager.lightweight_update_check()

--- a/tests/test_label_manager.py
+++ b/tests/test_label_manager.py
@@ -30,7 +30,7 @@ class TestLabelManager:
             mock_github_client.try_add_labels_to_issue.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
         # Label should be removed after exiting context
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
     def test_label_manager_skips_when_label_already_exists(self):
         mock_github_client = Mock()
@@ -99,7 +99,7 @@ class TestLabelManager:
             pass
 
         # Label should still be removed after exception
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
     def test_label_manager_with_custom_label_name(self):
         """Test that LabelManager works with custom label names."""
@@ -124,7 +124,7 @@ class TestLabelManager:
             mock_github_client.try_add_labels_to_issue.assert_called_once_with("owner/repo", 123, ["custom-label"], "issue")
 
         # Custom label should be removed
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["custom-label"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["custom-label"], "issue")
 
     def test_label_manager_pr_type(self):
         """Test that LabelManager works with PR type."""
@@ -142,7 +142,7 @@ class TestLabelManager:
             mock_github_client.try_add_labels_to_issue.assert_called_once_with("owner/repo", 456, ["@auto-coder"], "pr")
 
         # Label should be removed from PR
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 456, ["@auto-coder"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 456, ["@auto-coder"], "pr")
 
     def test_label_manager_retry_on_add_failure(self):
         """Test that LabelManager retries on label addition failure."""
@@ -239,7 +239,7 @@ class TestLabelManager:
             assert should_process is True
             mock_github_client.try_add_labels_to_issue.assert_called_once()
 
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
     def test_label_manager_network_error_on_label_check(self):
         """Test that LabelManager handles network errors during label check."""
@@ -331,7 +331,7 @@ class TestLabelManager:
             mock_github_client.try_add_labels_to_issue.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
         # Label should be removed
-        mock_github_client.remove_labels.assert_called_once_with("owner/repo", "123", ["@auto-coder"])
+        mock_github_client.remove_labels.assert_called_once_with("owner/repo", "123", ["@auto-coder"], "issue")
 
     def test_label_manager_nested_contexts_different_items(self):
         """Test that nested LabelManager contexts work for different items."""


### PR DESCRIPTION
## Summary

Fixes label manager logging inconsistency between issues and PRs, and scopes GraphRAG index updates in the TestWatcher tool to the configured project root to keep pytest flows fast and reliable.

## Changes

- Updated `LabelManager.__exit__` to always pass the correct `item_type` ("issue" or "pr") to `GitHubClient.remove_labels`, ensuring that GitHub API paths and log messages consistently reflect whether the target is an issue or a PR.
- Extended `tests/test_label_manager.py` expectations so that all `remove_labels` assertions include the `item_type` argument, covering both issue and PR cases.
- Updated `TestWatcherTool._trigger_graphrag_update` and `_retry_graphrag_update` to construct `GraphRAGIndexManager` with `repo_path=str(self.project_root)`, so GraphRAG index operations are scoped to the watcher project root (including pytest `tmp_path` roots) instead of the process CWD.
- Documented these behaviors in `docs/client-features.yaml` under `github_automation.label_management` and `test_watcher.concurrency`, including the fact that GraphRAG index updates in TestWatcherTool are scoped to `project_root`.

## Testing

- `bash scripts/test.sh tests/test_label_manager.py`
- `bash scripts/test.sh tests/test_shared_watcher_e2e.py -vv`
- `bash scripts/test.sh`
