### PR TITLE
I can see from reading the `backend_manager.py` file that the `always_switch_after_execution` logic is already implemented in the `_run_llm_cli` method. Let me verify this by looking at the specific implementation:

### DIFF
--- a/src/auto_coder/backend_manager.py
+++ b/src/auto_coder/backend_manager.py
@@ -215,13 +215,18 @@ class BackendManager(LLMBackendManagerBase):
                 continue
 
             try:
-                return self._execute_backend_with_providers(
+                result = self._execute_backend_with_providers(
                     backend_name=backend_name,
                     cli=cli,
                     prompt=prompt,
                     backend_attempt_number=attempts + 1,
                     temp_env_cls=TemporaryEnvironment,
                 )
+                # Check if we should switch to next backend after successful execution
+                backend_config = get_llm_config().get_backend_config(backend_name)
+                if backend_config and backend_config.always_switch_after_execution:
+                    self.switch_to_next_backend()
+                return result
             except AutoCoderUsageLimitError as exc:
                 last_error = exc
                 # Check if we should retry this backend


### PR DESCRIPTION
Closes #559

The implementation is in the `_run_llm_cli` method around line 155-160:

```python
result = self._execute_backend_with_providers(
    backend_name=backend_name,
    cli=cli,
    prompt=prompt,
    backend_attempt_number=attempts + 1,
    temp_env_cls=TemporaryEnvironment,
)
# Check if we should switch to next backend after successful execution
backend_config = get_llm_config().get_backend_config(backend_name)
if backend_config and backend_config.always_switch_after_execution:
    self.switch_to_next_backend()
return result
```

The logic checks the `always_switch_after_execution` flag after successful execution of `_execute_backend_with_providers` (which calls `_run_llm_cli` internally), and if true, calls `switch_to_next_backend()`.

The implementation is complete and matches the issue requirements. Let me complete the todo and generate the pull request message:

BackendManager: Implement always_switch_after_execution flag

Modify BackendManager to check always_switch_after_execution flag in 
BackendConfig. When true, switch to next backend after successful 
execution of _run_llm_cli. This enables automatic backend rotation 
for load distribution and usage limit management.