### PR TITLE
Add settings field support to Claude backend configuration

### DIFF
--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -39,6 +39,7 @@ class ClaudeClient(LLMClientBase):
             self.base_url = config_backend and config_backend.base_url
             self.openai_api_key = config_backend and config_backend.openai_api_key
             self.openai_base_url = config_backend and config_backend.openai_base_url
+            self.settings = config_backend and config_backend.settings
         else:
             # Fall back to default claude config
             config_backend = config.get_backend_config("claude")
@@ -47,6 +48,7 @@ class ClaudeClient(LLMClientBase):
             self.base_url = config_backend and config_backend.base_url
             self.openai_api_key = config_backend and config_backend.openai_api_key
             self.openai_base_url = config_backend and config_backend.openai_base_url
+            self.settings = config_backend and config_backend.settings
 
         self.default_model = self.model_name
         self.conflict_model = "sonnet"
@@ -86,8 +88,12 @@ class ClaudeClient(LLMClientBase):
                 "--allow-dangerously-skip-permissions",
                 "--model",
                 self.model_name,
-                escaped_prompt,
             ]
+
+            if self.settings:
+                cmd.extend(["--settings", self.settings])
+
+            cmd.append(escaped_prompt)
 
             # Prepare environment variables for subprocess
             env = os.environ.copy()

--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -74,6 +74,8 @@ class BackendConfig:
     model_provider: Optional[str] = None
     # Always switch to next backend after execution
     always_switch_after_execution: bool = False
+    # Path to settings file (for Claude backend)
+    settings: Optional[str] = None
 
 
 @dataclass
@@ -145,6 +147,7 @@ class LLMBackendConfiguration:
                     backend_type=config_data.get("backend_type"),
                     model_provider=config_data.get("model_provider"),
                     always_switch_after_execution=config_data.get("always_switch_after_execution", False),
+                    settings=config_data.get("settings"),
                 )
 
             # 1. Parse explicit [backends] section
@@ -158,7 +161,7 @@ class LLMBackendConfiguration:
             def is_potential_backend_config(d: dict) -> bool:
                 # Heuristic: if it has specific backend keys, it's likely a config
                 # We check for keys that are commonly used in backend definitions
-                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution"}
+                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings"}
                 # Also check if 'enabled' is present, but it's very common so we combine it
                 # with the fact that we are looking for backends.
                 # If a dict has 'enabled' and is in the top-level (or nested from top-level),
@@ -234,6 +237,7 @@ class LLMBackendConfiguration:
                 "backend_type": config.backend_type,
                 "model_provider": config.model_provider,
                 "always_switch_after_execution": config.always_switch_after_execution,
+                "settings": config.settings,
             }
 
         data = {"backend": {"order": self.backend_order, "default": self.default_backend}, "message_backend": {"order": self.message_backend_order, "default": self.message_default_backend or self.default_backend}, "backends": backend_data}


### PR DESCRIPTION
Add settings field support to Claude backend configuration

This change adds a settings field to the BackendConfig class and passes it to the Claude client, allowing users to specify a settings file for Claude backend operations.

Changes include:
- Adding settings field to BackendConfig dataclass
- Updating ClaudeClient to use the settings field if available
- Modifying configuration parsing and serialization to handle the settings field
- Adding documentation for the new settings field in README.md and example configuration file

This enhancement allows Claude backend users to provide custom settings files that can control specific Claude behaviors, making the Claude integration more flexible and configurable.