### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,10 @@ For backends using `backend_type = "codex"`, you can specify the model provider 
 
 ```toml
 [grok-4.1-fast]
-enabled = true
 model = "x-ai/grok-4.1-fast:free"
 backend_type = "codex"
 model_provider = "openrouter"
+# Note: enabled = true is the default
 ```
 
 This configuration is equivalent to running:
@@ -458,12 +458,12 @@ Here's a complete example showing how to configure a custom backend with OpenRou
 
 ```toml
 [backends.openrouter-grok]
-enabled = true
 backend_type = "codex"
 model = "x-ai/grok-4.1-fast:free"
 model_provider = "openrouter"
 openai_api_key = "sk-or-v1-..."  # Your OpenRouter API key
 openai_base_url = "https://openrouter.ai/api/v1"
+# Note: enabled = true is the default
 ```
 
 Make sure your codex configuration file (`~/.codex/config.toml`) contains the appropriate provider settings. For example:


### PR DESCRIPTION
Closes #712

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac184-b109-7d61-acbb-b13b7725ac90
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #712: Update documentation files to reflect `enabled = true` default
Issue Description:
# Sub-issue 2: Update documentation files

## Description

Update all documentation files to reflect that `enabled = true` is the default for backend configurations and remove redundant `enabled = true` lines from examples.

## Files to Modify

- `/home/node/src/auto-coder/README.md`
- `/home/node/src/auto-coder/docs/Qwen_Configuration_Guide.md`
- `/home/node/src/auto-coder/docs/MIGRATION_GUIDE_v2025.11.26.md`
- `/home/node/src/auto-coder/OPENROUTER_SETUP.md`

## Changes

1. **README.md**: 
   -

Changes Summary:
Perfect! All documentation updates have been completed successfully. Here's a summary of the changes made:

## Summary

I successfully updated the documentation files to reflect that `enabled = true` is the default for backend configurations. Here's what was done:

### Changes Made:

#### README.md ✅
- **Removed redundant `enabled = true` lines** from two configuration examples:
  1. Line 435: Example for OpenRouter with Grok model
  2. Line 461: Complete OpenRouter example
- **Added explanatory

Commit History Since Branch Creation:
Auto-Coder: Address issue #712

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
Reconnecting... 1/5