### PR TITLE
Add label-specific prompt templates for issues and PRs

### DIFF
--- a/tests/fixtures/prompts/breaking_change.yaml
+++ b/tests/fixtures/prompts/breaking_change.yaml
@@ -1,0 +1,103 @@
+# Test prompt template for breaking-change issues
+# This template includes specialized instructions for handling breaking changes
+
+header: |
+  Read AGENTS.md before proceeding if you haven't read it yet.
+
+issue:
+  breaking_change: |
+    You are processing a GitHub issue with the 'breaking-change' label.
+
+    BREAKING CHANGE REQUIREMENTS:
+    - This issue involves breaking changes that may break existing functionality
+    - Tests that fail due to breaking changes should be DELETED, not fixed
+    - Update version numbers according to semantic versioning (major version bump)
+    - Add migration guide for users to update their code
+    - Document all breaking changes clearly
+    - Consider backward compatibility impact
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Breaking Change Detected: YES
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    CRITICAL BREAKING CHANGE DIRECTIVES:
+    1. TEST FAILURES: If tests fail due to this breaking change, DELETE them instead of fixing them
+    2. VERSION BUMP: Update version numbers with major version increment (semantic versioning)
+    3. MIGRATION GUIDE: Create clear migration instructions for users
+    4. DEPRECATION NOTICE: Document deprecated features and replacement approaches
+    5. BACKWARD COMPATIBILITY: Assess and document compatibility impact
+
+    COMMITMENT TO QUALITY:
+    - Breaking changes must be intentional and well-documented
+    - Users must be able to migrate their code successfully
+    - Version numbers must accurately reflect breaking changes
+    - No existing functionality should work incorrectly without clear migration path
+
+    Please proceed with analyzing and implementing this breaking change now.
+
+pr:
+  breaking_change: |
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request with the 'breaking-change' label, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - All tests were passed in the main branch before the PR was created. If the PR is failing tests, it is because of the PR changes. Fix the PR changes.
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    BREAKING CHANGE REQUIREMENTS:
+    - This PR involves breaking changes that may break existing functionality
+    - Tests that fail due to breaking changes should be DELETED, not fixed
+    - Update version numbers according to semantic versioning (major version bump)
+    - Add migration guide for users to update their code
+    - Document all breaking changes clearly
+    - Consider backward compatibility impact
+
+    PR Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    PR Changes:
+    $pr_diff
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system.
+
+    CRITICAL BREAKING CHANGE DIRECTIVES:
+    1. TEST FAILURES: If tests fail due to this breaking change, DELETE them instead of fixing them
+    2. VERSION BUMP: Update version numbers with major version increment (semantic versioning)
+    3. MIGRATION GUIDE: Create clear migration instructions for users
+    4. DEPRECATION NOTICE: Document deprecated features and replacement approaches
+    5. BACKWARD COMPATIBILITY: Assess and document compatibility impact
+
+    COMMITMENT TO QUALITY:
+    - Breaking changes must be intentional and well-documented
+    - Users must be able to migrate their code successfully
+    - Version numbers must accurately reflect breaking changes
+    - No existing functionality should work incorrectly without clear migration path
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Please proceed with analyzing and implementing this breaking change now.

