### PR TITLE
Update Documentation for Qwen OpenRouter Configuration

### DIFF
--- a/OPENROUTER_SETUP.md
+++ b/OPENROUTER_SETUP.md
@@ -1,102 +1,217 @@
 # OpenRouter Setup Guide
 
 ## Overview
-Configuration has been completed to use Qwen3 Coder via OpenRouter with the Codex CLI.
+
+OpenRouter provides access to various AI models through a unified OpenAI-compatible API. This guide explains how to configure Auto-Coder to use Qwen and other models via OpenRouter.
+
+**Key Point:** When using OpenRouter with Auto-Coder, configure your backend with `backend_type = "codex"` to use the OpenAI-compatible client.
+
+## Quick Start
+
+### 1. Get OpenRouter API Key
+
+1. Sign up at [OpenRouter.ai](https://openrouter.ai/)
+2. Navigate to the [Keys page](https://openrouter.ai/keys)
+3. Create a new API key
+
+### 2. Configure Auto-Coder
+
+Create or update `~/.auto-coder/llm_config.toml`:
+
+```toml
+[backend]
+default = "qwen-openrouter"
+order = ["qwen-openrouter", "codex", "gemini"]
+
+[backends.qwen-openrouter]
+enabled = true
+model = "qwen/qwen3-coder:free"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+
+# Optional: Add custom headers for tracking
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
+```
+
+### 3. Verify Configuration
+
+```bash
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter --dry-run
+```
 
 ## Configuration Details
 
-### 1. Environment Variables
-The following environment variables have been added to `~/.bashrc`:
+### Backend Configuration
 
-```bash
-export OPENAI_API_KEY="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"
-export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
-export OPENAI_MODEL="qwen/qwen3-coder:free"
-```
-
-### 2. Codex Configuration File (~/.codex/config.toml)
-The following configuration has been added:
+The key is setting `backend_type = "codex"` to use Auto-Coder's OpenAI-compatible client:
 
 ```toml
+[backends.qwen-openrouter]
+enabled = true
 model = "qwen/qwen3-coder:free"
-model_provider = "openrouter"
-
-# OpenRouter configuration
-[model_providers.openrouter]
-name = "OpenRouter"
-base_url = "https://openrouter.ai/api/v1"
-env_key = "OPENAI_API_KEY"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
 ```
 
-## Usage
+### Important Parameters
 
-### Enable Environment Variables in Current Session
+- **`backend_type = "codex"`**: Use OpenAI-compatible client (required for OpenRouter)
+- **`openai_api_key`**: Your OpenRouter API key
+- **`openai_base_url`**: Must be `https://openrouter.ai/api/v1`
+- **`model`**: OpenRouter model identifier (e.g., `qwen/qwen3-coder:free`)
+
+### Available Qwen Models on OpenRouter
+
+Common Qwen models available through OpenRouter:
+
+- `qwen/qwen3-coder:free` - Free tier Qwen 3 Coder
+- `qwen/qwen-2.5-coder-32k-instruct` - Qwen 2.5 Coder (32K context)
+- `qwen/qwen-2.5-coder-72b-instruct` - Qwen 2.5 Coder (72B parameters)
+- `qwen/qwen-2.5-plus` - Qwen 2.5 Plus (general purpose)
+
+Visit [OpenRouter Models](https://openrouter.ai/models) for the complete list and pricing.
+
+## Multiple Provider Configuration
+
+You can configure multiple OpenRouter backends with different models:
+
+```toml
+[backends.qwen-openrouter-free]
+enabled = true
+model = "qwen/qwen3-coder:free"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+
+[backends.qwen-openrouter-plus]
+enabled = true
+model = "qwen/qwen-2.5-plus"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+
+[backend]
+order = ["qwen-openrouter-free", "qwen-openrouter-plus", "gemini"]
+default = "qwen-openrouter-free"
+```
+
+## Custom Headers (Optional)
+
+OpenRouter supports custom headers for tracking usage:
+
+```toml
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
+```
+
+These are passed to the OpenAI-compatible API to help identify your application.
+
+## Environment Variable Configuration
+
+Alternatively, you can use environment variables:
+
 ```bash
-source ~/.bashrc
+export AUTO_CODER_OPENAI_API_KEY="sk-or-v1-your-key-here"
+export AUTO_CODER_OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 ```
 
-Or
+## Usage Examples
+
+### Process Issues with Qwen via OpenRouter
 
 ```bash
-export OPENAI_API_KEY="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"
-export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
-export OPENAI_MODEL="qwen/qwen3-coder:free"
+# Use specific OpenRouter backend
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter
+
+# Use backend order
+auto-coder process-issues --repo owner/repo
 ```
 
-### Running Codex CLI
-With the configuration complete, you can now use Codex normally:
+### Feature Suggestion with OpenRouter
 
 ```bash
-codex "Hello, how are you?"
+auto-coder create-feature-issues --repo owner/repo --backend qwen-openrouter
 ```
 
-Or
+### Fix Issues with OpenRouter
 
 ```bash
-codex exec "Write a Python function to calculate fibonacci numbers"
+auto-coder fix-to-pass-tests --target-repository owner/repo --backend qwen-openrouter
 ```
-
-## Verifying Configuration
-
-### Verify Environment Variables
-```bash
-env | grep OPENAI
-```
-
-### Verify Codex Configuration
-```bash
-cat ~/.codex/config.toml
-```
-
-### Verify Codex Version
-```bash
-codex --version
-```
-
-## Backup
-The original configuration file has been backed up at:
-- `~/.codex/config.toml.backup`
 
 ## Troubleshooting
 
-### If Configuration Is Not Applied
-1. Open a new terminal session
-2. Or run `source ~/.bashrc`
+### "Invalid API key" Error
 
-### To Change Model Provider
-Edit the following line in `~/.codex/config.toml`:
-```toml
-model_provider = "openrouter"  # Can be changed to other providers
+1. Verify your OpenRouter API key is correct
+2. Ensure the key hasn't expired
+3. Check your OpenRouter account has sufficient credits
+
+### "Model not found" Error
+
+1. Verify the model name is correct
+2. Check the model is available on OpenRouter
+3. Ensure your API key has access to the model (some models require special access)
+
+### Rate Limit Errors
+
+OpenRouter has rate limits depending on your plan:
+
+- **Free tier**: Limited requests per minute/day
+- **Paid tier**: Higher limits available
+
+If you hit rate limits:
+- Wait before retrying
+- Use a free model like `qwen/qwen3-coder:free` for testing
+- Consider upgrading your OpenRouter plan
+
+### "Invalid base URL" Error
+
+Ensure `openai_base_url` is set to exactly:
+```
+https://openrouter.ai/api/v1
 ```
 
-### To Use Different Model
-Edit the following line in `~/.codex/config.toml`:
-```toml
-model = "qwen/qwen3-coder:free"  # Can be changed to other OpenRouter models
-```
+## Migration from Codex Fallback
 
-## Reference Links
-- [Codex CLI Configuration Documentation](https://developers.openai.com/codex/local-config/)
+**Previous behavior:**
+- QwenClient had an internal Codex fallback mechanism
+
+**Current behavior:**
+- Must explicitly configure OpenRouter backends with `backend_type = "codex"`
+- No automatic fallback between backend types
+
+**Migration steps:**
+1. Get your OpenRouter API key
+2. Create a backend configuration with `backend_type = "codex"`
+3. Remove any reliance on automatic fallback behavior
+4. Test with your new configuration
+
+## Comparison: Qwen CLI vs OpenRouter
+
+| Feature | Qwen CLI (OAuth) | OpenRouter |
+|---------|------------------|------------|
+| Setup | Requires Qwen CLI auth | Requires API key only |
+| Model Access | Limited to Qwen CLI models | Access to all OpenRouter models |
+| Pricing | Varies by provider | Transparent per-model pricing |
+| Integration | Native CLI tool | OpenAI-compatible API |
+| Setup Complexity | Moderate | Simple |
+| Rate Limits | Provider-specific | OpenRouter's limits |
+
+## Additional Resources
+
+- [OpenRouter Website](https://openrouter.ai/)
 - [OpenRouter Models](https://openrouter.ai/models)
-- [Codex GitHub Repository](https://github.com/openai/codex)
+- [OpenRouter API Documentation](https://openrouter.ai/docs)
+- [Qwen Configuration Guide](QWEN.md)
+- [LLM Backend Configuration](docs/llm_backend_config.example.toml)
 
+## Best Practices
+
+1. **Use environment variables** for API keys in production
+2. **Start with free models** for testing (`qwen/qwen3-coder:free`)
+3. **Monitor your usage** through the OpenRouter dashboard
+4. **Configure multiple backends** for fallback options
+5. **Set appropriate rate limits** in your OpenRouter account settings
+6. **Use custom headers** for better tracking and billing attribution

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,285 @@
+# Qwen Configuration Guide
+
+This guide explains how to configure Qwen for use with Auto-Coder. There are two primary configuration methods:
+
+1. **Qwen CLI (OAuth)** - Native Qwen CLI authentication
+2. **OpenAI-Compatible Providers** - Using Qwen models through providers like OpenRouter, Azure OpenAI, etc.
+
+## Quick Start
+
+### Option 1: Qwen CLI (OAuth) - Direct Qwen Usage
+
+Configure using `backend_type = "qwen"`:
+
+```toml
+[backends.qwen]
+enabled = true
+model = "qwen3-coder-plus"
+backend_type = "qwen"
+
+# No API keys needed - uses OAuth
+```
+
+### Option 2: OpenRouter (Recommended) - Qwen via OpenAI-Compatible API
+
+Configure using `backend_type = "codex"`:
+
+```toml
+[backends.qwen-openrouter]
+enabled = true
+model = "qwen/qwen3-coder:free"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+```
+
+## Configuration Details
+
+### Method 1: Qwen CLI (OAuth)
+
+This method uses the native Qwen CLI with OAuth authentication. No API keys are required.
+
+#### Advantages:
+- Simple setup - no API keys to manage
+- Native Qwen CLI experience
+- Direct integration with Qwen services
+
+#### Setup:
+1. Install and authenticate the Qwen CLI
+2. Configure Auto-Coder with `backend_type = "qwen"`
+
+```toml
+[backends.qwen]
+enabled = true
+model = "qwen3-coder-plus"
+backend_type = "qwen"
+```
+
+#### Usage:
+```bash
+auto-coder process-issues --repo owner/repo --backend qwen
+```
+
+### Method 2: OpenAI-Compatible Providers (OpenRouter, Azure, etc.)
+
+This method uses OpenAI-compatible API endpoints to access Qwen models through providers like OpenRouter, Azure OpenAI, or compatible services.
+
+#### Advantages:
+- Access to multiple Qwen model variants
+- Unified OpenAI-compatible interface
+- Better rate limiting and availability
+
+#### Setup:
+
+**For OpenRouter:**
+
+```toml
+[backends.qwen-openrouter]
+enabled = true
+model = "qwen/qwen3-coder:free"
+openai_api_key = "sk-or-v1-your-openrouter-key"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+
+# Optional: Add custom headers
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
+```
+
+**For Azure OpenAI:**
+
+```toml
+[backends.qwen-azure]
+enabled = true
+model = "qwen-35-coder"
+openai_api_key = "your-azure-openai-key"
+openai_base_url = "https://your-resource.openai.azure.com"
+backend_type = "codex"
+
+# Azure-specific options
+options = ["-o", "api_version", "2024-02-01"]
+```
+
+**For Custom OpenAI-Compatible Endpoint:**
+
+```toml
+[backends.qwen-custom]
+enabled = true
+model = "qwen-2.5-coder-32k-instruct"
+openai_api_key = "your-api-key"
+openai_base_url = "https://api.example.com/v1"
+backend_type = "codex"
+```
+
+#### Usage:
+```bash
+# Use with backend name
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter
+
+# Or add to backend order
+[backend]
+order = ["qwen-openrouter", "gemini", "codex"]
+default = "qwen-openrouter"
+```
+
+## Key Configuration Parameters
+
+### `backend_type`
+- `"qwen"`: Use native Qwen CLI (OAuth) - for direct Qwen usage
+- `"codex"`: Use OpenAI-compatible client (API keys required) - for providers like OpenRouter
+
+### `openai_api_key`
+- API key for your provider (OpenRouter, Azure, etc.)
+- Required when `backend_type = "codex"`
+
+### `openai_base_url`
+- Provider's API endpoint URL
+- Examples:
+  - OpenRouter: `https://openrouter.ai/api/v1`
+  - Azure: `https://your-resource.openai.azure.com`
+  - Custom: `https://api.example.com/v1`
+
+### `model`
+- Model name to use
+- Examples:
+  - OpenRouter: `qwen/qwen3-coder:free`, `qwen/qwen-2.5-coder-32k-instruct`
+  - Qwen CLI: `qwen3-coder-plus`
+
+## Complete Configuration Example
+
+Here's a complete `llm_config.toml` example with both Qwen configurations:
+
+```toml
+[backend]
+default = "qwen-openrouter"
+order = ["qwen-openrouter", "qwen", "gemini", "codex"]
+
+[backends.qwen-openrouter]
+enabled = true
+model = "qwen/qwen3-coder:free"
+openai_api_key = "sk-or-v1-your-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+backend_type = "codex"
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
+
+[backends.qwen]
+enabled = true
+model = "qwen3-coder-plus"
+backend_type = "qwen"
+
+[backends.gemini]
+enabled = true
+model = "gemini-2.5-pro"
+api_key = "your-gemini-api-key"
+backend_type = "gemini"
+
+[backends.codex]
+enabled = true
+model = "codex"
+backend_type = "codex"
+```
+
+## Environment Variables
+
+You can override configuration with environment variables:
+
+```bash
+# Global fallback
+export AUTO_CODER_OPENAI_API_KEY="sk-or-v1-your-key"
+export AUTO_CODER_OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+
+# Backend-specific
+export AUTO_CODER_QWEN_OPENAI_API_KEY="sk-or-v1-your-key"
+export AUTO_CODER_QWEN_OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+```
+
+## Credential Passing Options
+
+Qwen backends support two methods for passing credentials:
+
+### 1. Environment Variables (Default)
+
+Credentials are passed via environment variables:
+```bash
+export OPENAI_API_KEY="sk-xxx"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export OPENAI_MODEL="qwen/qwen3-coder:free"
+```
+
+### 2. Command-Line Options
+
+Credentials are passed directly to the CLI:
+```bash
+qwen --api-key sk-xxx --base-url https://openrouter.ai/api/v1 -m qwen/qwen3-coder:free -p "prompt"
+```
+
+**Switch between methods:**
+```bash
+# Use environment variables (default)
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter
+
+# Use command-line options
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter --qwen-use-cli-options
+```
+
+**Environment variable management:**
+```bash
+# Clear existing environment variables (default)
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter
+
+# Preserve existing environment variables
+auto-coder process-issues --repo owner/repo --backend qwen-openrouter --qwen-preserve-env
+```
+
+## Which Method to Choose?
+
+| Use Case | Recommended Method | `backend_type` |
+|----------|-------------------|----------------|
+| Direct Qwen CLI access | Qwen CLI (OAuth) | `"qwen"` |
+| OpenRouter access | OpenAI-Compatible | `"codex"` |
+| Azure OpenAI | OpenAI-Compatible | `"codex"` |
+| Custom OpenAI-compatible endpoint | OpenAI-Compatible | `"codex"` |
+| Multiple provider options | OpenAI-Compatible | `"codex"` |
+
+## Troubleshooting
+
+### "qwen CLI not available" Error
+- Install and authenticate the Qwen CLI
+- Ensure Qwen CLI is in your PATH
+- Verify with: `qwen --version`
+
+### "Backend type 'qwen' not supported" Error
+- Check that `backend_type` is set correctly
+- For Qwen CLI: `backend_type = "qwen"`
+- For OpenAI-compatible: `backend_type = "codex"`
+
+### Authentication Errors with OpenRouter/Azure
+- Verify your API key is correct
+- Check the base URL format
+- Ensure the model name is valid for your provider
+- Verify the API key has sufficient permissions
+
+### Rate Limit Errors
+- Provider-specific rate limits apply
+- Consider switching to a different model or provider
+- Configure retry settings in your backend
+
+## Migration from Old Configuration
+
+If you have an existing configuration, here's what changed:
+
+**Old behavior:**
+- QwenClient could fall back to Codex internally
+- Single configuration method
+
+**New behavior:**
+- Must explicitly choose between:
+  - `backend_type = "qwen"` for Qwen CLI
+  - `backend_type = "codex"` for OpenAI-compatible providers
+- No automatic fallback between different backend types
+
+## Additional Resources
+
+- [LLM Backend Configuration Reference](docs/llm_backend_config.example.toml)
+- [OpenRouter Setup Guide](OPENROUTER_SETUP.md)
+- [Qwen Credential Options](docs/qwen-credentials-options.md)
+- [Backend Manager Documentation](GLOBAL_BACKEND_MANAGER_USAGE.md)

--- a/docs/llm_backend_config.example.toml
+++ b/docs/llm_backend_config.example.toml
@@ -6,37 +6,57 @@
 
 [backend]
 # Default backend to use when multiple are available
-default = "qwen"
+default = "qwen-openrouter"
 
 # Order of backends to try (only enabled backends will be used)
-order = ["qwen", "gemini", "codex", "claude"]
+order = ["qwen-openrouter", "qwen", "gemini", "codex", "claude"]
 
 [message_backend]
 # Separate configuration for message generation (commit messages, PR descriptions)
 # If not specified, falls back to general backend configuration
-default = "qwen"
-order = ["qwen", "gemini"]
+default = "qwen-openrouter"
+order = ["qwen-openrouter", "qwen", "gemini"]
 
 [backends]
 
-# Qwen Configuration
-# ------------------
+# Qwen Configuration - Two Methods
+# =================================
+
+# Method 1: Qwen CLI (OAuth) - Direct Qwen Usage
+# ----------------------------------------------
+# Use backend_type = "qwen" for native Qwen CLI authentication
 [qwen]
 enabled = true
 model = "qwen3-coder-plus"
 
-# OpenAI-compatible API settings (for qwen via codex CLI)
-openai_api_key = "your-qwen-api-key-here"
-openai_base_url = "https://api.qwen.com/v1"
+# No API keys needed - uses OAuth with Qwen CLI
+# Note: This requires Qwen CLI to be installed and authenticated
+
+# Backend type identifier - "qwen" for native CLI
+backend_type = "qwen"
 
 # Additional options to pass to the Qwen CLI
-# These options will be added to the command line when calling qwen or codex
+# These options will be added to the command line when calling qwen
 # Example: ["-o", "stream", "false", "--debug"]
 options = []
 
-# Backend type identifier (can be used for aliases)
-# This allows creating custom names that map to underlying backend types
-backend_type = "qwen"
+
+# Method 2: Qwen via OpenRouter (OpenAI-Compatible API)
+# -----------------------------------------------------
+# Use backend_type = "codex" for OpenAI-compatible providers
+[qwen-openrouter]
+enabled = true
+model = "qwen/qwen3-coder:free"
+
+# OpenAI-compatible API settings (required for OpenRouter, Azure, etc.)
+openai_api_key = "sk-or-v1-your-openrouter-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
+
+# Backend type identifier - "codex" for OpenAI-compatible client
+backend_type = "codex"
+
+# Optional: Add custom headers for tracking usage
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
 
 # Gemini Configuration
 # --------------------
@@ -68,73 +88,142 @@ model = "codex"
 options = []
 backend_type = "codex"
 
-# Custom Alias Example
+# Custom Alias Examples
 # --------------------
 # You can create custom aliases that point to underlying backend types
 # This allows you to have multiple configurations for the same backend
+
+# Example 1: Qwen via OpenRouter with faster model
 [qwen-fast]
 enabled = true
-model = "qwen-turbo"
-openai_api_key = "your-qwen-api-key-here"
-openai_base_url = "https://api.qwen.com/v1"
+model = "qwen/qwen-2.5-plus"
+openai_api_key = "sk-or-v1-your-openrouter-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
 
-# Use 'qwen' backend type but with different options
-backend_type = "qwen"
+# Use 'codex' backend type (OpenAI-compatible)
+backend_type = "codex"
 
-# Custom options for this alias (e.g., faster model, different settings)
+# Custom options for faster responses
 options = ["-o", "timeout", "30", "-o", "stream", "true"]
 
-[qwen-debug]
+
+# Example 2: Qwen via OpenRouter with premium model
+[qwen-premium]
 enabled = true
-model = "qwen3-coder-plus"
-openai_api_key = "your-qwen-api-key-here"
-openai_base_url = "https://api.qwen.com/v1"
+model = "qwen/qwen-2.5-coder-72b-instruct"
+openai_api_key = "sk-or-v1-your-openrouter-key-here"
+openai_base_url = "https://openrouter.ai/api/v1"
 
-# Use 'qwen' backend type with debug options
-backend_type = "qwen"
+# Use 'codex' backend type (OpenAI-compatible)
+backend_type = "codex"
 
-# Debug-specific options
-options = ["--verbose", "--debug", "-o", "output_format", "json"]
+# Premium model with additional options
+options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
 
-# Azure OpenAI Configuration Example
-# ----------------------------------
-# This example shows how to configure qwen with Azure OpenAI endpoint
+
+# Example 3: Azure OpenAI with Qwen model
 [qwen-azure]
 enabled = false  # Set to true if using Azure
 model = "qwen-35-coder"
 openai_api_key = "your-azure-openai-key"
 openai_base_url = "https://your-resource.openai.azure.com"
 
+# Use 'codex' backend type for Azure OpenAI
+backend_type = "codex"
+
 # Azure-specific options
-backend_type = "qwen"
 options = ["-o", "api_version", "2024-02-01"]
 
-# OpenRouter Configuration Example
-# --------------------------------
-# Example using OpenRouter as a provider for qwen
-[qwen-openrouter]
-enabled = false  # Set to true if using OpenRouter
-model = "qwen/qwen-2.5-coder-32k-instruct"
-openai_api_key = "sk-or-v1-your-key-here"
-openai_base_url = "https://openrouter.ai/api/v1"
 
-# OpenRouter-specific options
-backend_type = "qwen"
-options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
+# Example 4: Custom OpenAI-compatible endpoint
+[qwen-custom]
+enabled = false  # Set to true if using custom endpoint
+model = "qwen-2.5-coder-32k-instruct"
+openai_api_key = "your-custom-endpoint-key"
+openai_base_url = "https://api.example.com/v1"
 
-# Notes:
-# ------
-# 1. The `options` field is primarily used by the qwen backend to pass
-#    command-line arguments to the qwen or codex CLI tools.
+# Use 'codex' backend type for OpenAI-compatible providers
+backend_type = "codex"
+
+# Additional Backend Examples (Non-Qwen)
+# ======================================
+
+[gemini]
+enabled = true
+model = "gemini-2.5-pro"
+
+# Gemini API settings
+api_key = "your-gemini-api-key-here"
+base_url = "https://generativelanguage.googleapis.com"
+
+# Optional retry configuration for usage limits
+usage_limit_retry_count = 3
+usage_limit_retry_wait_seconds = 30
+# Rotate to the next backend after every successful call to stay under strict execution limits
+always_switch_after_execution = true
+
+# Gemini doesn't support custom options in the same way as qwen/codex
+# Options field is mainly used for qwen/codex backends
+options = []
+backend_type = "gemini"
+
+[codex]
+enabled = true
+model = "codex"
+# Codex typically doesn't need API keys as it's handled by providers
+options = []
+backend_type = "codex"
+
+# Notes and Best Practices
+# ========================
+
+# IMPORTANT: backend_type Configuration
+# ---------------------------------------
+# The `backend_type` field is crucial for proper configuration:
 #
-# 2. The `backend_type` field allows you to create custom aliases that
-#    map to underlying backend implementations. This is useful when you
-#    want multiple configurations for the same backend type.
+# 1. "qwen" - Use native Qwen CLI (OAuth authentication)
+#    - No API keys required
+#    - Requires Qwen CLI installation and authentication
+#    - Limited to models available through Qwen CLI
 #
-# 3. Only the qwen backend currently utilizes the `options` field in its
+# 2. "codex" - Use OpenAI-compatible client (API keys required)
+#    - Required for OpenRouter, Azure OpenAI, and similar providers
+#    - Requires openai_api_key and openai_base_url
+#    - Access to all models offered by the provider
+#
+# 3. "gemini" - Use Gemini client
+#    - Requires api_key and base_url
+#    - Direct Google API integration
+#
+# 4. "claude" - Use Claude client
+#    - Anthropic API integration
+#
+# 5. "codex" (for default codex backend) - Use Codex client
+#    - Default OpenAI Codex integration
+
+# Backend Aliases
+# ---------------
+# You can create multiple configurations for the same backend type by using
+# different backend names with the same backend_type. This is useful for:
+# - Using multiple models from the same provider
+# - Different configurations for different use cases
+# - Fallback configurations with different models
+
+# Configuration Inheritance and Options
+# -------------------------------------
+# 1. The `options` field is primarily used by qwen/codex backends to pass
+#    command-line arguments to the CLI tools.
+#
+# 2. Only qwen and codex backends currently utilize the `options` field in their
 #    subprocess calls. Other backends may ignore this field.
 #
-# 4. Environment variables can override configuration values:
+# 3. The `backend_type` field allows you to create custom aliases that
+#    map to underlying backend implementations. This is useful when you
+#    want multiple configurations for the same backend type.
+
+# Environment Variables
+# --------------------
+# Environment variables can override configuration values:
 #    - AUTO_CODER_DEFAULT_BACKEND
 #    - AUTO_CODER_MESSAGE_DEFAULT_BACKEND
 #    - AUTO_CODER_<BACKEND>_API_KEY (e.g., AUTO_CODER_GEMINI_API_KEY)
@@ -142,6 +231,17 @@ options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Cod
 #    - AUTO_CODER_<BACKEND>_OPENAI_API_KEY (e.g., AUTO_CODER_QWEN_OPENAI_API_KEY)
 #    - AUTO_CODER_OPENAI_BASE_URL (global fallback)
 #    - AUTO_CODER_<BACKEND>_OPENAI_BASE_URL
+
+# Provider-Specific Configurations
+# --------------------------------
+# 1. OpenAI-compatible providers (OpenRouter, Azure OpenAI, custom endpoints)
+#    should use:
+#    - openai_api_key
+#    - openai_base_url
+#    - backend_type = "codex"
 #
-# 5. Provider-specific configurations (like Azure OpenAI or OpenRouter)
-#    should use the openai_api_key and openai_base_url fields.
+# 2. Native providers (Gemini, Claude)
+#    should use:
+#    - api_key
+#    - base_url
+#    - backend_type matching the provider name


### PR DESCRIPTION
Closes #639

This commit updates the Qwen configuration documentation to explain how to properly configure Qwen OpenRouter and similar providers using the new `backend_type = "codex"` setting, following the removal of internal Codex fallback in QwenClient. The documentation now clearly distinguishes between Qwen CLI (OAuth) and OpenAI-compatible providers.