### PR TITLE
Implement mergeability remediation logic for non-mergeable PRs

### DIFF
--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -189,10 +189,89 @@ def _get_mergeable_state(
 
 
 def _start_mergeability_remediation(pr_number: int, merge_state_status: Optional[str]) -> List[str]:
-    """Stub hook for future mergeability remediation workflow."""
+    """Implement mergeability remediation flow for non-mergeable PRs.
+
+    This function handles the end-to-end flow for non-mergeable PRs:
+    1. Get PR details and determine the base branch
+    2. Checkout the PR branch
+    3. Update from the base branch
+    4. Resolve conflicts using existing helpers (including package-lock handling)
+    5. Push the updated branch
+    6. Mark PR as processed once push succeeds (via ACTION_FLAG:SKIP_ANALYSIS)
+
+    Args:
+        pr_number: PR number
+        merge_state_status: Current merge state status from GitHub
+
+    Returns:
+        List of action strings describing what was done
+    """
+    actions = []
     state_text = merge_state_status or "unknown"
-    log_action(f"Starting mergeability remediation stub for PR #{pr_number}")
-    return [f"Mergeability remediation stub invoked for PR #{pr_number} (state: {state_text})"]
+
+    try:
+        log_action(f"Starting mergeability remediation for PR #{pr_number} (state: {state_text})")
+        actions.append(f"Starting mergeability remediation for PR #{pr_number} (state: {state_text})")
+
+        # Step 1: Get PR details to determine the base branch
+        gh_logger = get_gh_logger()
+        pr_details_result = gh_logger.execute_with_logging(
+            ["gh", "pr", "view", str(pr_number), "--json", "base"],
+            capture_output=True,
+        )
+
+        if not pr_details_result.success:  # type: ignore[attr-defined]
+            error_msg = f"Failed to get PR #{pr_number} details: {pr_details_result.stderr}"
+            actions.append(error_msg)
+            log_action(error_msg, False)
+            return actions
+
+        try:
+            pr_data = json.loads(pr_details_result.stdout)
+            base_branch = pr_data.get("base", {}).get("ref", "main")
+        except Exception:
+            base_branch = "main"
+
+        actions.append(f"Determined base branch for PR #{pr_number}: {base_branch}")
+
+        # Step 2: Checkout the PR branch
+        # Create minimal PR data for checkout function
+        pr_data_for_checkout = {"number": pr_number, "head": {"ref": f"pr-{pr_number}"}}
+        checkout_success = _checkout_pr_branch("", pr_data_for_checkout, AutomationConfig())
+
+        if not checkout_success:
+            error_msg = f"Failed to checkout PR #{pr_number} branch"
+            actions.append(error_msg)
+            log_action(error_msg, False)
+            return actions
+
+        actions.append(f"Checked out PR #{pr_number} branch")
+
+        # Step 3: Update from base branch with conflict resolution
+        # The _update_with_base_branch function includes:
+        # - Fetching latest changes
+        # - Merging base branch
+        # - Using _perform_base_branch_merge_and_conflict_resolution for conflicts
+        # - Pushing updated branch with retry
+        update_actions = _update_with_base_branch("", {"number": pr_number, "base_branch": base_branch}, AutomationConfig())
+        actions.extend(update_actions)
+
+        # Step 4: Verify successful remediation
+        # If push succeeded, the action flag will be set
+        if "ACTION_FLAG:SKIP_ANALYSIS" in update_actions or any("Pushed updated branch" in action for action in update_actions):
+            actions.append(f"Mergeability remediation completed for PR #{pr_number}")
+            actions.append("ACTION_FLAG:SKIP_ANALYSIS")
+        elif "Failed" in str(update_actions):
+            # Remediation attempted but failed
+            actions.append(f"Mergeability remediation failed for PR #{pr_number}")
+
+    except Exception as e:
+        error_msg = f"Error during mergeability remediation for PR #{pr_number}: {str(e)}"
+        logger.error(error_msg)
+        actions.append(error_msg)
+        log_action(error_msg, False)
+
+    return actions
 
 
 def _process_pr_for_merge(

--- a/tests/test_pr_mergeability_remediation.py
+++ b/tests/test_pr_mergeability_remediation.py
@@ -20,14 +20,88 @@ def test_non_mergeable_detection_is_reported(mock_check_progress):
 
 @patch("src.auto_coder.pr_processor._check_github_actions_status")
 @patch("src.auto_coder.pr_processor.check_github_actions_and_exit_if_in_progress")
-def test_mergeability_remediation_stub_invoked(mock_check_progress, mock_check_status):
-    """Verify remediation stub path is activated when enabled."""
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_mergeability_remediation_flow_invoked(mock_update, mock_checkout, mock_check_progress, mock_check_status):
+    """Verify remediation flow is activated when enabled."""
     mock_check_progress.return_value = True
+    mock_checkout.return_value = True
+    mock_update.return_value = ["Pushed updated branch for PR #99", "ACTION_FLAG:SKIP_ANALYSIS"]
+
     config = AutomationConfig()
     config.ENABLE_MERGEABILITY_REMEDIATION = True
     pr_data = {"number": 99, "mergeable": False}
 
     actions = _handle_pr_merge(Mock(), "owner/repo", pr_data, config, {})
 
-    assert any("remediation stub" in action.lower() for action in actions)
+    # Verify that remediation flow was invoked and skip-analysis flag was set
+    assert any("Starting mergeability remediation" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" in actions
+    mock_check_status.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor._check_github_actions_status")
+@patch("src.auto_coder.pr_processor.check_github_actions_and_exit_if_in_progress")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_mergeability_remediation_success_path(mock_update, mock_checkout, mock_check_progress, mock_check_status):
+    """Verify remediation success path - checkout and update succeed."""
+    mock_check_progress.return_value = True
+    mock_checkout.return_value = True
+    mock_update.return_value = ["Determined base branch for PR #100: main", "Checked out PR #100 branch", "Pushed updated branch for PR #100", "ACTION_FLAG:SKIP_ANALYSIS"]
+
+    config = AutomationConfig()
+    config.ENABLE_MERGEABILITY_REMEDIATION = True
+    pr_data = {"number": 100, "mergeable": False}
+
+    actions = _handle_pr_merge(Mock(), "owner/repo", pr_data, config, {})
+
+    # Verify success
+    assert any("Starting mergeability remediation" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" in actions
+    assert any("Mergeability remediation completed" in action for action in actions)
+    mock_check_status.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor._check_github_actions_status")
+@patch("src.auto_coder.pr_processor.check_github_actions_and_exit_if_in_progress")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+def test_mergeability_remediation_checkout_fails(mock_checkout, mock_check_progress, mock_check_status):
+    """Verify remediation handles checkout failure."""
+    mock_check_progress.return_value = True
+    mock_checkout.return_value = False
+
+    config = AutomationConfig()
+    config.ENABLE_MERGEABILITY_REMEDIATION = True
+    pr_data = {"number": 101, "mergeable": False}
+
+    actions = _handle_pr_merge(Mock(), "owner/repo", pr_data, config, {})
+
+    # Verify failure is handled
+    assert any("Starting mergeability remediation" in action for action in actions)
+    assert any("Failed to checkout" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
+    mock_check_status.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor._check_github_actions_status")
+@patch("src.auto_coder.pr_processor.check_github_actions_and_exit_if_in_progress")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_mergeability_remediation_update_fails(mock_update, mock_checkout, mock_check_progress, mock_check_status):
+    """Verify remediation handles update failure."""
+    mock_check_progress.return_value = True
+    mock_checkout.return_value = True
+    mock_update.return_value = ["Failed to update: merge conflict resolution failed"]
+
+    config = AutomationConfig()
+    config.ENABLE_MERGEABILITY_REMEDIATION = True
+    pr_data = {"number": 102, "mergeable": False}
+
+    actions = _handle_pr_merge(Mock(), "owner/repo", pr_data, config, {})
+
+    # Verify failure is handled
+    assert any("Starting mergeability remediation" in action for action in actions)
+    assert any("Failed" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
     mock_check_status.assert_not_called()


### PR DESCRIPTION
Closes #568

Added end-to-end flow to detect non-mergeable PRs, update from base branch,
resolve conflicts using existing helpers, and push updated branches. This
replaces the stub implementation with full remediation logic.