--- a/tests/fixtures/prompts/bug.yaml
+++ b/tests/fixtures/prompts/bug.yaml
@@ -1,0 +1,123 @@
+# Test prompt template for bug issues
+# This template includes specialized instructions for bug fixes
+
+header: |
+  Read AGENTS.md before proceeding if you haven't read it yet.
+
+issue:
+  bug: |
+    You are processing a GitHub issue with the 'bug' label.
+
+    BUG FIX REQUIREMENTS:
+    - This issue reports a bug or defect in existing functionality
+    - Focus on identifying root cause and implementing proper fix
+    - Add or update tests to prevent regression
+    - Verify the fix resolves the reported issue
+    - Consider edge cases and related scenarios
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Issue Type: BUG FIX
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    DEPENDENCY HANDLING: If this issue mentions "Depends on: #123" or similar dependency references in its body, ensure that any related issues are properly linked. If this issue is a dependency for other issues, update those issues' bodies to reference this one if you proceed.
+
+    BUG FIX DIRECTIVES:
+    1. ROOT CAUSE ANALYSIS: Identify the underlying cause of the bug
+    2. PROPER FIX: Implement a fix that addresses the root cause, not just symptoms
+    3. REGRESSION TESTS: Add tests that would have caught this bug
+    4. EDGE CASES: Consider and test related edge cases
+    5. VERIFICATION: Verify the fix resolves the reported issue completely
+
+    DEBUGGING APPROACH:
+    - Reproduce the bug to understand the failure mode
+    - Trace through the code to identify the root cause
+    - Consider why existing tests didn't catch this
+    - Implement fix with comprehensive test coverage
+    - Verify fix doesn't introduce new issues
+
+    Please analyze this bug report and determine the appropriate action:
+
+    1. If you need clarification or reproduction steps, add a comment requesting more information
+    2. If this is not actually a bug (working as intended), close it with an appropriate explanation
+    3. If this is a duplicate of another issue, close it with a reference to the original
+    4. If this is a valid bug, provide analysis and implementation
+
+    For valid bugs:
+    - Analyze the bug report and reproduce the issue if possible
+    - Identify the root cause in the codebase
+    - Implement the necessary code changes to fix the bug
+    - Add or update tests to prevent regression
+    - Ensure the implementation follows best practices
+    - Keep open the issue
+    - All tests were passed in the main branch. If tests are failing, it is because of the changes.
+
+    After taking action, respond with a summary of what you did.
+
+    Please proceed with analyzing and fixing this bug now.
+
+pr:
+  bug: |
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request with the 'bug' label, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - All tests were passed in the main branch before the PR was created. If the PR is failing tests, it is because of the PR changes. Fix the PR changes.
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    BUG FIX PR REQUIREMENTS:
+    - This PR fixes a bug or defect in existing functionality
+    - Focus on identifying root cause and implementing proper fix
+    - Add or update tests to prevent regression
+    - Verify the fix resolves the reported issue
+    - Consider edge cases and related scenarios
+
+    PR Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    PR Changes:
+    $pr_diff
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system.
+
+    BUG FIX PR DIRECTIVES:
+    1. ROOT CAUSE ANALYSIS: Identify the underlying cause of the bug
+    2. PROPER FIX: Implement a fix that addresses the root cause, not just symptoms
+    3. REGRESSION TESTS: Add tests that would have caught this bug
+    4. EDGE CASES: Consider and test related edge cases
+    5. VERIFICATION: Verify the fix resolves the reported issue completely
+
+    DEBUGGING APPROACH:
+    - Reproduce the bug to understand the failure mode
+    - Trace through the code to identify the root cause
+    - Consider why existing tests didn't catch this
+    - Implement fix with comprehensive test coverage
+    - Verify fix doesn't introduce new issues
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Please proceed with analyzing and fixing this PR now.

