### PR TITLE
Update documentation for WIP branch behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,43 @@ git push origin --delete issue-699/attempt-1
 git push origin issue-699_attempt-1
 ```
 
+## Work-in-Progress (WIP) Branch Resumption
+
+When you run `auto-coder process` from a non-main branch, the system automatically detects work in progress and resumes processing:
+
+### Automatic WIP Detection
+
+1. Detects current branch is not `main`
+2. Searches for open PR with matching head branch
+3. If PR found, resumes work on that PR
+4. If no PR found, extracts issue number from branch name (e.g., `fix/123-description` → issue #123)
+
+### Label Handling in WIP Mode
+
+**Important**: When resuming WIP branches, `auto-coder` **ignores** the `\@auto-coder` label state:
+- Processing continues even if `\@auto-coder` label already exists on the PR/issue
+- This allows you to retry/continue work without manually removing labels
+- The label will be re-added if not present, or left as-is if already present
+
+**Regular Mode** (not on WIP branch):
+- Checks for `\@auto-coder` label before processing
+- Skips processing if label already exists (prevents concurrent work)
+- Use `--check-labels=false` to override this behavior
+
+### Example Usage
+
+```bash
+# On branch 'fix/toml-parsing' with PR #704
+auto-coder process
+# → Automatically resumes PR #704, ignoring existing \@auto-coder label
+
+# Explicit target (bypasses label checks)
+auto-coder process --only 704
+
+# Force label checking even on WIP branch (not recommended)
+auto-coder process --check-labels
+```
+
 ## Configuration
 
 ### Configuration File Locations


### PR DESCRIPTION
Closes #719

Added a new section to the README that clarifies how auto-coder handles work-in-progress branches, including automatic detection, PR resumption, and special handling of the \@auto-coder label. This addresses issue #719 by documenting the system's behavior when processing from non-main branches.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac270-c098-7863-8934-6ace820e9526
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #719: Update Documentation for WIP Branch Behavior
Issue Description:
# Update Documentation for WIP Branch Behavior

Depends on: (Will be updated with sub-issue #4 number after posting)

## Objective

Update documentation to clarify WIP branch resumption behavior and `\@auto-coder` label handling.

## Changes Required

### File: `README.md` (or relevant documentation file)

**Add/Update Section**: "Work-in-Progress Branch Resumption"

**Content to Add**:

```markdown
## Work-in-Progress (WIP) Branch Resumption

When you run `auto-coder process` from a non-main bra

Changes Summary:
Perfect! I have successfully completed the documentation update for issue #719. Let me provide a summary:

## Summary

I've successfully updated the documentation in `/workspaces/auto-coder/README.md` to clarify WIP (Work-in-Progress) branch resumption behavior and `\@auto-coder` label handling.

### Changes Made

**File Modified:** `/workspaces/auto-coder/README.md`

**New Section Added:** "Work-in-Progress (WIP) Branch Resumption" (lines 366-401)

The new documentation section includes:

1. **A

Commit History Since Branch Creation:
Auto-Coder: Address issue #719

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
exec
git log --oneline -10 in /workspaces/auto-coder succeeded in 7ms:
640891c Auto-Coder: Address issue #719
8c5af48 OpenAI Codex v0.63.0 (research preview) (#775)
fe0328f OpenAI Codex v0.63.0 (research preview) (#773)
f456f85 Auto-Coder: Address issue #717 (#771)
12d1c64 Auto-Coder: Address issue #716 (#769)
59a20c0 Auto-Coder: Address issue #715 (#767)
97a1ac5 Add model_provider field to LLM backend config (#761)
35054e8 Add settings field support to Claude backend configuration (#754)
8e3f25f Update branch naming to use underscores instead of slashes (#752)
2954c22 Refactor LLM clients to use backend configuration system (#750)
exec
git show 640891c in /workspaces/auto-coder succeeded in 7ms:
commit 640891c71c9b74fe1be66820846164cced9847b3
Author: Tetsuo Kitamura <kitamura.tetsuo@gmail.com>
Date:   Thu Nov 27 08:12:38 2025 +0900

    Auto-Coder: Address issue #719

diff --git a/README.md b/README.md
index 49ddbbb..26568e0 100644
--- a/README.md
+++ b/README.md
@@ -363,6 +363,43 @@ git push origin --delete issue-699/attempt-1
 git push origin issue-699_attempt-1
 ```
 
+## Work-in-Progress (WIP) Branch Resumption
+
+When you run `auto-coder process` from a non-main branch, the system automatically detects work in progress and resumes processing:
+
+### Automatic WIP Detection
+
codex
Update documentation for WIP branch behavior

Added a new section to the README that clarifies how auto-coder handles work-in-progress branches, including automatic detection, PR resumption, and special handling of the \@auto-coder label. This addresses issue #719 by documenting the system's behavior when processing from non-main branches.