### PR TITLE
Fix issue #701: Update Configuration Loading to Use Path Resolution

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -102,10 +102,7 @@ class LLMBackendConfiguration:
     @classmethod
     def load_from_file(cls, config_path: Optional[str] = None) -> "LLMBackendConfiguration":
         """Load configuration from TOML file."""
-        if config_path is None:
-            config_path = os.path.expanduser("~/.auto-coder/llm_config.toml")
-        else:
-            config_path = os.path.expanduser(config_path)
+        config_path = resolve_config_path(config_path)
 
         if not os.path.exists(config_path):
             # Create a default configuration file if none exists


### PR DESCRIPTION
Closes #701

This PR addresses issue #701.

# Sub-issue 2: Update Configuration Loading to Use Path Resolution

Depends on #699

## Description

Update the `LLMBackendConfiguration.load_from_file()` class method to use the new `resolve_config_p