### PR TITLE
Fix issue #736: Update branch name generation to use underscore

### DIFF
--- a/src/auto_coder/git_branch.py
+++ b/src/auto_coder/git_branch.py
@@ -360,7 +360,7 @@ def extract_number_from_branch(branch_name: str) -> Optional[int]:
     Supports patterns like:
     - issue-123
     - pr-456
-    - issue-123/attempt-1
+    - issue-123_attempt-1
     - feature/issue-789
     - fix/pr-101
 
@@ -392,8 +392,8 @@ def extract_attempt_from_branch(branch_name: str) -> Optional[int]:
     Extract attempt number from branch name.
 
     Supports patterns like:
-    - issue-123/attempt-1
-    - issue-456/attempt-2
+    - issue-123_attempt-1
+    - issue-456_attempt-2
     - issue-789 (returns 0 for no attempt suffix)
 
     Args:
@@ -405,8 +405,8 @@ def extract_attempt_from_branch(branch_name: str) -> Optional[int]:
     if not branch_name:
         return None
 
-    # Match issue-XXX/attempt-Y pattern
-    match = re.search(r"issue-\d+/attempt-(\d+)", branch_name, re.IGNORECASE)
+    # Match issue-XXX_attempt-Y pattern
+    match = re.search(r"issue-\d+_attempt-(\d+)", branch_name, re.IGNORECASE)
     if match:
         return int(match.group(1))
 

--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -36,9 +36,13 @@ def generate_work_branch_name(issue_number: int, attempt: int) -> str:
 
     Returns:
         The generated work branch name.
