### PR TITLE
Fix issue #737: Update branch name parsing to support both formats

### DIFF
--- a/src/auto_coder/git_branch.py
+++ b/src/auto_coder/git_branch.py
@@ -360,7 +360,8 @@ def extract_number_from_branch(branch_name: str) -> Optional[int]:
     Supports patterns like:
     - issue-123
     - pr-456
-    - issue-123_attempt-1
+    - issue-123_attempt-1 (new format with underscore)
+    - issue-123/attempt-1 (legacy format with slash)
     - feature/issue-789
     - fix/pr-101
 
@@ -392,9 +393,11 @@ def extract_attempt_from_branch(branch_name: str) -> Optional[int]:
     Extract attempt number from branch name.
 
     Supports patterns like:
-    - issue-123_attempt-1
+    - issue-123_attempt-1 (new format with underscore)
     - issue-456_attempt-2
-    - issue-789 (returns 0 for no attempt suffix)
+    - issue-123/attempt-1 (legacy format with slash, for backward compatibility)
+    - issue-456/attempt-2 (legacy)
+    - issue-789 (returns None for no attempt suffix)
 
     Args:
         branch_name: Branch name to parse
@@ -405,8 +408,13 @@ def extract_attempt_from_branch(branch_name: str) -> Optional[int]:
     if not branch_name:
         return None
 
-    # Match issue-XXX_attempt-Y pattern
+    # Try new underscore format first: issue-XXX_attempt-Y
     match = re.search(r"issue-\d+_attempt-(\d+)", branch_name, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+
+    # Fallback to legacy slash format for backward compatibility: issue-XXX/attempt-Y
+    match = re.search(r"issue-\d+/attempt-(\d+)", branch_name, re.IGNORECASE)
     if match:
         return int(match.group(1))
 

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -163,3 +163,15 @@ class TestExtractAttemptFromBranch:
         """Test that attempt extraction is case-insensitive."""
         assert extract_attempt_from_branch("issue-123_Attempt-1") == 1
         assert extract_attempt_from_branch("issue-456_ATTEMPT-2") == 2
+
+    def test_extract_attempt_from_branch_legacy_slash_format(self):
+        """Test extracting attempt number from legacy slash format."""
+        assert extract_attempt_from_branch("issue-123/attempt-1") == 1
+        assert extract_attempt_from_branch("issue-456/attempt-2") == 2
+        assert extract_attempt_from_branch("issue-789/attempt-10") == 10
+        assert extract_attempt_from_branch("feature/issue-123/attempt-3") == 3
+
+    def test_extract_attempt_from_branch_legacy_slash_case_insensitive(self):
+        """Test that legacy slash format attempt extraction is case-insensitive."""
+        assert extract_attempt_from_branch("issue-123/Attempt-1") == 1
+        assert extract_attempt_from_branch("issue-456/ATTEMPT-2") == 2


### PR DESCRIPTION
Closes #737

This PR addresses issue #737.

# Update Branch Name Parsing to Support Both Formats

## Description

Update the `extract_attempt_from_branch()` function in `git_branch.py` to support **both** the old slash format (`issue-X/attempt-