### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/OPENROUTER_SETUP.md
+++ b/OPENROUTER_SETUP.md
@@ -1,5 +1,7 @@
 # OpenRouter Setup Guide
 
+**Note:** By default, all backends have `enabled = true`. You only need to specify `enabled = false` to disable a backend.
+
 ## Overview
 
 OpenRouter provides access to various AI models through a unified OpenAI-compatible API. This guide explains how to configure Auto-Coder to use Qwen and other models via OpenRouter.
@@ -24,7 +26,6 @@ default = "qwen-openrouter"
 order = ["qwen-openrouter", "codex", "gemini"]
 
 [backends.qwen-openrouter]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -48,7 +49,6 @@ The key is setting `backend_type = "codex"` to use Auto-Coder's OpenAI-compatibl
 
 ```toml
 [backends.qwen-openrouter]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -79,14 +79,12 @@ You can configure multiple OpenRouter backends with different models:
 
 ```toml
 [backends.qwen-openrouter-free]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
 backend_type = "codex"
 
 [backends.qwen-openrouter-plus]
-enabled = true
 model = "qwen/qwen-2.5-plus"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ This approach is **backward compatible**: existing users with only home director
 
 Auto-Coder uses a TOML configuration file for backend settings. You can place this file in either location mentioned above.
 
+**Note:** By default, all backends have `enabled = true`. You only need to specify `enabled = false` to disable a backend.
+
 #### Custom Backend Names
 
 You can define custom backend names using the `backend_type` field. This is useful for:
@@ -412,7 +414,6 @@ You can define custom backend names using the `backend_type` field. This is usef
 Example:
 ```toml
 [backends.grok-4.1-fast]
-enabled = true
 backend_type = "codex"  # Use codex CLI for OpenAI-compatible APIs
 model = "grok-4.1-fast"
 openai_api_key = "your-openrouter-api-key"
@@ -460,7 +461,6 @@ order = ["gemini", "qwen", "claude"]
 default = "gemini"
 
 [backends.codex]
-enabled = true
 api_key = ""
 base_url = ""
 model = "codex"
@@ -471,7 +471,6 @@ usage_limit_retry_count = 0
 usage_limit_retry_wait_seconds = 0
 
 [backends.codex_mcp]
-enabled = true
 api_key = ""
 base_url = ""
 model = "codex-mcp"
@@ -482,7 +481,6 @@ usage_limit_retry_count = 0
 usage_limit_retry_wait_seconds = 0
 
 [backends.gemini]
-enabled = true
 api_key = "your-gemini-api-key"  # Alternatively use GEMINI_API_KEY env var
 base_url = ""
 model = "gemini-2.5-pro"
@@ -494,7 +492,6 @@ usage_limit_retry_wait_seconds = 30
 always_switch_after_execution = false
 
 [backends.qwen]
-enabled = true
 api_key = "your-qwen-api-key"  # Alternatively use OPENAI_API_KEY env var
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"  # Or your OpenAI-compatible endpoint
 model = "qwen3-coder-plus"
@@ -506,7 +503,6 @@ usage_limit_retry_wait_seconds = 60
 always_switch_after_execution = false
 
 [backends.claude]
-enabled = true
 api_key = "your-claude-api-key"  # Alternatively use ANTHROPIC_API_KEY env var
 base_url = ""
 model = "sonnet"
@@ -517,7 +513,6 @@ usage_limit_retry_count = 5
 usage_limit_retry_wait_seconds = 45
 
 [backends.auggie]
-enabled = true
 api_key = ""
 base_url = ""
 model = "GPT-5"
@@ -616,12 +611,10 @@ order = ["gemini", "qwen", "claude"]
 default = "gemini"
 
 [backends.gemini]
-enabled = true
 model = "gemini-2.5-pro"
 always_switch_after_execution = true  # switch to qwen after each gemini call
 
 [backends.qwen]
-enabled = true
 model = "qwen3-coder-plus"
 always_switch_after_execution = true  # continue rotation to claude next
 ```
@@ -1220,7 +1213,6 @@ If you see this error with a custom backend name:
 **Example fix:**
 ```toml
 [backends.my-custom-backend]
-enabled = true
 backend_type = "codex"  # Add this line
 model = "grok-4.1-fast"
 openai_api_key = "your-key"

--- a/docs/MIGRATION_GUIDE_v2025.11.26.md
+++ b/docs/MIGRATION_GUIDE_v2025.11.26.md
@@ -1,5 +1,7 @@
 # Migration Guide: v2025.11.26
 
+**Note:** By default, all backends have `enabled = true`. You only need to specify `enabled = false` to disable a backend.
+
 ## Breaking Changes
 
 ### Backend Prerequisites Check Enhancement
@@ -49,7 +51,6 @@ If you're using custom backend names (aliases), you **must** add a `backend_type
 ```toml
 # ~/.auto-coder/llm_config.toml
 [backends.my-custom-backend]
-enabled = true
 model = "qwen3-coder-plus"
 openai_api_key = "your-key"
 openai_base_url = "https://api.example.com"
@@ -62,7 +63,6 @@ This configuration would **fail** with the new version because `my-custom-backen
 ```toml
 # ~/.auto-coder/llm_config.toml
 [backends.my-custom-backend]
-enabled = true
 backend_type = "qwen"  # ← Required: specify which backend type this uses
 model = "qwen3-coder-plus"
 openai_api_key = "your-key"
@@ -85,7 +85,6 @@ The `backend_type` field must be one of these known backend types:
 
 ```toml
 [backends.my-openrouter]
-enabled = true
 backend_type = "codex"  # OpenRouter is OpenAI-compatible
 model = "openrouter/grok-4.1-fast"
 api_key = "your-openrouter-key"
@@ -96,7 +95,6 @@ base_url = "https://openrouter.ai/api/v1"
 
 ```toml
 [backends.gemini-flash-alias]
-enabled = true
 backend_type = "gemini"
 model = "gemini-2.5-flash"
 api_key = "your-gemini-key"
@@ -106,7 +104,6 @@ api_key = "your-gemini-key"
 
 ```toml
 [backends.qwen-turbo]
-enabled = true
 backend_type = "qwen"
 model = "qwen3-coder-plus"
 openai_api_key = "your-key"

--- a/docs/Qwen_Configuration_Guide.md
+++ b/docs/Qwen_Configuration_Guide.md
@@ -5,6 +5,8 @@ This guide explains how to configure Qwen for use with Auto-Coder. There are two
 1. **Qwen CLI (OAuth)** - Native Qwen CLI authentication
 2. **OpenAI-Compatible Providers** - Using Qwen models through providers like OpenRouter, Azure OpenAI, etc.
 
+**Note:** By default, all backends have `enabled = true`. You only need to specify `enabled = false` to disable a backend.
+
 ## Quick Start
 
 ### Option 1: Qwen CLI (OAuth) - Direct Qwen Usage
@@ -13,7 +15,6 @@ Configure using `backend_type = "qwen"`:
 
 ```toml
 [backends.qwen]
-enabled = true
 model = "qwen3-coder-plus"
 backend_type = "qwen"
 
@@ -26,7 +27,6 @@ Configure using `backend_type = "codex"`:
 
 ```toml
 [backends.qwen-openrouter]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -50,7 +50,6 @@ This method uses the native Qwen CLI with OAuth authentication. No API keys are 
 
 ```toml
 [backends.qwen]
-enabled = true
 model = "qwen3-coder-plus"
 backend_type = "qwen"
 ```
@@ -75,7 +74,6 @@ This method uses OpenAI-compatible API endpoints to access Qwen models through p
 
 ```toml
 [backends.qwen-openrouter]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-openrouter-key"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -89,7 +87,6 @@ options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Cod
 
 ```toml
 [backends.qwen-azure]
