### PR TITLE
Update documentation for lock mechanism context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,26 @@ Auto-Coder includes a lock mechanism to prevent concurrent executions that could
 - The lock is automatically released when the command completes
 - Lock files are stored in the `.git` directory of your repository
 
+**For Developers:**
+The `LockManager` class supports Python's context manager protocol for safe lock management:
+```python
+from auto_coder.lock_manager import LockManager
+
+# Recommended: Using context manager (automatic cleanup)
+with LockManager() as lock:
+    # Lock is automatically acquired here
+    do_work()
+# Lock is automatically released here, even if an exception occurs
+
+# Alternative: Manual management
+lock = LockManager()
+if lock.acquire():
+    try:
+        do_work()
+    finally:
+        lock.release()
+```
+
 **Manual Lock Control:**
 
 ```bash

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -199,6 +199,31 @@ This fork maintains full attribution to the original author Riley Lemm. The orig
       - "Lock information includes PID, hostname, and start time"
       - "Automatically detects stale locks (process no longer running)"
       - "Lock is released when command completes successfully"
+      - "Supports context manager protocol for safe lock acquisition and release"
+    usage_patterns:
+      context_manager:
+        description: "Recommended pattern using Python's with statement"
+        example: |
+          with LockManager() as lock:
+              # Lock is automatically acquired here
+              do_work()
+          # Lock is automatically released here, even if an exception occurs
+        benefits:
+          - "Automatic cleanup even on exceptions"
+          - "More Pythonic and readable code"
+          - "Prevents accidental lock leaks"
+      manual_management:
+        description: "Explicit acquire/release pattern"
+        example: |
+          lock = LockManager()
+          if lock.acquire():
+              try:
+                  do_work()
+              finally:
+                  lock.release()
+        use_cases:
+          - "Complex control flow requiring early release"
+          - "Legacy code compatibility"
     commands:
       auto_lock:
         description: "Lock is automatically acquired by default for all commands"

--- a/src/auto_coder/lock_manager.py
+++ b/src/auto_coder/lock_manager.py
@@ -38,7 +38,25 @@ class LockInfo:
 
 
 class LockManager:
-    """Manages lock files to prevent concurrent auto-coder executions."""
+    """Manages lock files to prevent concurrent auto-coder executions.
+
+    This class can be used either with explicit acquire/release calls or as a context manager.
+
+    Examples:
+        Using as a context manager (recommended):
+        >>> with LockManager() as lock:
+        ...     # Lock is automatically acquired here
+        ...     do_work()
+        ... # Lock is automatically released here, even if an exception occurs
+
+        Using explicit acquire/release:
+        >>> lock = LockManager()
+        >>> if lock.acquire():
+        ...     try:
+        ...         do_work()
+        ...     finally:
+        ...         lock.release()
+    """
 
     def __init__(self):
         self.lock_file_path = self._get_lock_file_path()
@@ -71,6 +89,10 @@ class LockManager:
 
     def acquire_lock(self, force: bool = False) -> bool:
         """Acquire a lock.
+
+        This method is called automatically when using LockManager as a context manager.
+        For manual lock management, call this method explicitly and ensure release_lock()
+        is called in a finally block.
 
         Args:
             force: If True, forcibly overwrite existing lock
@@ -111,7 +133,11 @@ class LockManager:
         return self.lock_file_path.exists()
 
     def release_lock(self) -> None:
-        """Remove the lock file."""
+        """Remove the lock file.
+
+        This method is called automatically when using LockManager as a context manager.
+        For manual lock management, ensure this is called in a finally block.
+        """
         if self.lock_file_path is None:
             return
         try:
@@ -176,7 +202,11 @@ class LockManager:
     # Alias methods with exact names as specified in issue #573
 
     def acquire(self, force: bool = False) -> bool:
-        """Acquire a lock.
+        """Acquire a lock (alias for acquire_lock).
+
+        This method is called automatically when using LockManager as a context manager.
+        For manual lock management, call this method explicitly and ensure release()
+        is called in a finally block.
 
         Args:
             force: If True, forcibly overwrite existing lock
@@ -187,7 +217,11 @@ class LockManager:
         return self.acquire_lock(force=force)
 
     def release(self) -> None:
-        """Remove the lock file."""
+        """Remove the lock file (alias for release_lock).
+
+        This method is called automatically when using LockManager as a context manager.
+        For manual lock management, ensure this is called in a finally block.
+        """
         self.release_lock()
 
     def get_lock_info(self) -> dict:


### PR DESCRIPTION
Closes #651

Updated docstrings and documentation to reflect the new context manager
usage pattern for the lock mechanism, providing clear examples of both
recommended and manual usage patterns.