### PR TITLE
Implement model flag support in CodexClient

### DIFF
--- a/src/auto_coder/codex_client.py
+++ b/src/auto_coder/codex_client.py
@@ -105,8 +105,13 @@ class CodexClient(LLMClientBase):
                 "-s",
                 "workspace-write",
                 "--dangerously-bypass-approvals-and-sandbox",
-                escaped_prompt,
             ]
+
+            # Add --model flag if model_name is specified
+            if self.model_name:
+                cmd.extend(["--model", self.model_name])
+
+            cmd.append(escaped_prompt)
 
             usage_markers = (
                 "rate limit",


### PR DESCRIPTION
Closes #673

Modified the _run_llm_cli method to pass the --model flag to the codex exec
command when self.model_name is available, enabling proper model selection.