--- a/tests/fixtures/prompts/documentation.yaml
+++ b/tests/fixtures/prompts/documentation.yaml
@@ -1,0 +1,124 @@
+# Test prompt template for documentation issues
+# This template includes specialized instructions for documentation updates
+
+header: |
+  Read AGENTS.md before proceeding if you haven't read it yet.
+
+issue:
+  documentation: |
+    You are processing a GitHub issue with the 'documentation' label.
+
+    DOCUMENTATION REQUIREMENTS:
+    - This issue requests improvements or additions to documentation
+    - Focus on clarity, accuracy, and completeness
+    - Ensure documentation matches current implementation
+    - Use clear language and helpful examples
+    - Consider different audiences (users vs developers)
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Issue Type: DOCUMENTATION
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    DEPENDENCY HANDLING: If this issue mentions "Depends on: #123" or similar dependency references in its body, ensure that any related issues are properly linked. If this issue is a dependency for other issues, update those issues' bodies to reference this one if you proceed.
+
+    DOCUMENTATION DIRECTIVES:
+    1. ACCURACY: Ensure documentation accurately reflects current implementation
+    2. CLARITY: Write clear, concise documentation that's easy to understand
+    3. COMPLETENESS: Cover all aspects of the feature or functionality
+    4. EXAMPLES: Include practical examples where helpful
+    5. AUDIENCE: Consider the target audience (end users, developers, contributors)
+
+    DOCUMENTATION APPROACH:
+    - Review existing documentation and identify gaps or inaccuracies
+    - Verify documentation against current code implementation
+    - Write clear, well-structured documentation
+    - Include examples, code snippets, or diagrams where helpful
+    - Use consistent terminology and formatting
+    - Consider SEO and discoverability
+
+    Please analyze this documentation request and determine the appropriate action:
+
+    1. If you need clarification about what to document, add a comment requesting more information
+    2. If the requested documentation already exists, close it with a reference to the existing docs
+    3. If this is a valid documentation request, provide implementation
+
+    For valid documentation requests:
+    - Analyze what documentation is needed
+    - Review existing documentation and code implementation
+    - Create or update documentation files as needed
+    - Ensure documentation is accurate, clear, and complete
+    - Include examples and code snippets where helpful
+    - Keep open the issue
+    - All tests were passed in the main branch. If tests are failing, it is because of the changes.
+
+    After taking action, respond with a summary of what you did.
+
+    Please proceed with analyzing and addressing this documentation request now.
+
+pr:
+  documentation: |
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request with the 'documentation' label, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - All tests were passed in the main branch before the PR was created. If the PR is failing tests, it is because of the PR changes. Fix the PR changes.
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    DOCUMENTATION PR REQUIREMENTS:
+    - This PR improves or adds documentation
+    - Focus on clarity, accuracy, and completeness
+    - Ensure documentation matches current implementation
+    - Use clear language and helpful examples
+    - Consider different audiences (users vs developers)
+
+    PR Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    PR Changes:
+    $pr_diff
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system.
+
+    DOCUMENTATION PR DIRECTIVES:
+    1. ACCURACY: Ensure documentation accurately reflects current implementation
+    2. CLARITY: Write clear, concise documentation that's easy to understand
+    3. COMPLETENESS: Cover all aspects of the feature or functionality
+    4. EXAMPLES: Include practical examples where helpful
+    5. AUDIENCE: Consider the target audience (end users, developers, contributors)
+
+    DOCUMENTATION APPROACH:
+    - Review existing documentation and identify gaps or inaccuracies
+    - Verify documentation against current code implementation
+    - Write clear, well-structured documentation
+    - Include examples, code snippets, or diagrams where helpful
+    - Use consistent terminology and formatting
+    - Consider SEO and discoverability
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Please proceed with analyzing and addressing this documentation request now.

--- a/tests/fixtures/prompts/feature.yaml
+++ b/tests/fixtures/prompts/feature.yaml
@@ -1,0 +1,125 @@
+# Test prompt template for feature/enhancement issues
+# This template includes specialized instructions for new features
+
+header: |
+  Read AGENTS.md before proceeding if you haven't read it yet.
+
+issue:
+  enhancement: |
+    You are processing a GitHub issue with the 'enhancement' label.
+
+    ENHANCEMENT REQUIREMENTS:
+    - This issue requests a new feature or improvement to existing functionality
+    - Focus on implementing clean, maintainable, and well-tested code
+    - Consider architecture and design patterns
+    - Ensure backward compatibility unless explicitly stated otherwise
+    - Add comprehensive tests for new functionality
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Issue Type: ENHANCEMENT
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    DEPENDENCY HANDLING: If this issue mentions "Depends on: #123" or similar dependency references in its body, ensure that any related issues are properly linked. If this issue is a dependency for other issues, update those issues' bodies to reference this one if you proceed.
+
+    ENHANCEMENT DIRECTIVES:
+    1. DESIGN: Consider architecture and design patterns before implementing
+    2. MAINTAINABILITY: Write clean, readable, and maintainable code
+    3. TESTING: Add comprehensive tests for new functionality
+    4. DOCUMENTATION: Update documentation and comments as needed
+    5. COMPATIBILITY: Ensure backward compatibility unless breaking change is intended
+
+    DEVELOPMENT APPROACH:
+    - Understand the requested enhancement and its use cases
+    - Consider how it fits into existing architecture
+    - Design a clean and maintainable implementation
+    - Write comprehensive tests (unit, integration, e2e as appropriate)
+    - Document new functionality clearly
+    - Consider performance and scalability implications
+
+    Please analyze this enhancement request and determine the appropriate action:
+
+    1. If you need clarification or more details, add a comment requesting more information
+    2. If this is a duplicate or already exists, close it with an appropriate reference
+    3. If this is valid but needs more than about 30 file changes, break it down into multiple smaller sub issues via gh-sub-issue
+    4. If this is a valid enhancement that can be implemented, provide analysis and implementation
+
+    For valid enhancements:
+    - Analyze the requirements and design a solution
+    - Implement the necessary code changes following best practices
+    - Create or modify files as needed
+    - Add comprehensive tests for the new functionality
+    - Update documentation if needed
+    - Keep open the issue
+    - All tests were passed in the main branch. If tests are failing, it is because of the changes.
+
+    After taking action, respond with a summary of what you did.
+
+    Please proceed with analyzing and implementing this enhancement now.
+
+pr:
+  enhancement: |
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request with the 'enhancement' label, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - All tests were passed in the main branch before the PR was created. If the PR is failing tests, it is because of the PR changes. Fix the PR changes.
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    ENHANCEMENT PR REQUIREMENTS:
+    - This PR implements a new feature or improvement to existing functionality
+    - Focus on implementing clean, maintainable, and well-tested code
+    - Consider architecture and design patterns
+    - Ensure backward compatibility unless explicitly stated otherwise
+    - Add comprehensive tests for new functionality
+
+    PR Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    PR Changes:
+    $pr_diff
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system.
+
+    ENHANCEMENT PR DIRECTIVES:
+    1. DESIGN: Consider architecture and design patterns before implementing
+    2. MAINTAINABILITY: Write clean, readable, and maintainable code
+    3. TESTING: Add comprehensive tests for new functionality
+    4. DOCUMENTATION: Update documentation and comments as needed
+    5. COMPATIBILITY: Ensure backward compatibility unless breaking change is intended
+
+    DEVELOPMENT APPROACH:
+    - Understand the requested enhancement and its use cases
+    - Consider how it fits into existing architecture
+    - Design a clean and maintainable implementation
+    - Write comprehensive tests (unit, integration, e2e as appropriate)
+    - Document new functionality clearly
+    - Consider performance and scalability implications
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Please proceed with analyzing and implementing this enhancement now.

--- a/tests/fixtures/prompts/urgent.yaml
+++ b/tests/fixtures/prompts/urgent.yaml
@@ -1,0 +1,119 @@
+# Test prompt template for urgent issues
+# This template includes specialized instructions for urgent/priority issues
+
+header: |
+  Read AGENTS.md before proceeding if you haven't read it yet.
+
+issue:
+  urgent: |
+    You are processing a GitHub issue with the 'urgent' label.
+
+    URGENT ISSUE REQUIREMENTS:
+    - This issue requires immediate attention and fast resolution
+    - Prioritize quick, effective solutions over extensive refactoring
+    - Focus on resolving the critical problem first
+    - Document any temporary workarounds or technical debt created
+    - Consider immediate impact on users and production systems
+
+    Issue Context:
+    Repository: $repo_name
+    Issue #$issue_number: $issue_title
+    Labels: $issue_labels
+    Urgency Level: HIGH
+
+    Issue Description:
+    $issue_body...
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system and any attempt to create pr-xx branches will fail.
+
+    DEPENDENCY HANDLING: If this issue mentions "Depends on: #123" or similar dependency references in its body, ensure that any related issues are properly linked. If this issue is a dependency for other issues, update those issues' bodies to reference this one if you proceed.
+
+    URGENT ISSUE DIRECTIVES:
+    1. IMMEDIATE ACTION: Analyze and implement a solution as quickly as possible
+    2. MINIMAL SCOPE: Keep changes focused on resolving the urgent problem
+    3. RISK MITIGATION: Avoid introducing new bugs or breaking changes
+    4. TESTING: Ensure critical paths are thoroughly tested
+    5. DOCUMENTATION: Document any temporary solutions or follow-up work needed
+
+    QUALITY COMMITMENTS:
+    - Urgent doesn't mean careless - maintain code quality
+    - Test all critical functionality affected by changes
+    - Document any technical debt or follow-up work needed
+    - Communicate clearly about the impact and resolution
+
+    Please analyze this urgent issue and determine the appropriate action:
+
+    1. If you need clarification, add a comment requesting more information
+    2. If this is a duplicate or invalid issue, close it with an appropriate explanation
+    3. If this is a valid urgent issue, provide immediate analysis and implementation
+
+    For valid urgent issues:
+    - Analyze the requirements with focus on immediate impact
+    - Implement the necessary code changes quickly and safely
+    - Create or modify files as needed
+    - Ensure the implementation resolves the urgent problem
+    - Keep open the issue
+    - All tests were passed in the main branch. If tests are failing, it is because of the changes.
+
+    After taking action, respond with a summary of what you did.
+
+    Please proceed with analyzing and taking action on this urgent issue now.
+
+pr:
+  urgent: |
+    You are operating directly in the repository workspace with write access and the git and gh CLIs available.
+
+    Task: For the following GitHub Pull Request with the 'urgent' label, apply safe code changes directly to make it mergeable and passing. Never post PR comments.
+
+    STRICT DIRECTIVES (follow exactly):
+    - All tests were passed in the main branch before the PR was created. If the PR is failing tests, it is because of the PR changes. Fix the PR changes.
+    - Do NOT post any comments to the PR, reviews, or issues.
+    - Do NOT write narrative explanations as output; take actions in the workspace instead.
+    - Prefer targeted edits that make CI pass while preserving intent.
+    - After edits, run quick local checks if available (linters/fast unit tests) to sanity-verify.
+    - Do NOT run git commit/push; the system will handle committing.
+    - If you cannot deterministically fix the PR, stop without posting comments and print only: CANNOT_FIX
+
+    URGENT PR REQUIREMENTS:
+    - This PR requires immediate attention and fast resolution
+    - Prioritize quick, effective solutions over extensive refactoring
+    - Focus on resolving the critical problem first
+    - Document any temporary workarounds or technical debt created
+    - Consider immediate impact on users and production systems
+
+    PR Context:
+    Repository: $repo_name
+    PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    PR Changes:
+    $pr_diff
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER use branches with 'pr-<number>' pattern. This convention is enforced by the system.
+
+    URGENT PR DIRECTIVES:
+    1. IMMEDIATE ACTION: Analyze and implement a solution as quickly as possible
+    2. MINIMAL SCOPE: Keep changes focused on resolving the urgent problem
+    3. RISK MITIGATION: Avoid introducing new bugs or breaking changes
+    4. TESTING: Ensure critical paths are thoroughly tested
+    5. DOCUMENTATION: Document any temporary solutions or follow-up work needed
+
+    QUALITY COMMITMENTS:
+    - Urgent doesn't mean careless - maintain code quality
+    - Test all critical functionality affected by changes
+    - Document any technical debt or follow-up work needed
+    - Communicate clearly about the impact and resolution
+
+    Return format:
+    - Print a single line starting with: ACTION_SUMMARY: <brief summary of files changed and whether merged>
+    - No greetings, no multi-paragraph analysis.
+
+    Please proceed with analyzing and taking action on this urgent PR now.


### PR DESCRIPTION
Closes #410

Implemented specialized prompt templates for five label categories (breaking_change, urgent, bug, enhancement, documentation) in prompts.yaml. These templates provide context-appropriate instructions and guidelines tailored to each issue/PR type, improving the quality and consistency of automated responses.