### PR TITLE
Fix historical search for GitHub Actions logs failing due to missing repo context

### DIFF
--- a/src/auto_coder/util/github_action.py
+++ b/src/auto_coder/util/github_action.py
@@ -737,7 +737,7 @@ def get_detailed_checks_from_history(
             # Get jobs for this run using gh run view
             gh_logger = get_gh_logger()
             jobs_result = gh_logger.execute_with_logging(
-                ["gh", "run", "view", str(run_id), "--json", "jobs"],
+                ["gh", "run", "view", str(run_id), "-R", repo_name, "--json", "jobs"],
                 repo=repo_name,
                 timeout=60,
                 capture_output=True,
@@ -792,7 +792,7 @@ def get_detailed_checks_from_history(
                 # Fallback: create a check based on run conclusion
                 gh_logger = get_gh_logger()
                 run_result = gh_logger.execute_with_logging(
-                    ["gh", "run", "view", str(run_id), "--json", "conclusion,status"],
+                    ["gh", "run", "view", str(run_id), "-R", repo_name, "--json", "conclusion,status"],
                     repo=repo_name,
                     timeout=60,
                     capture_output=True,
@@ -1339,6 +1339,8 @@ def _search_github_actions_logs_from_history(
                         "gh",
                         "run",
                         "list",
+                        "-R",
+                        repo_name,
                         "--limit",
                         str(max_runs),
                         "--json",
@@ -1376,6 +1378,8 @@ def _search_github_actions_logs_from_history(
                     "gh",
                     "run",
                     "list",
+                    "-R",
+                    repo_name,
                     "--limit",
                     str(max_runs),
                     "--json",
@@ -1391,6 +1395,8 @@ def _search_github_actions_logs_from_history(
                         "gh",
                         "run",
                         "list",
+                        "-R",
+                        repo_name,
                         "--limit",
                         str(max_runs),
                         "--json",
@@ -1586,6 +1592,8 @@ def _get_github_actions_logs(
                 "gh",
                 "run",
                 "list",
+                "-R",
+                repo_name,
                 "--limit",
                 "50",
                 "--json",
@@ -1614,7 +1622,7 @@ def _get_github_actions_logs(
             if run_id:
                 gh_logger = get_gh_logger()
                 jobs_res = gh_logger.execute_with_logging(
-                    ["gh", "run", "view", run_id, "--json", "jobs"],
+                    ["gh", "run", "view", run_id, "-R", repo_name, "--json", "jobs"],
                     repo=repo_name,
                     timeout=60,
                     capture_output=True,

--- a/tests/test_github_actions_log_search.py
+++ b/tests/test_github_actions_log_search.py
@@ -85,6 +85,10 @@ class TestSearchGitHubActionsLogsFromHistory:
 
                 result = _search_github_actions_logs_from_history("test/repo", config, failed_checks, max_runs=10)
 
+                run_list_command = mock_cmd.call_args_list[0].args[0]
+                assert "-R" in run_list_command
+                assert "test/repo" in run_list_command
+
                 # Ensure the job lookup is scoped to the repository
                 job_view_command = mock_cmd.call_args_list[1].args[0]
                 assert "-R" in job_view_command


### PR DESCRIPTION
Closes #563

Added explicit -R <repo> scoping to all GH CLI calls in GitHub Actions log search paths to ensure proper repository context is maintained. This prevents failures when the working directory doesn't match the target repository.