### PR TITLE
Replace branch_context with switch_to_branch() in GitHub Actions Handlers

### DIFF
--- a/src/auto_coder/util/github_action.py
+++ b/src/auto_coder/util/github_action.py
@@ -20,7 +20,6 @@ from auto_coder.progress_decorators import progress_stage
 
 from ..automation_config import AutomationConfig
 from ..gh_logger import get_gh_logger
-from ..git_branch import branch_context
 from ..github_client import GitHubClient
 from ..logger_config import get_logger
 from ..utils import CommandExecutor, log_action


### PR DESCRIPTION
Closes #691

This change fixes the incorrect use of branch_context context manager in
two functions by replacing it with direct switch_to_branch() calls. The
context manager was automatically reverting to the original branch,
making the main branch switch ineffective.
[ERROR] [ImportProcessor] Failed to import dataclass: ENOENT: no such file or directory, access '/workspaces/auto-coder/dataclass'