+
+    Note:
+        Uses underscore separator (_) instead of slash (/) to avoid Git ref namespace conflicts.
+        Format: issue-<number>_attempt-<attempt>
     """
     if attempt > 0:
-        return f"issue-{issue_number}/attempt-{attempt}"
+        return f"issue-{issue_number}_attempt-{attempt}"
     return f"issue-{issue_number}"
 
 
@@ -384,7 +388,7 @@ def _apply_issue_actions_directly(
                 # Check if parent issue has attempts and use the appropriate parent branch
                 parent_attempt = get_current_attempt(repo_name, parent_issue_number)
                 if parent_attempt > 0:
-                    parent_branch = f"issue-{parent_issue_number}/attempt-{parent_attempt}"
+                    parent_branch = f"issue-{parent_issue_number}_attempt-{parent_attempt}"
                 else:
                     parent_branch = f"issue-{parent_issue_number}"
                 logger.info(f"Issue #{issue_number} has parent issue #{parent_issue_number}, using branch {parent_branch} as base")

--- a/tests/test_attempt_manager.py
+++ b/tests/test_attempt_manager.py
@@ -751,7 +751,7 @@ class TestGenerateWorkBranchName:
 
     def test_generate_branch_with_attempt(self):
         """Branch includes attempt segment when attempt is positive."""
-        assert generate_work_branch_name(42, 3) == "issue-42/attempt-3"
+        assert generate_work_branch_name(42, 3) == "issue-42_attempt-3"
 
 
 class TestExtractAttemptFromBranch:
@@ -759,21 +759,21 @@ class TestExtractAttemptFromBranch:
 
     def test_extract_attempt_from_branch_with_attempt(self):
         """Test extracting attempt number from branch with attempt suffix."""
-        branch_name = "issue-123/attempt-1"
+        branch_name = "issue-123_attempt-1"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 1
 
     def test_extract_attempt_from_branch_attempt_2(self):
         """Test extracting attempt number 2."""
-        branch_name = "issue-456/attempt-2"
+        branch_name = "issue-456_attempt-2"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 2
 
     def test_extract_attempt_from_branch_attempt_10(self):
         """Test extracting higher attempt number."""
-        branch_name = "issue-789/attempt-10"
+        branch_name = "issue-789_attempt-10"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 10
@@ -807,39 +807,39 @@ class TestExtractAttemptFromBranch:
 
     def test_extract_attempt_from_branch_case_insensitive(self):
         """Test that extraction is case insensitive."""
-        branch_name = "issue-123/ATTEMPT-5"
+        branch_name = "issue-123_ATTEMPT-5"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 5
 
     def test_extract_attempt_from_branch_mixed_case(self):
         """Test extraction with mixed case."""
-        branch_name = "Issue-456/AtTeMpT-3"
+        branch_name = "Issue-456_AtTeMpT-3"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 3
 
     def test_extract_attempt_from_branch_special_chars(self):
         """Test extraction when branch has multiple segments (returns None due to strict pattern)."""
-        # The pattern requires attempt- to come immediately after issue-XXX/
+        # The pattern requires attempt- to come immediately after issue-XXX_
         # So this won't match because there are extra segments
-        branch_name = "issue-123/special-chars/attempt-7"
+        branch_name = "issue-123/special-chars_attempt-7"
         attempt = extract_attempt_from_branch(branch_name)
 
-        # Pattern is strict: issue-\d+/attempt-(\d+)
+        # Pattern is strict: issue-\d+_attempt-(\d+)
         # So this returns None
         assert attempt is None
 
     def test_extract_attempt_from_branch_with_feature_prefix(self):
         """Test extraction from branch with valid feature/ prefix."""
-        branch_name = "feature/issue-456/attempt-3"
+        branch_name = "feature/issue-456_attempt-3"
         attempt = extract_attempt_from_branch(branch_name)
 
         assert attempt == 3
 
     def test_extract_attempt_from_branch_multiple_attempt_patterns(self):
         """Test extraction when multiple attempt patterns exist."""
-        branch_name = "issue-123/attempt-1/attempt-2"
+        branch_name = "issue-123_attempt-1_attempt-2"
         attempt = extract_attempt_from_branch(branch_name)
 
         # Should match the first attempt pattern
@@ -848,8 +848,8 @@ class TestExtractAttemptFromBranch:
     def test_extract_attempt_from_branch_complex_name(self):
         """Test extraction from complex branch name (returns None due to strict pattern)."""
         # The pattern is strict and doesn't allow extra segments
-        branch_name = "feature/issue-789/complex-name/attempt-4"
+        branch_name = "feature/issue-789/complex-name_attempt-4"
         attempt = extract_attempt_from_branch(branch_name)
 
-        # Pattern requires exact format: issue-\d+/attempt-(\d+)
+        # Pattern requires exact format: issue-\d+_attempt-(\d+)
         assert attempt is None

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -142,10 +142,10 @@ class TestExtractAttemptFromBranch:
 
     def test_extract_attempt_from_branch_with_attempt(self):
         """Test extracting attempt number from branch with attempt suffix."""
-        assert extract_attempt_from_branch("issue-123/attempt-1") == 1
-        assert extract_attempt_from_branch("issue-456/attempt-2") == 2
-        assert extract_attempt_from_branch("issue-789/attempt-10") == 10
-        assert extract_attempt_from_branch("feature/issue-123/attempt-3") == 3
+        assert extract_attempt_from_branch("issue-123_attempt-1") == 1
+        assert extract_attempt_from_branch("issue-456_attempt-2") == 2
+        assert extract_attempt_from_branch("issue-789_attempt-10") == 10
+        assert extract_attempt_from_branch("feature/issue-123_attempt-3") == 3
 
     def test_extract_attempt_from_branch_without_attempt(self):
         """Test extracting attempt number from branch without attempt suffix."""
@@ -161,5 +161,5 @@ class TestExtractAttemptFromBranch:
 
     def test_extract_attempt_from_branch_case_insensitive(self):
         """Test that attempt extraction is case-insensitive."""
-        assert extract_attempt_from_branch("issue-123/Attempt-1") == 1
-        assert extract_attempt_from_branch("issue-456/ATTEMPT-2") == 2
+        assert extract_attempt_from_branch("issue-123_Attempt-1") == 1
+        assert extract_attempt_from_branch("issue-456_ATTEMPT-2") == 2


### PR DESCRIPTION
Closes #736

This PR addresses issue #736.

# Update Branch Name Generation to Use Underscore Separator

## Description

Update the `generate_work_branch_name()` function in `issue_processor.py` to generate attempt branches with underscore (`_`