### PR TITLE
I need to understand the changes that were made for issue #637. Let me look at the current state of the CodexClient and ClaudeClient to see what was implemented.

### DIFF
--- a/src/auto_coder/cli_helpers.py
+++ b/src/auto_coder/cli_helpers.py
@@ -425,7 +425,14 @@ def build_backend_manager(
 
     def _create_claude_client(backend_name: str):
         """Create a ClaudeClient."""
-        return ClaudeClient(model_name=models.get(backend_name))
+        # Get the backend config to check if it's an alias
+        backend_config = config.get_backend_config(backend_name)
+        if backend_config and backend_config.backend_type == "claude":
+            # It's an alias with backend_type "claude", pass backend_name
+            return ClaudeClient(model_name=models.get(backend_name), backend_name=backend_name)
+        else:
+            # It's the default claude backend
+            return ClaudeClient(model_name=models.get(backend_name))
 
     def _create_auggie_client(backend_name: str):
         """Create an AuggieClient."""
@@ -433,7 +440,20 @@ def build_backend_manager(
 
     def _create_codex_client(backend_name: str):
         """Create a CodexClient."""
-        return CodexClient(model_name=models.get(backend_name, "codex"))
+        # Get the backend config
+        backend_config = config.get_backend_config(backend_name)
+        if backend_config and backend_config.backend_type == "codex":
+            # It's an alias with backend_type "codex", pass configuration values
+            return CodexClient(
+                model_name=models.get(backend_name, "codex"),
+                api_key=backend_config.api_key,
+                base_url=backend_config.base_url,
+                openai_api_key=backend_config.openai_api_key,
+                openai_base_url=backend_config.openai_base_url,
+            )
+        else:
+            # It's the default codex backend
+            return CodexClient(model_name=models.get(backend_name, "codex"))
 
     def _create_codex_mcp_client(backend_name: str):
         """Create a CodexMCPClient."""

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -1,0 +1,120 @@
+"""
+Tests for Claude client functionality.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.auto_coder.claude_client import ClaudeClient
+
+
+class TestClaudeClient:
+    """Test cases for ClaudeClient class."""
+
+    @patch("subprocess.run")
+    def test_init_checks_cli(self, mock_run):
+        """ClaudeClient should check claude --version at init."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient()
+        assert client.model_name == "sonnet"
+
+    @patch("subprocess.run")
+    def test_init_with_model_name(self, mock_run):
+        """ClaudeClient should use provided model name."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient(model_name="opus")
+        assert client.model_name == "opus"
+        assert client.conflict_model == "sonnet"
+
+    @patch("subprocess.run")
+    def test_init_with_backend_name(self, mock_run):
+        """ClaudeClient should use config for provided backend name."""
+        mock_run.return_value.returncode = 0
+
+        # Mock the config
+        mock_config = MagicMock()
+        mock_backend_config = MagicMock()
+        mock_backend_config.model = "custom-sonnet"
+        mock_config.get_backend_config.return_value = mock_backend_config
+
+        with patch("src.auto_coder.claude_client.get_llm_config", return_value=mock_config):
+            client = ClaudeClient(backend_name="custom-claude")
+            assert client.model_name == "custom-sonnet"
+
+    @patch("subprocess.run")
+    def test_init_prefers_model_name_over_backend_name(self, mock_run):
+        """ClaudeClient should prefer model_name over backend_name config."""
+        mock_run.return_value.returncode = 0
+
+        # Mock the config
+        mock_config = MagicMock()
+        mock_backend_config = MagicMock()
+        mock_backend_config.model = "config-model"
+        mock_config.get_backend_config.return_value = mock_backend_config
+
+        with patch("src.auto_coder.claude_client.get_llm_config", return_value=mock_config):
+            client = ClaudeClient(model_name="explicit-model", backend_name="custom-claude")
+            assert client.model_name == "explicit-model"
+
+    @patch("subprocess.run")
+    def test_init_falls_back_to_default_claude_config(self, mock_run):
+        """ClaudeClient should fall back to default claude config when no backend_name."""
+        mock_run.return_value.returncode = 0
+
+        # Mock the config
+        mock_config = MagicMock()
+        mock_backend_config = MagicMock()
+        mock_backend_config.model = "default-model"
+        mock_config.get_backend_config.return_value = mock_backend_config
+
+        with patch("src.auto_coder.claude_client.get_llm_config", return_value=mock_config):
+            client = ClaudeClient()
+            # Should use "claude" backend config
+            mock_config.get_backend_config.assert_called_with("claude")
+            assert client.model_name == "default-model"
+
+    @patch("subprocess.run")
+    def test_switch_to_conflict_model(self, mock_run):
+        """ClaudeClient should switch to conflict model."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient(model_name="opus")
+
+        # Default should be opus
+        assert client.model_name == "opus"
+
+        # Switch to conflict model (sonnet)
+        client.switch_to_conflict_model()
+        assert client.model_name == "sonnet"
+
+    @patch("subprocess.run")
+    def test_switch_back_to_default_model(self, mock_run):
+        """ClaudeClient should switch back to default model."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient(model_name="opus")
+
+        # Switch to conflict model
+        client.switch_to_conflict_model()
+        assert client.model_name == "sonnet"
+
+        # Switch back to default
+        client.switch_to_default_model()
+        assert client.model_name == "opus"
+
+    @patch("subprocess.run")
+    def test_escape_prompt(self, mock_run):
+        """ClaudeClient should escape @ in prompts."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient()
+
+        escaped = client._escape_prompt("Hello @world")
+        assert escaped == "Hello \\@world"
+
+    @patch("subprocess.run")
+    def test_escape_prompt_trims_whitespace(self, mock_run):
+        """ClaudeClient should trim whitespace from prompts."""
+        mock_run.return_value.returncode = 0
+        client = ClaudeClient()
+
+        escaped = client._escape_prompt("  Hello world  ")
+        assert escaped == "Hello world"


### PR DESCRIPTION
Closes #637

Now let me check if there's a ClaudeClient file that also needs to be modified:

Let me read the ClaudeClient file:

Based on the issue description and the code I've seen, I need to create a pull request message that reflects the changes made to support aliases and configuration for both CodexClient and ClaudeClient. Let me check the issue description again to understand what was supposed to be done.

From the issue description, I can see that:
1. The CodexClient was modified to accept optional parameters: `api_key`, `base_url`, `openai_api_key`, `openai_base_url`
2. The ClaudeClient should also be enhanced to support aliases and configuration

Looking at the CodexClient code, I can see these changes are already implemented. Now I need to check if the ClaudeClient was also updated properly.

Looking at ClaudeClient, I can see it already supports backend_name parameter for configuration lookup, but it doesn't have the same configuration parameter support as CodexClient. Let me check if the changes were made to ClaudeClient as well. I notice that there are no additional parameters like `api_key`, `base_url`, etc., in the ClaudeClient's `__init__` method. Let me see if I need to update it.

Based on the issue description, both CodexClient and ClaudeClient should be enhanced. From the partial task description, it seems like both should accept configuration values directly or accept the specific backend name to look up, not hardcode the configuration section.

Let me create the pull request message based on what I see in the code:

Enhance CodexClient and ClaudeClient to support Aliases and Configuration

Updated both client classes to accept custom configuration parameters like API keys
and base URLs directly, allowing for flexible backend aliasing and configuration
without hardcoding specific configuration sections. This enables custom backends
like [grok-4.1-fast] with backend_type="codex" or [MiniMax-M2] with backend_type="claude".

Wait, I need to verify if ClaudeClient was actually updated as mentioned in the issue. Looking at the ClaudeClient code, I only see it accepts `model_name` and `backend_name` parameters, but I don't see it accepting configuration values like `api_key`, `base_url` etc. like the CodexClient does. This suggests that the ClaudeClient might not have been fully updated.

The issue description says both clients should be enhanced, but from what I can see, only the CodexClient was updated with additional configuration parameters. Let me check if there are any recent changes that might have been made to ClaudeClient that I'm not seeing in the current file.

Based on the information provided in the issue description summary, it states that changes were made to both clients, but from the code I can see, only CodexClient has been enhanced with the additional configuration parameters. I'll focus on what I can see in the current code for the pull request message.

The actual changes I can see are:
1. CodexClient was modified to accept optional parameters: `api_key`, `base_url`, `openai_api_key`, `openai_base_url`
2. Updated `_run_llm_cli` to inject these configuration values as environment variables into the subprocess

For ClaudeClient, it already had support for `backend_name` parameter to look up configurations, but doesn't seem to have the additional configuration parameters like CodexClient does. The issue might be partially complete.

Let me provide a pull request message based on the actual visible changes:

Enhance CodexClient to support custom backend configuration

Updated CodexClient to accept optional configuration parameters (api_key, base_url,
openai_api_key, openai_base_url) allowing for flexible backend aliasing and custom
backend support. Configuration values are now injected as environment variables
into the subprocess, enabling aliases like [grok-4.1-fast] with backend_type="codex".