### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/docs/llm_backend_config.example.toml
+++ b/docs/llm_backend_config.example.toml
@@ -34,7 +34,6 @@ order = ["qwen-openrouter", "qwen", "gemini"]
 # ----------------------------------------------
 # Use backend_type = "qwen" for native Qwen CLI authentication
 [qwen]
-# enabled = true is the default (no need to specify)
 model = "qwen3-coder-plus"
 
 # No API keys needed - uses OAuth with Qwen CLI
@@ -53,7 +52,6 @@ options = []
 # -----------------------------------------------------
 # Use backend_type = "codex" for OpenAI-compatible providers
 [qwen-openrouter]
-# enabled = true is the default (no need to specify)
 model = "qwen/qwen3-coder:free"
 
 # OpenAI-compatible API settings (required for OpenRouter, Azure, etc.)
@@ -69,7 +67,6 @@ options = ["-o", "HTTPReferer", "https://yourapp.com", "-o", "XTitle", "Auto-Cod
 # Gemini Configuration
 # --------------------
 [gemini]
-# enabled = true is the default (no need to specify)
 model = "gemini-2.5-pro"
 
 # Gemini API settings
@@ -88,7 +85,6 @@ backend_type = "gemini"
 # -------------------
 # Codex client can be used for generic OpenAI-compatible APIs like OpenRouter.
 [codex]
-# enabled = true is the default (no need to specify)
 model = "codex" # Placeholder, model is usually set by the provider
 # Generic API key and base URL for providers that don't use OpenAI-specific env vars
 api_key = "your-api-key-here"
@@ -106,7 +102,6 @@ backend_type = "codex"
 
 # Example 1: Qwen via OpenRouter with faster model
 [qwen-fast]
-# enabled = true is the default (no need to specify)
 model = "qwen/qwen-2.5-plus"
 openai_api_key = "sk-or-v1-your-openrouter-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"
@@ -120,7 +115,6 @@ options = ["-o", "timeout", "30", "-o", "stream", "true"]
 
 # Example 2: Qwen via OpenRouter with premium model
 [qwen-premium]
-# enabled = true is the default (no need to specify)
 model = "qwen/qwen-2.5-coder-72b-instruct"
 openai_api_key = "sk-or-v1-your-openrouter-key-here"
 openai_base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
Closes #711

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac178-820b-7073-bb0c-cb51daefa817
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #711: Update example TOML configuration to remove redundant `enabled = true`
Issue Description:
# Sub-issue 1: Update example TOML configuration

## Description

Update the example TOML configuration file to remove redundant `enabled = true` lines, only keeping `enabled = false` where backends should be disabled by default.

## Files to Modify

- `/home/node/src/auto-coder/docs/llm_backend_config.example.toml`

## Changes

1. Remove `enabled = true` from all backend configurations where the backend should be enabled
2. Keep `enabled = false` only for:
   - `[qwen-azure]` (line 129) - Azure

Changes Summary:
Perfect! I have successfully completed the documentation update for issue #711. Here's a summary of what was done:

## Changes Made

**File Modified:** `/workspaces/auto-coder/docs/llm_backend_config.example.toml`

### 1. Removed redundant `enabled = true` comments
Removed the following redundant comments from all enabled backends:
- `[qwen]` - Removed comment at line 37
- `[qwen-openrouter]` - Removed comment at line 56
- `[gemini]` - Removed comment at line 72
- `[codex]` - Removed comment at 

Commit History Since Branch Creation:
Auto-Coder: Address issue #711

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers