### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,59 @@ Supported `backend_type` values: `codex`, `codex-mcp`, `gemini`, `qwen`, `auggie
 
 For detailed configuration examples and troubleshooting, see [Custom Backend Configuration](docs/Custom_Backend_Configuration.md).
 
+#### Configuring Model Provider
+
+For backends using `backend_type = "codex"`, you can specify the model provider using the `model_provider` field. This tells the codex CLI which provider to use when making API calls.
+
+##### Example: Using OpenRouter
+
+```toml
+[grok-4.1-fast]
+enabled = true
+model = "x-ai/grok-4.1-fast:free"
+backend_type = "codex"
+model_provider = "openrouter"
+```
+
+This configuration is equivalent to running:
+```bash
+codex -c model="x-ai/grok-4.1-fast:free" -c model_provider=openrouter
+```
+
+##### Supported Providers
+
+The `model_provider` field supports any provider that the codex CLI recognizes, such as:
+- `openrouter` - For OpenRouter API
+- `anthropic` - For Anthropic Claude
+- `openai` - For OpenAI models
+
+> **Note:** You still need to configure provider-specific settings (like API endpoints and authentication) in your codex configuration file (`~/.codex/config.toml`) or via environment variables. The `model_provider` field simply tells codex which provider configuration to use.
+
+##### Complete Example with OpenRouter
+
+Here's a complete example showing how to configure a custom backend with OpenRouter:
+
+```toml
+[backends.openrouter-grok]
+enabled = true
+backend_type = "codex"
+model = "x-ai/grok-4.1-fast:free"
+model_provider = "openrouter"
+openai_api_key = "sk-or-v1-..."  # Your OpenRouter API key
+openai_base_url = "https://openrouter.ai/api/v1"
+```
+
+Make sure your codex configuration file (`~/.codex/config.toml`) contains the appropriate provider settings. For example:
+
+```toml
+# ~/.codex/config.toml
+[openrouter]
+api_base = "https://openrouter.ai/api/v1"
+default_model = "x-ai/grok-4.1-fast:free"
+```
+
+Check the codex CLI documentation for the full list of supported providers and their configuration options.
+
 #### Configuration Management
 
 To manage the configuration file, use the built-in config commands:


### PR DESCRIPTION
Closes #709

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac121-e83d-70f1-8211-eed264fbde34
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #709: Update Documentation for model_provider
Issue Description:
# Sub-Issue 4: Update Documentation for model_provider

## Description

Update documentation to explain how to use the new `model_provider` field for backend configuration.

## Dependencies

Depends on #TBD (Sub-Issue 1: Add model_provider Field to BackendConfig)

## Changes Required

### File: `README.md`

Add a section explaining:
1. The purpose of `model_provider` for codex-based backends
2. Example TOML configuration using `model_provider`
3. How it's translated to `-c model_provider=<value>

Changes Summary:
## Summary

I have successfully completed GitHub Issue #709 (Sub-Issue 4): **Update Documentation for model_provider**.

### Changes Made

**File Modified:** `README.md` (lines 344-396)

Added a comprehensive "Configuring Model Provider" section that includes:

1. **Clear Explanation**: Documents the purpose of `model_provider` for codex-based backends
2. **Example Configuration**: Shows TOML configuration with OpenRouter example
3. **CLI Translation**: Explains how `model_provider` translates t

Commit History Since Branch Creation:
Auto-Coder: Address issue #709

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers