### PR TITLE
Fix issue #717: Pass check_labels to LabelManager

### DIFF
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -384,7 +384,7 @@ class AutomationEngine:
                 raise ValueError(f"Item number is missing for {item_type} #{candidate.data.get('number', 'N/A')}")
 
             # Use LabelManager context manager to handle @auto-coder label automatically
-            with LabelManager(self.github, repo_name, item_number, item_type=item_type, config=config) as should_process:
+            with LabelManager(self.github, repo_name, item_number, item_type=item_type, config=config, check_labels=config.CHECK_LABELS) as should_process:
                 if not should_process:
                     result.actions = ["Skipped - another instance started processing (@auto-coder label added)"]
                     return result


### PR DESCRIPTION
Closes #717

Updated AutomationEngine to pass the CHECK_LABELS configuration to LabelManager
when creating label manager instances. This ensures proper label handling during
PR and issue processing. All 1897 tests passed.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac18c-88bf-7fc0-9e6b-246dec8bfde3
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #717: Update AutomationEngine to Pass check_labels to LabelManager
Issue Description:
# Update AutomationEngine to Pass `check_labels` to LabelManager

Depends on: (Will be updated with sub-issue #1 number after posting)

## Objective

Modify `AutomationEngine` to pass the `CHECK_LABELS` configuration to `LabelManager` when creating label manager instances.

## Changes Required

### File: `src/auto_coder/automation_engine.py`

**Locate LabelManager Usage**:
- Search for all instances where `LabelManager` is instantiated
- Common patterns to search for:
  - `with LabelManager(`
  

Changes Summary:
Perfect! All 1897 tests passed. Let me provide a summary of the fix:

## Summary

I successfully fixed issue #717 by updating the `AutomationEngine` to pass the `check_labels` configuration to `LabelManager`.

### Root Cause Analysis

The bug was in `/workspaces/auto-coder/src/auto_coder/automation_engine.py` at line 387. While three `LabelManager` instantiations existed in the file:
1. **Line 160-167** (PR processing in `_get_candidates`) - ✅ Already had `check_labels=self.config.CHECK_LABELS`


Commit History Since Branch Creation:
Auto-Coder: Address issue #717

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
exec
git log --oneline -n 5 in /workspaces/auto-coder succeeded in 5ms:
12e3e04 Auto-Coder: Address issue #717
12d1c64 Auto-Coder: Address issue #716 (#769)
59a20c0 Auto-Coder: Address issue #715 (#767)
97a1ac5 Add model_provider field to LLM backend config (#761)
35054e8 Add settings field support to Claude backend configuration (#754)
exec
git show --name-only 12e3e04 in /workspaces/auto-coder succeeded in 5ms:
commit 12e3e04d3586ca71e62b1c905481d78c601dca89
Author: Tetsuo Kitamura <kitamura.tetsuo@gmail.com>
Date:   Thu Nov 27 04:03:18 2025 +0900

    Auto-Coder: Address issue #717

src/auto_coder/automation_engine.py
Reconnecting... 1/5
Reconnecting... 2/5
Reconnecting... 3/5
Reconnecting... 4/5
exec
git show 12e3e04 in /workspaces/auto-coder succeeded in 7ms:
commit 12e3e04d3586ca71e62b1c905481d78c601dca89
Author: Tetsuo Kitamura <kitamura.tetsuo@gmail.com>
Date:   Thu Nov 27 04:03:18 2025 +0900

    Auto-Coder: Address issue #717

diff --git a/src/auto_coder/automation_engine.py b/src/auto_coder/automation_engine.py
index 0bde0ea..27b377d 100644
--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -384,7 +384,7 @@ class AutomationEngine:
                 raise ValueError(f"Item number is missing for {item_type} #{candidate.data.get('number', 'N/A')}")
 
             # Use LabelManager context manager to handle @auto-coder label automatically
-            with LabelManager(self.github, repo_name, item_number, item_type=item_type, config=config) as should_process:
+            with LabelManager(self.github, repo_name, item_number, item_type=item_type, config=config, check_labels=config.CHECK_LABELS) as should_process:
                 if not should_process:
                     result.actions = ["Skipped - another instance started processing (@auto-coder label added)"]
                     return result
codex
Fix issue #717: Pass check_labels to LabelManager

Updated AutomationEngine to pass the CHECK_LABELS configuration to LabelManager
when creating label manager instances. This ensures proper label handling during
PR and issue processing. All 1897 tests passed.