### PR TITLE
Implement breaking-change label handling for issue processing

### DIFF
--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -13,6 +13,35 @@ class AutomationConfig:
     REPORTS_DIR: str = "reports"
     TEST_SCRIPT_PATH: str = "scripts/test.sh"
 
+    # Label prompt mappings for label-based issue/PR processing
+    # Maps labels to prompt template keys
+    label_prompt_mappings: Dict[str, str] = field(
+        default_factory=lambda: {
+            # Breaking-change labels (highest priority)
+            "breaking-change": "issue.breaking_change",
+            "breaking": "issue.breaking_change",
+            "api-change": "issue.breaking_change",
+            "deprecation": "issue.breaking_change",
+            "version-major": "issue.breaking_change",
+        }
+    )
+
+    # Label priorities (highest priority first)
+    # Breaking-change has highest priority, above urgent
+    label_priorities: List[str] = field(
+        default_factory=lambda: [
+            "breaking-change",
+            "breaking",
+            "api-change",
+            "deprecation",
+            "version-major",
+            "urgent",
+            "enhancement",
+            "feature",
+            "bug",
+        ]
+    )
+
     def get_reports_dir(self, repo_name: str) -> str:
         """Get the reports directory for a specific repository.
 

--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -375,16 +375,22 @@ def _apply_issue_actions_directly(
                     commit_log = get_commit_log(base_branch=config.MAIN_BRANCH)
 
                 # Create a comprehensive prompt for LLM CLI
+                # Extract issue labels for label-based prompt selection
+                issue_labels_list = issue_data.get("labels", [])
+
                 action_prompt = render_prompt(
                     "issue.action",
                     repo_name=repo_name,
                     issue_number=issue_data.get("number", "unknown"),
                     issue_title=issue_data.get("title", "Unknown"),
                     issue_body=(issue_data.get("body") or "")[:10000],
-                    issue_labels=", ".join(issue_data.get("labels", [])),
+                    issue_labels=", ".join(issue_labels_list),
                     issue_state=issue_data.get("state", "open"),
                     issue_author=issue_data.get("author", "unknown"),
                     commit_log=commit_log or "(No commit history)",
+                    labels=issue_labels_list,
+                    label_prompt_mappings=config.label_prompt_mappings,
+                    label_priorities=config.label_priorities,
                 )
                 logger.debug(
                     "Prepared issue-action prompt for #%s (preview: %s)",

--- a/src/auto_coder/prompt_loader.py
+++ b/src/auto_coder/prompt_loader.py
@@ -102,6 +102,25 @@ def _resolve_label_priority(
     return applicable_labels[0]  # Fallback to first applicable label
 
 
+def _is_breaking_change_issue(issue_labels: List[str]) -> bool:
+    """Check if issue has breaking-change related labels.
+
+    Args:
+        issue_labels: List of labels from the issue
+
+    Returns:
+        True if issue has any breaking-change related labels, False otherwise
+    """
+    breaking_change_aliases = [
+        "breaking-change",
+        "breaking",
+        "api-change",
+        "deprecation",
+        "version-major",
+    ]
+    return any(label.lower() in breaking_change_aliases for label in issue_labels)
+
+
 def _get_prompt_for_labels(
     issue_labels: List[str],
     label_prompt_mappings: Dict[str, str],

--- a/src/auto_coder/prompts.yaml
+++ b/src/auto_coder/prompts.yaml
@@ -204,6 +204,46 @@ issue:
 
     Please proceed with analyzing and taking action on this issue now.
 
+  breaking_change: |-
+    You are processing a GitHub issue with the 'breaking-change' label.
+
+    BREAKING CHANGE REQUIREMENTS:
+    - This issue involves breaking changes that may break existing functionality
+    - Tests that fail due to breaking changes should be DELETED, not fixed
+    - Update version numbers according to semantic versioning (major version bump)
+    - Add migration guide for users to update their code
+    - Document all breaking changes clearly
+    - Consider backward compatibility impact
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Breaking Change Detected: YES
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern (e.g., 'pr-123'). This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    CRITICAL BREAKING CHANGE DIRECTIVES:
+    1. TEST FAILURES: If tests fail due to this breaking change, DELETE them instead of fixing them
+    2. VERSION BUMP: Update version numbers with major version increment (semantic versioning)
+    3. MIGRATION GUIDE: Create clear migration instructions for users
+    4. DEPRECATION NOTICE: Document deprecated features and replacement approaches
+    5. BACKWARD COMPATIBILITY: Assess and document compatibility impact
+
+    COMMITMENT TO QUALITY:
+    - Breaking changes must be intentional and well-documented
+    - Users must be able to migrate their code successfully
+    - Version numbers must accurately reflect breaking changes
+    - No existing functionality should work incorrectly without clear migration path
+
+    Please proceed with analyzing and implementing this breaking change now.
+
 tests:
   workspace_fix: |-
     You are operating directly in this repository workspace with write access.


### PR DESCRIPTION
Closes #395

Added specialized handling for GitHub issues with the 'breaking-change' label. The implementation includes a dedicated prompt template that guides the LLM to delete failing tests and provide version management guidance when processing breaking changes.