### PR TITLE
Implement prompt router and configuration system

### DIFF
--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -85,6 +85,243 @@ class AutomationConfig:
         ]
     )
 
+    def __init__(
+        self,
+        env_override: bool = True,
+        custom_label_mappings: Optional[Dict[str, str]] = None,
+        custom_priorities: Optional[List[str]] = None,
+    ):
+        """Initialize AutomationConfig with optional environment variable overrides.
+
+        Args:
+            env_override: If True, read from environment variables
+            custom_label_mappings: Optional custom label prompt mappings
+            custom_priorities: Optional custom label priorities
+        """
+        # Store init parameters for later use
+        self._env_override = env_override
+        self._custom_label_mappings = custom_label_mappings
+        self._custom_priorities = custom_priorities
+
+        # Set default values
+        object.__setattr__(self, "REPORTS_DIR", "reports")
+        object.__setattr__(self, "TEST_SCRIPT_PATH", "scripts/test.sh")
+        object.__setattr__(self, "MAX_PR_DIFF_SIZE", 2000)
+        object.__setattr__(self, "MAX_PROMPT_SIZE", 1000)
+        object.__setattr__(self, "MAX_RESPONSE_SIZE", 200)
+        object.__setattr__(self, "max_issues_per_run", -1)
+        object.__setattr__(self, "max_prs_per_run", -1)
+        object.__setattr__(self, "MAX_FIX_ATTEMPTS", 30)
+        object.__setattr__(self, "MAIN_BRANCH", "main")
+        object.__setattr__(self, "SKIP_MAIN_UPDATE_WHEN_CHECKS_FAIL", True)
+        object.__setattr__(self, "IGNORE_DEPENDABOT_PRS", False)
+        object.__setattr__(self, "FORCE_CLEAN_BEFORE_CHECKOUT", False)
+        object.__setattr__(self, "DISABLE_LABELS", False)
+        object.__setattr__(self, "CHECK_LABELS", True)
+        object.__setattr__(self, "CHECK_DEPENDENCIES", True)
+        object.__setattr__(self, "SEARCH_GITHUB_ACTIONS_HISTORY", True)
+        object.__setattr__(self, "ENABLE_ACTIONS_HISTORY_FALLBACK", True)
+        object.__setattr__(self, "MERGE_METHOD", "--squash")
+        object.__setattr__(self, "MERGE_AUTO", True)
+        object.__setattr__(self, "PR_LABEL_COPYING_ENABLED", True)
+        object.__setattr__(self, "PR_LABEL_MAX_COUNT", 3)
+        object.__setattr__(
+            self,
+            "PR_LABEL_PRIORITIES",
+            [
+                "urgent",
+                "breaking-change",
+                "bug",
+                "enhancement",
+                "documentation",
+                "question",
+            ],
+        )
+        object.__setattr__(
+            self,
+            "PR_LABEL_MAPPINGS",
+            {
+                "breaking-change": [
+                    "breaking-change",
+                    "breaking change",
+                    "bc-breaking",
+                    "breaking",
+                    "incompatible",
+                    "api-change",
+                    "deprecation",
+                    "version-major",
+                    "major-change",
+                ],
+                "bug": [
+                    "bug",
+                    "bugfix",
+                    "fix",
+                    "error",
+                    "issue",
+                    "defect",
+                    "broken",
+                    "hotfix",
+                    "patch",
+                ],
+                "documentation": [
+                    "documentation",
+                    "docs",
+                    "doc",
+                    "readme",
+                    "guide",
+                ],
+                "enhancement": [
+                    "enhancement",
+                    "feature",
+                    "improvement",
+                    "feat",
+                    "request",
+                    "new-feature",
+                    "refactor",
+                    "optimization",
+                    "optimisation",
+                ],
+                "urgent": [
+                    "urgent",
+                    "high-priority",
+                    "critical",
+                    "asap",
+                    "priority-high",
+                    "blocker",
+                ],
+                "question": [
+                    "question",
+                    "help wanted",
+                    "support",
+                    "q&a",
+                ],
+            },
+        )
+
+        # Initialize label prompt mappings
+        object.__setattr__(
+            self,
+            "label_prompt_mappings",
+            {
+                "breaking-change": "issue.breaking_change",
+                "breaking": "issue.breaking_change",
+                "api-change": "issue.breaking_change",
+                "deprecation": "issue.breaking_change",
+                "version-major": "issue.breaking_change",
+                "urgent": "issue.urgent",
+                "high-priority": "issue.urgent",
+                "critical": "issue.urgent",
+                "blocker": "issue.urgent",
+                "bug": "issue.bug",
+                "bugfix": "issue.bug",
+                "defect": "issue.bug",
+                "error": "issue.bug",
+                "fix": "issue.bug",
+                "enhancement": "issue.enhancement",
+                "feature": "issue.enhancement",
+                "improvement": "issue.enhancement",
+                "new-feature": "issue.enhancement",
+                "documentation": "issue.documentation",
+                "docs": "issue.documentation",
+                "doc": "issue.documentation",
+            },
+        )
+
+        # Initialize label priorities
+        object.__setattr__(
+            self,
+            "label_priorities",
+            [
+                "breaking-change",
+                "breaking",
+                "api-change",
+                "deprecation",
+                "version-major",
+                "urgent",
+                "high-priority",
+                "critical",
+                "blocker",
+                "bug",
+                "bugfix",
+                "defect",
+                "error",
+                "fix",
+                "enhancement",
+                "feature",
+                "improvement",
+                "new-feature",
+                "documentation",
+                "docs",
+                "doc",
+            ],
+        )
+
+        # Apply environment variable overrides if enabled
+        if env_override:
+            self._apply_env_overrides()
+
+        # Apply custom overrides if provided
+        if custom_label_mappings:
+            self._merge_label_mappings(custom_label_mappings)
+
+        if custom_priorities:
+            object.__setattr__(self, "label_priorities", custom_priorities)
+
+    def _apply_env_overrides(self) -> None:
+        """Apply environment variable overrides for label configurations."""
+        # Read label prompt mappings from environment variable
+        mappings_json = os.environ.get("AUTO_CODER_LABEL_PROMPT_MAPPINGS")
+        if mappings_json:
+            try:
+                env_mappings = json.loads(mappings_json)
+                if isinstance(env_mappings, dict):
+                    self._merge_label_mappings(env_mappings)
+                    logger.info(f"Loaded {len(env_mappings)} label prompt mappings from environment")
+                else:
+                    logger.warning("AUTO_CODER_LABEL_PROMPT_MAPPINGS must be a JSON object (dict)")
+            except json.JSONDecodeError as exc:
+                logger.error(f"Failed to parse AUTO_CODER_LABEL_PROMPT_MAPPINGS: {exc}")
+
+        # Read label priorities from environment variable
+        priorities_json = os.environ.get("AUTO_CODER_LABEL_PRIORITIES")
+        if priorities_json:
+            try:
+                env_priorities = json.loads(priorities_json)
+                if isinstance(env_priorities, list):
+                    object.__setattr__(self, "label_priorities", env_priorities)
+                    logger.info(f"Loaded {len(env_priorities)} label priorities from environment")
+                else:
+                    logger.warning("AUTO_CODER_LABEL_PRIORITIES must be a JSON array (list)")
+            except json.JSONDecodeError as exc:
+                logger.error(f"Failed to parse AUTO_CODER_LABEL_PRIORITIES: {exc}")
+
+    def _merge_label_mappings(self, new_mappings: Dict[str, str]) -> None:
+        """Merge new label mappings with existing ones.
+
+        Args:
+            new_mappings: Dictionary of new label-to-prompt mappings
+        """
+        current_mappings = dict(self.label_prompt_mappings)
+        current_mappings.update(new_mappings)
+        object.__setattr__(self, "label_prompt_mappings", current_mappings)
+
+    def validate_label_config(self) -> None:
+        """Validate label prompt configuration.
+
+        Raises:
+            ValueError: If configuration values are invalid
+        """
+        if not self.label_priorities:
+            raise ValueError("label_priorities cannot be empty")
+
+        if not self.label_prompt_mappings:
+            raise ValueError("label_prompt_mappings cannot be empty")
+
+        # Validate that all priorities reference valid mappings
+        for priority_label in self.label_priorities:
+            if priority_label not in self.label_prompt_mappings:
+                logger.warning(f"label_priorities contains '{priority_label}' not in label_prompt_mappings")
+
     def get_reports_dir(self, repo_name: str) -> str:
         """Get the reports directory for a specific repository.
 


### PR DESCRIPTION
Closes #407

Added label-to-prompt mapping configuration, priority-based label selection logic, default fallback prompt handling, and environment variable support for flexible prompt routing based on issue labels.
[ERROR] [ImportProcessor] Could not find child token in parent raw content. Aborting parsing for this branch. Child raw: "

"
[ERROR] [ImportProcessor] Failed to import auto-coder: ENOENT: no such file or directory, access '/workspaces/auto-coder/auto-coder'
[ERROR] [ImportProcessor] Failed to import augmentcode/auggie`.: ENOENT: no such file or directory, access '/workspaces/auto-coder/augmentcode/auggie`.'
[ERROR] [ImportProcessor] Failed to import dataclass: ENOENT: no such file or directory, access '/workspaces/auto-coder/dataclass'