### PR TITLE
🤖

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -138,6 +138,14 @@ cli:
           options:
             - { name: --force, flag: true }
             - { name: --repo-path, type: path }
+        - name: cleanup
+          options:
+            - { name: --dry-run, flag: true }
+            - { name: --retention-days, type: int, default: 7 }
+            - { name: --max-per-repo, type: int, default: 9 }
+            - { name: --repo-path, type: path }
+            - { name: --verbose, flag: true }
+
         - name: setup-mcp
           options:
             - { name: --install-dir, default: "~/graphrag_mcp" }
@@ -195,6 +203,18 @@ features:
     auto_setup: true
     mcp_config_check: true
     index_update: available via CLI
+    snapshot_cleanup:
+      retention_days_default: 7
+      max_snapshots_per_repo_default: 9
+      env_flags:
+        - GRAPHRAG_RETENTION_DAYS
+        - GRAPHRAG_MAX_SNAPSHOTS_PER_REPO
+        - GRAPHRAG_CLEANUP_ON_INIT
+        - GRAPHRAG_CLEANUP_ON_UPDATE
+      cli_command: "auto-coder graphrag cleanup [--dry-run] [--retention-days N] [--max-per-repo M] [--repo-path PATH]"
+      hooks:
+        - initialize_graphrag
+        - GraphRAGIndexManager.update_index
     pytest_fallback: "Under pytest, GraphRAGIndexManager avoids external graph-builder and uses fast Python fallback indexing"
     docker_manager:
       fallback_recovery: true
@@ -246,6 +266,11 @@ env:
   AUTO_CODER_QWEN_CONFIG: Override path to qwen-providers.toml
   AUTO_CODER_CONFIG_DIR: Directory that contains qwen-providers.toml
   AC_DISABLE_PLAYWRIGHT: "If set to 1, TestWatcherTool skips Playwright execution and returns a synthetic report (useful in CI)"
+  GRAPHRAG_RETENTION_DAYS: "Number of days to retain GraphRAG index snapshots before cleanup (default: 7)"
+  GRAPHRAG_MAX_SNAPSHOTS_PER_REPO: "Maximum number of GraphRAG index snapshots to keep per repository (default: 9)"
+  GRAPHRAG_CLEANUP_ON_INIT: "Enable automatic GraphRAG snapshot cleanup during initialize_graphrag (default: 1)"
+  GRAPHRAG_CLEANUP_ON_UPDATE: "Enable automatic GraphRAG snapshot cleanup after each index update (default: 1)"
+
 
 external_dependencies:
   graphrag:

--- a/src/auto_coder/cli_helpers.py
+++ b/src/auto_coder/cli_helpers.py
@@ -100,8 +100,20 @@ def initialize_graphrag(force_reindex: bool = False) -> None:
             click.echo("   2. Check container status: auto-coder graphrag status")
             click.echo("   3. Check Docker logs: docker-compose -f docker-compose.graphrag.yml logs")
             raise click.ClickException("Failed to initialize GraphRAG environment. " "Run 'auto-coder graphrag start' to start containers.")
+
         logger.info("GraphRAG environment ready")
         click.echo("✅ GraphRAG environment ready")
+
+        # Optionally run snapshot cleanup after successful initialization
+        cleanup_raw = os.environ.get("GRAPHRAG_CLEANUP_ON_INIT", "1")
+        cleanup_enabled = cleanup_raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+        if cleanup_enabled:
+            try:
+                logger.info("Running GraphRAG snapshot cleanup after initialization...")
+                graphrag_integration.run_cleanup(dry_run=False)
+            except Exception as cleanup_error:
+                logger.warning(f"GraphRAG cleanup during initialization failed: {cleanup_error}")
     except click.ClickException:
         raise
     except Exception as e:

--- a/src/auto_coder/mcp_servers/graphrag_mcp/.env.example
+++ b/src/auto_coder/mcp_servers/graphrag_mcp/.env.example
@@ -9,4 +9,14 @@ QDRANT_PORT=6333
 QDRANT_COLLECTION=document_chunks
 
 # Embedding Model Configuration (optional)
-MODEL_NAME=all-MiniLM-L6-v2 
+MODEL_NAME=all-MiniLM-L6-v2
+
+# GraphRAG snapshot cleanup configuration (used by auto-coder)
+# Number of days to retain snapshots before they become eligible for deletion (default: 7)
+GRAPHRAG_RETENTION_DAYS=7
+# Maximum number of snapshots to keep per repository (default: 9)
+GRAPHRAG_MAX_SNAPSHOTS_PER_REPO=9
+# Enable automatic cleanup during initialize_graphrag (1=on, 0=off)
+GRAPHRAG_CLEANUP_ON_INIT=1
+# Enable automatic cleanup after each index update (1=on, 0=off)
+GRAPHRAG_CLEANUP_ON_UPDATE=1