-enabled = true
 model = "qwen-35-coder"
 openai_api_key = "your-azure-openai-key"
 openai_base_url = "https://your-resource.openai.azure.com"
@@ -103,7 +100,6 @@ options = ["-o", "api_version", "2024-02-01"]
 
 ```toml
 [backends.qwen-custom]
-enabled = true
 model = "qwen-2.5-coder-32k-instruct"
 openai_api_key = "your-api-key"
 openai_base_url = "https://api.example.com/v1"
@@ -154,7 +150,6 @@ default = "qwen-openrouter"
 order = ["qwen-openrouter", "qwen", "gemini", "codex"]
 
 [backends.qwen-openrouter]
-enabled = true
 model = "qwen/qwen3-coder:free"
 openai_api_key = "sk-or-v1-your-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -162,18 +157,15 @@ backend_type = "codex"
 options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Coder"]
 
 [backends.qwen]
-enabled = true
 model = "qwen3-coder-plus"
 backend_type = "qwen"
 
 [backends.gemini]
-enabled = true
 model = "gemini-2.5-pro"
 api_key = "your-gemini-api-key"
 backend_type = "gemini"
 
 [backends.codex]
-enabled = true
 model = "codex"
 backend_type = "codex"
 ```
@@ -189,7 +181,6 @@ You can configure any OpenAI-compatible model as a custom backend using `backend
 ```toml
 # Using Grok models via OpenRouter
 [backends.grok-4.1-fast]
-enabled = true
 model = "x-ai/grok-4.1-fast"
 openai_api_key = "sk-or-v1-your-openrouter-key"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -197,7 +188,6 @@ backend_type = "codex"
 
 # Using Claude models via OpenRouter
 [backends.claude-sonnet-4]
-enabled = true
 model = "anthropic/claude-sonnet-4"
 openai_api_key = "sk-or-v1-your-openrouter-key"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -205,7 +195,6 @@ backend_type = "codex"
 
 # Using Mistral models
 [backends.mistral-large]
-enabled = true
 model = "mistralai/mistral-large"
 openai_api_key = "sk-or-v1-your-key"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -219,7 +208,6 @@ For Claude models that support OpenAI-compatible API, you can use `backend_type 
 ```toml
 # Using Claude models via OpenRouter (when using ClaudeClient)
 [backends.minimax-coder]
-enabled = true
 model = "minimax-coder"
 api_key = "your-minimax-api-key"
 base_url = "https://api.minimaxi.com/v1"


### PR DESCRIPTION
Closes #712

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac135-33a3-7ca3-a2bc-dc8768519857
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #712: Update documentation files to reflect `enabled = true` default
Issue Description:
# Sub-issue 2: Update documentation files

## Description

Update all documentation files to reflect that `enabled = true` is the default for backend configurations and remove redundant `enabled = true` lines from examples.

## Files to Modify

- `/home/node/src/auto-coder/README.md`
- `/home/node/src/auto-coder/docs/Qwen_Configuration_Guide.md`
- `/home/node/src/auto-coder/docs/MIGRATION_GUIDE_v2025.11.26.md`
- `/home/node/src/auto-coder/OPENROUTER_SETUP.md`

## Changes

1. **README.md**: 
   -

Changes Summary:
## Summary

I have successfully updated all documentation files to reflect that `enabled = true` is the default for backend configurations. Here's what was changed:

### Files Modified:

1. **`/workspaces/auto-coder/README.md`**
   - Added note explaining `enabled = true` is the default (line 405)
   - Removed `enabled = true` from 10 configuration examples throughout the file

2. **`/workspaces/auto-coder/docs/Qwen_Configuration_Guide.md`**
   - Added note explaining `enabled = true` is the def

Commit History Since Branch Creation:
Auto-Coder: Address issue #712

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers