### PR TITLE
Update utils.py to import extract_first_failed_test from test_log_utils

### DIFF
--- a/src/auto_coder/utils.py
+++ b/src/auto_coder/utils.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
 
 from .logger_config import get_logger
+from .test_log_utils import extract_first_failed_test
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
Closes #468

Modified src/auto_coder/utils.py to import the extract_first_failed_test
function from the new test_log_utils module, completing the refactoring
initiated in issue #467.