### PR TITLE
I'll analyze the GitHub issue #569 about adding tests for mergeability remediation and generate a pull request message. Let me check if this issue has already been addressed by looking for relevant files and changes.

### DIFF
--- a/tests/test_pr_mergeability_remediation.py
+++ b/tests/test_pr_mergeability_remediation.py
@@ -3,7 +3,7 @@
 from unittest.mock import Mock, patch
 
 from src.auto_coder.automation_config import AutomationConfig
-from src.auto_coder.pr_processor import _handle_pr_merge
+from src.auto_coder.pr_processor import _get_mergeable_state, _handle_pr_merge, _start_mergeability_remediation
 
 
 @patch("src.auto_coder.pr_processor.check_github_actions_and_exit_if_in_progress")
@@ -105,3 +105,183 @@ def test_mergeability_remediation_update_fails(mock_update, mock_checkout, mock_
     assert any("Failed" in action for action in actions)
     assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
     mock_check_status.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+def test_get_mergeable_state_uses_existing_data(mock_gh_logger):
+    """Verify mergeable state uses existing data when available."""
+    mock_result = Mock()
+    mock_result.success = False  # GitHub API call not needed
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_result
+
+    config = AutomationConfig()
+    pr_data = {"mergeable": True, "mergeStateStatus": "CLEAN"}
+
+    result = _get_mergeable_state("owner/repo", pr_data, config)
+
+    assert result["mergeable"] is True
+    assert result["merge_state_status"] == "CLEAN"
+    # Should not call GitHub API when mergeable is not None
+    mock_gh_logger.return_value.execute_with_logging.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+def test_get_mergeable_state_refreshes_when_unknown(mock_gh_logger):
+    """Verify mergeable state is refreshed when current value is unknown."""
+    mock_result = Mock()
+    mock_result.success = True
+    mock_result.stdout = '{"mergeable": false, "mergeStateStatus": "DIRTY"}'
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_result
+
+    config = AutomationConfig()
+    pr_data = {"mergeable": None, "mergeStateStatus": None}
+
+    result = _get_mergeable_state("owner/repo", pr_data, config)
+
+    assert result["mergeable"] is False
+    assert result["merge_state_status"] == "DIRTY"
+    # Verify GitHub API was called
+    mock_gh_logger.return_value.execute_with_logging.assert_called_once()
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+def test_get_mergeable_state_handles_api_failure(mock_gh_logger):
+    """Verify mergeable state handles API failure gracefully."""
+    mock_result = Mock()
+    mock_result.success = False
+    mock_result.stderr = "API error"
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_result
+
+    config = AutomationConfig()
+    pr_data = {"mergeable": None, "mergeStateStatus": None}
+
+    # Should not raise exception
+    result = _get_mergeable_state("owner/repo", pr_data, config)
+
+    assert result["mergeable"] is None
+    assert result["merge_state_status"] is None
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_start_mergeability_remediation_success(mock_update, mock_checkout, mock_gh_logger):
+    """Verify successful mergeability remediation flow."""
+    # Mock PR details retrieval
+    mock_pr_result = Mock()
+    mock_pr_result.success = True
+    mock_pr_result.stdout = '{"base": {"ref": "develop"}}'
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    # Mock successful checkout and update
+    mock_checkout.return_value = True
+    mock_update.return_value = ["Pushed updated branch for PR #200", "ACTION_FLAG:SKIP_ANALYSIS"]
+
+    actions = _start_mergeability_remediation(200, "DIRTY")
+
+    assert any("Starting mergeability remediation for PR #200" in action for action in actions)
+    assert any("Determined base branch for PR #200: develop" in action for action in actions)
+    assert any("Checked out PR #200 branch" in action for action in actions)
+    assert any("Mergeability remediation completed for PR #200" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" in actions
+    assert "Failed" not in str(actions)
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+def test_start_mergeability_remediation_pr_details_fails(mock_gh_logger):
+    """Verify remediation handles PR details retrieval failure."""
+    # Mock PR details retrieval failure
+    mock_pr_result = Mock()
+    mock_pr_result.success = False
+    mock_pr_result.stderr = "PR not found"
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    actions = _start_mergeability_remediation(201, "UNKNOWN")
+
+    assert any("Starting mergeability remediation for PR #201" in action for action in actions)
+    assert any("Failed to get PR #201 details" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_start_mergeability_remediation_checkout_fails(mock_update, mock_checkout, mock_gh_logger):
+    """Verify remediation handles checkout failure."""
+    # Mock PR details retrieval success
+    mock_pr_result = Mock()
+    mock_pr_result.success = True
+    mock_pr_result.stdout = '{"base": {"ref": "main"}}'
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    # Mock failed checkout
+    mock_checkout.return_value = False
+    mock_update.return_value = []
+
+    actions = _start_mergeability_remediation(202, "CLEAN")
+
+    assert any("Starting mergeability remediation for PR #202" in action for action in actions)
+    assert any("Failed to checkout PR #202 branch" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
+    # Update should not be called when checkout fails
+    mock_update.assert_not_called()
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_start_mergeability_remediation_update_fails(mock_update, mock_checkout, mock_gh_logger):
+    """Verify remediation handles update failure."""
+    # Mock PR details retrieval success
+    mock_pr_result = Mock()
+    mock_pr_result.success = True
+    mock_pr_result.stdout = '{"base": {"ref": "main"}}'
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    # Mock successful checkout but failed update
+    mock_checkout.return_value = True
+    mock_update.return_value = ["Failed to merge: merge conflict resolution failed"]
+
+    actions = _start_mergeability_remediation(203, "UNKNOWN")
+
+    assert any("Starting mergeability remediation for PR #203" in action for action in actions)
+    assert any("Mergeability remediation failed for PR #203" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+@patch("src.auto_coder.pr_processor._checkout_pr_branch")
+@patch("src.auto_coder.pr_processor._update_with_base_branch")
+def test_start_mergeability_remediation_handles_exception(mock_update, mock_checkout, mock_gh_logger):
+    """Verify remediation handles unexpected exceptions."""
+    # Mock PR details retrieval
+    mock_pr_result = Mock()
+    mock_pr_result.success = True
+    mock_pr_result.stdout = '{"base": {"ref": "main"}}'
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    # Make checkout raise an exception
+    mock_checkout.side_effect = RuntimeError("Checkout failed unexpectedly")
+
+    actions = _start_mergeability_remediation(204, "UNKNOWN")
+
+    assert any("Starting mergeability remediation for PR #204" in action for action in actions)
+    assert any("Error during mergeability remediation" in action for action in actions)
+    assert "ACTION_FLAG:SKIP_ANALYSIS" not in actions
+
+
+@patch("src.auto_coder.pr_processor.get_gh_logger")
+def test_start_mergeability_remediation_parses_base_branch_fallback(mock_gh_logger):
+    """Verify remediation falls back to 'main' when JSON parsing fails."""
+    # Mock PR details with invalid JSON response
+    mock_pr_result = Mock()
+    mock_pr_result.success = True
+    mock_pr_result.stdout = "not valid json"
+    mock_gh_logger.return_value.execute_with_logging.return_value = mock_pr_result
+
+    # Mock checkout failure (any failure is fine, we just want to check the fallback)
+    with patch("src.auto_coder.pr_processor._checkout_pr_branch", return_value=False):
+        actions = _start_mergeability_remediation(205, "UNKNOWN")
+
+        # Should have determined base branch as 'main' despite JSON parsing exception
+        assert any("Determined base branch for PR #205: main" in action for action in actions)


### PR DESCRIPTION
Closes #569

Great! I can see that there's already a test file for mergeability remediation. Let me examine the test file to understand what tests have been implemented:

Let me also check the PR processor to understand the implementation of the mergeability remediation:

Now I'll look at the GitHub issue to understand exactly what was requested. Let me check if there's any issue tracking file:

Let me search for any references to issue 569 or mergeability remediation in the codebase:

Based on my analysis of the code, I can see that tests for mergeability remediation have already been implemented in the file `tests/test_pr_mergeability_remediation.py`. Let me complete my understanding by looking at the git history to confirm this issue has been addressed:

Perfect! I can see that issue #569 has already been addressed with commits that mention "Auto-Coder: Address issue #569". Let me look at the specific commit to understand what was done:

Let me check what the actual commit message says for this issue:

Now I have all the information I need. Let me create a concise pull request message for issue #569:

Add tests for mergeability remediation flow

Added comprehensive unit tests for the mergeability remediation functionality, covering successful remediation, failure paths, and edge cases to ensure proper handling of non-mergeable PRs.