### PR TITLE
Update documentation for always_switch_after_execution option

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ timeout = 30
 max_retries = 3
 usage_limit_retry_count = 3
 usage_limit_retry_wait_seconds = 30
+always_switch_after_execution = false
 
 [backends.qwen]
 enabled = true
@@ -314,6 +315,7 @@ timeout = 30
 max_retries = 3
 usage_limit_retry_count = 2
 usage_limit_retry_wait_seconds = 60
+always_switch_after_execution = false
 
 [backends.claude]
 enabled = true
@@ -393,6 +395,30 @@ Different LLM providers have different rate limiting behaviors:
 - **Codex**: 0-1 retries (OpenAI Codex has strict rate limits)
 
 Adjust these values based on your usage patterns and the specific rate limits of your LLM providers.
+
+### Post-Execution Backend Rotation
+
+Enable `always_switch_after_execution` on individual backends to rotate to the next backend in `backend.order` after every successful run. This is useful when you want round-robin usage across providers (for example, to spread traffic or avoid hitting soft limits) instead of sticking to the same backend until a failure occurs.
+
+Example:
+
+```toml
+[backend]
+order = ["gemini", "qwen", "claude"]
+default = "gemini"
+
+[backends.gemini]
+enabled = true
+model = "gemini-2.5-pro"
+always_switch_after_execution = true  # switch to qwen after each gemini call
+
+[backends.qwen]
+enabled = true
+model = "qwen3-coder-plus"
+always_switch_after_execution = true  # continue rotation to claude next
+```
+
+If `always_switch_after_execution` is omitted or set to `false`, Auto-Coder keeps using the active backend until a retry/rotation condition is triggered.
 
 ### Environment Variables
 

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -70,6 +70,32 @@ The auto-coder system supports multiple LLM backends:
           usage_limit_retry_wait_seconds = 30
       configuration_file: "~/.auto-coder/llm_config.toml"
       scope: "Per-backend configuration allows different backends to have different retry policies"
+  post_execution_rotation:
+      description: "Optional round-robin style rotation after every successful backend call"
+      fields:
+        - name: "always_switch_after_execution"
+          type: "bool"
+          default: false
+          purpose: "If true, immediately switch to the next backend in backend.order after a successful execution"
+      use_cases:
+        - "Distribute traffic evenly across providers"
+        - "Avoid soft per-backend limits by rotating proactively"
+      example:
+        toml_example: |
+          [backend]
+          order = ["gemini", "qwen", "claude"]
+
+          [backends.gemini]
+          enabled = true
+          model = "gemini-2.5-pro"
+          always_switch_after_execution = true
+
+          [backends.qwen]
+          enabled = true
+          model = "qwen3-coder-plus"
+          always_switch_after_execution = true
+      configuration_file: "~/.auto-coder/llm_config.toml"
+      scope: "Per-backend flag; defaults to false when omitted"
 
 #### GraphRAG Integration
 


### PR DESCRIPTION
Closes #561

Added documentation for the new always_switch_after_execution configuration
option in README.md with TOML example and explanation of round-robin rotation.