--- a/tests/test_graphrag_cleanup.py
+++ b/tests/test_graphrag_cleanup.py
@@ -1,0 +1,125 @@
+"""Tests for GraphRAG snapshot cleanup and CLI wiring."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+from click.testing import CliRunner
+
+from src.auto_coder.cli_commands_graphrag import graphrag_group
+from src.auto_coder.graphrag_index_manager import GraphRAGIndexManager
+
+
+def _make_index_manager(tmp_path: Path) -> GraphRAGIndexManager:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_file = tmp_path / "index_state.json"
+    return GraphRAGIndexManager(repo_path=str(repo), index_state_file=str(state_file))
+
+
+def test_build_repo_key_uses_remote_and_strips_credentials(tmp_path, monkeypatch):
+    manager = _make_index_manager(tmp_path)
+    repo_str = str(manager.repo_path.resolve())
+
+    def fake_run(args, capture_output=False, text=False, timeout=None):
+        class Result:
+            returncode = 0
+            stdout = "https://token123@github.com/example/repo.git\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr("src.auto_coder.graphrag_index_manager.subprocess.run", fake_run)
+
+    key = manager._build_repo_key()
+    assert repo_str in key
+    assert "github.com/example/repo.git" in key
+    assert "token123@" not in key
+
+
+def test_cleanup_snapshots_applies_time_based_policy(tmp_path, monkeypatch):
+    manager = _make_index_manager(tmp_path)
+    repo = manager.repo_path
+    repo_key = manager._build_repo_key()
+    now = datetime.now(timezone.utc)
+
+    snapshots = [
+        {
+            "repo_key": repo_key,
+            "snapshot_id": "old",
+            "indexed_at": (now - timedelta(days=10)).isoformat(),
+            "repo_path": str(repo),
+            "codebase_hash": "h1",
+        },
+        {
+            "repo_key": repo_key,
+            "snapshot_id": "mid",
+            "indexed_at": (now - timedelta(days=5)).isoformat(),
+            "repo_path": str(repo),
+            "codebase_hash": "h2",
+        },
+        {
+            "repo_key": repo_key,
+            "snapshot_id": "new",
+            "indexed_at": now.isoformat(),
+            "repo_path": str(repo),
+            "codebase_hash": "h3",
+        },
+    ]
+    manager._save_index_state({"codebase_hash": "current", "indexed_at": str(repo.resolve()), "snapshots": snapshots})
+
+    deleted: List[str] = []
+
+    def fake_delete(snap):
+        deleted.append(snap.snapshot_id)
+
+    monkeypatch.setattr(manager, "_delete_snapshot_from_stores", fake_delete)
+
+    result = manager.cleanup_snapshots(dry_run=False, retention_days=7, max_snapshots_per_repo=9)
+
+    assert deleted == ["old"]
+    assert {a.snapshot_id for a in result.deleted} == {"old"}
+    state_after = manager._load_index_state()
+    remaining_ids = [s["snapshot_id"] for s in state_after["snapshots"]]
+    assert remaining_ids == ["mid", "new"]
+
+
+def test_graphrag_cleanup_cli_dry_run_works(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_file = repo / ".auto-coder" / "graphrag_index_state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc)
+    state = {
+        "codebase_hash": "h1",
+        "indexed_at": str(repo.resolve()),
+        "snapshots": [
+            {
+                "repo_key": str(repo),
+                "snapshot_id": "s1",
+                "indexed_at": (now - timedelta(days=10)).isoformat(),
+                "repo_path": str(repo),
+                "codebase_hash": "h1",
+            },
+            {
+                "repo_key": str(repo),
+                "snapshot_id": "s2",
+                "indexed_at": now.isoformat(),
+                "repo_path": str(repo),
+                "codebase_hash": "h2",
+            },
+        ],
+    }
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        graphrag_group,
+        ["cleanup", "--dry-run", "--repo-path", str(repo)],
+    )
+
+    assert result.exit_code == 0
+    assert "Dry-run complete" in result.output


### PR DESCRIPTION
Closes #375

Implemented an automatic retention mechanism for GraphRAG MCP snapshots, deleting entries older than 7 days and trimming per-repository history to the latest 9 items. Wired cleanup into GraphRAG initialization, post-index update hooks, and a new CLI command so maintenance can run automatically or on demand, and added tests to cover the new behavior. This prevents unbounded growth of local snapshot data while always preserving at least one recent snapshot per repository.