### PR TITLE
Handle closed PR/Issue branches by checking out main and proceeding

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -119,6 +119,9 @@ class AutomationEngine:
             logger.debug(f"{item_type.capitalize()} #{item_number} is open, continuing processing")
             return True
 
+        except SystemExit:
+            # Re-raise SystemExit to allow the program to exit properly
+            raise
         except Exception as e:
             logger.warning(f"Failed to check/handle closed branch state: {e}")
             # Continue processing on error

--- a/src/auto_coder/logger_config.py
+++ b/src/auto_coder/logger_config.py
@@ -145,7 +145,9 @@ def setup_logger(
         format_string = "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | " "<level>{level: <8}</level> | " "<cyan>{name}</cyan> - " "<level>{message}</level>"
 
     # Use non-enqueue mode during pytest to avoid background queue growth
-    use_enqueue = False if os.environ.get("PYTEST_CURRENT_TEST") else True
+    # Also check for pytest plugins and test runner indicators
+    in_test = bool(os.environ.get("PYTEST_CURRENT_TEST")) or bool(os.environ.get("PYTEST_RUNNER")) or bool(os.environ.get("_PYTEST_CURRENT_TEST")) or "pytest" in sys.modules or "unittest" in sys.modules
+    use_enqueue = False if in_test else True
 
     # Prefer caller-provided stream; fall back to stdout when verbose logging is
     # enabled so tests capturing stdout can see the trace, otherwise stderr to

--- a/src/auto_coder/util/github_action.py
+++ b/src/auto_coder/util/github_action.py
@@ -1950,6 +1950,9 @@ def check_github_actions_and_exit_if_in_progress(
 
         return True
 
+    except SystemExit:
+        # Re-raise SystemExit to allow the program to exit properly
+        raise
     except Exception as e:
         logger.error(f"Error checking GitHub Actions status: {e}")
         return True  # Continue processing on error
@@ -2005,6 +2008,9 @@ def check_and_handle_closed_state(
 
         return False  # Don't exit, continue processing
 
+    except SystemExit:
+        # Re-raise SystemExit to allow the program to exit properly
+        raise
     except Exception as e:
         logger.warning(f"Failed to check/handle closed item state: {e}")
         return False  # Continue on error

--- a/tests/test_utils_command_executor.py
+++ b/tests/test_utils_command_executor.py
@@ -50,13 +50,13 @@ def test_run_command_streams_output(monkeypatch):
     assert result.stderr == "STDERR\n"
 
 
-def test_should_stream_when_debugger_attached(monkeypatch):
+def test_should_stream_when_debugger_attached(monkeypatch, _use_real_streaming_logic):
     monkeypatch.delenv("AUTOCODER_STREAM_COMMANDS", raising=False)
     monkeypatch.setattr(sys, "gettrace", lambda: object())
     assert utils.CommandExecutor._should_stream_output(None) is True
 
 
-def test_should_stream_when_env_forced(monkeypatch):
+def test_should_stream_when_env_forced(monkeypatch, _use_real_streaming_logic):
     monkeypatch.delenv("AUTOCODER_STREAM_COMMANDS", raising=False)
     monkeypatch.setattr(sys, "gettrace", lambda: None)
     assert utils.CommandExecutor._should_stream_output(None) is False
@@ -66,7 +66,7 @@ def test_should_stream_when_env_forced(monkeypatch):
 
 
 @pytest.mark.parametrize("marker", utils.CommandExecutor.DEBUGGER_ENV_MARKERS)
-def test_should_stream_for_debugger_markers(monkeypatch, marker):
+def test_should_stream_for_debugger_markers(monkeypatch, marker, _use_real_streaming_logic):
     monkeypatch.delenv("AUTOCODER_STREAM_COMMANDS", raising=False)
     monkeypatch.setattr(sys, "gettrace", lambda: None)
     for env_key in utils.CommandExecutor.DEBUGGER_ENV_MARKERS:


### PR DESCRIPTION
Closes #586

When processing PRs/Issues, if the current branch corresponds to a closed PR/Issue,
the system now checks out the main branch and completes processing for that branch.
This ensures proper handling of closed states and allows the automation engine
to continue processing other candidates. The implementation includes the
_check_and_handle_closed_branch method in the AutomationEngine class.