### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -157,7 +157,14 @@ class AutomationEngine:
                 continue
 
             # Skip if another instance is processing (@auto-coder label present) using LabelManager check
-            with LabelManager(self.github, repo_name, pr_number, item_type="pr", skip_label_add=True) as should_process:
+            with LabelManager(
+                self.github,
+                repo_name,
+                pr_number,
+                item_type="pr",
+                skip_label_add=True,
+                check_labels=self.config.CHECK_LABELS,
+            ) as should_process:
                 if not should_process:
                     continue
 
@@ -247,6 +254,7 @@ class AutomationEngine:
                     number,
                     item_type="issue",
                     skip_label_add=True,
+                    check_labels=self.config.CHECK_LABELS,
                 ) as should_process:
                     if not should_process:
                         continue

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -447,7 +447,11 @@ def create_feature_issues(
 
     check_graphrag_mcp_for_backends(selected_backends, client=manager)
 
-    automation_engine = AutomationEngine(github_client)  # type: ignore[arg-type]
+    # Configure engine behavior flags
+    engine_config = AutomationConfig()
+    engine_config.DISABLE_LABELS = bool(disable_labels)
+
+    automation_engine = AutomationEngine(github_client, config=engine_config)  # type: ignore[arg-type]
 
     # Analyze and create feature issues
     automation_engine.create_feature_issues(repo_name)


### PR DESCRIPTION
Closes #716

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac181-446f-7e10-91f5-2ce3ee904c87
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #716: Pass check_labels Config to AutomationEngine
Issue Description:
# Pass `check_labels` Config to AutomationEngine

Depends on: (Will be updated with sub-issue #1 number after posting)

## Objective

Ensure that the `CHECK_LABELS` configuration is properly passed from CLI to `AutomationEngine` so it can control `LabelManager` behavior.

## Changes Required

### File: `src/auto_coder/cli_commands_main.py`

**Verify Configuration Passing** (around line 215-218):
- The code already creates `AutomationEngine` with `config=engine_config`
- Verify that `engine_confi

Changes Summary:
Excellent! All tests passed (1897 passed, 16 skipped). Let me create a comprehensive summary of the fix:

## Summary

### Root Cause
The bug was in `/workspaces/auto-coder/src/auto_coder/automation_engine.py`. When `LabelManager` was instantiated for checking candidates (PRs and issues), it wasn't being passed the `check_labels` parameter from the config. This meant even when `engine_config.CHECK_LABELS` was set to `False` (e.g., for WIP branches or `--only` flag), the `LabelManager` still used 

Commit History Since Branch Creation:
Auto-Coder: Address issue #716

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers