### PR TITLE
Implement retry logic for usage limits in BackendManager

### DIFF
--- a/src/auto_coder/backend_manager.py
+++ b/src/auto_coder/backend_manager.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .backend_provider_manager import BackendProviderManager
@@ -177,6 +178,8 @@ class BackendManager(LLMBackendManagerBase):
         attempts = 0
         tried: set[int] = set()
         last_error: Optional[Exception] = None
+        # Track retry attempts per backend
+        retry_attempts: Dict[str, int] = {}
 
         while attempts < len(self._all_backends):
             if self._current_idx in tried:
@@ -205,6 +208,20 @@ class BackendManager(LLMBackendManagerBase):
                 )
             except AutoCoderUsageLimitError as exc:
                 last_error = exc
+                # Check if we should retry this backend
+                backend_config = get_llm_config().get_backend_config(backend_name)
+                if backend_config and backend_config.usage_limit_retry_count > 0:
+                    current_retries = retry_attempts.get(backend_name, 0)
+                    if current_retries < backend_config.usage_limit_retry_count:
+                        # Retry the same backend
+                        retry_attempts[backend_name] = current_retries + 1
+                        wait_seconds = backend_config.usage_limit_retry_wait_seconds
+                        logger.info(f"Retrying backend '{backend_name}' (retry {current_retries + 1}/{backend_config.usage_limit_retry_count}) after {wait_seconds} seconds")
+                        time.sleep(wait_seconds)
+                        # Don't switch to next backend, retry on the same one
+                        continue
+
+                # If we reach here, either no retry config or retries exhausted
                 logger.warning(f"Backend '{backend_name}' exhausted providers due to usage limits: {exc}")
                 self.switch_to_next_backend()
                 attempts += 1


### PR DESCRIPTION
Closes #501

Added retry functionality to _run_llm_cli method that handles AutoCoderUsageLimitError
by checking backend configuration for retry settings and waiting before retrying.
This prevents immediate backend rotation when usage limits are hit.