### PR TITLE
Add usage_markers support to BackendConfig

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -76,6 +76,8 @@ class BackendConfig:
     always_switch_after_execution: bool = False
     # Path to settings file (for Claude backend)
     settings: Optional[str] = None
+    # Usage markers for tracking usage patterns
+    usage_markers: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -148,6 +150,7 @@ class LLMBackendConfiguration:
                     model_provider=config_data.get("model_provider"),
                     always_switch_after_execution=config_data.get("always_switch_after_execution", False),
                     settings=config_data.get("settings"),
+                    usage_markers=config_data.get("usage_markers", []),
                 )
 
             # 1. Parse explicit [backends] section
@@ -238,6 +241,7 @@ class LLMBackendConfiguration:
                 "model_provider": config.model_provider,
                 "always_switch_after_execution": config.always_switch_after_execution,
                 "settings": config.settings,
+                "usage_markers": config.usage_markers,
             }
 
         data = {"backend": {"order": self.backend_order, "default": self.default_backend}, "message_backend": {"order": self.message_backend_order, "default": self.message_default_backend or self.default_backend}, "backends": backend_data}


### PR DESCRIPTION
Closes #744

Implemented usage_markers field in BackendConfig dataclass to track backend usage patterns. Updated parse_backend_config and save_to_file methods to handle the new field. This enables better backend usage analytics and configuration management.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac2a1-98b8-7d53-bd21-c4e862804639
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #744: Add usage_markers to BackendConfig
Issue Description:
Add usage_markers to BackendConfig

Update `src/auto_coder/llm_backend_config.py` to support `usage_markers`.

- Add `usage_markers: List[str] = field(default_factory=list)` to `BackendConfig` dataclass.
- Update `parse_backend_config` to read `usage_markers` from the config dict.
- Update `save_to_file` to include `usage_markers` when writing to TOML.


Changes Summary:
Perfect! Now let me create a comprehensive summary of the implementation:

## Summary

I have successfully implemented the `usage_markers` feature for the `BackendConfig` class as requested in GitHub issue #744. Here's what was done:

### Changes Made

**1. Updated `src/auto_coder/llm_backend_config.py`:**

- **Added `usage_markers` field to `BackendConfig` dataclass** (line 80):
  ```python
  usage_markers: List[str] = field(default_factory=list)
  ```

- **Updated `parse_backend_config` functi

Commit History Since Branch Creation:
Auto-Coder: Address issue #744

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
codex
Add usage_markers support to BackendConfig

Implemented usage_markers field in BackendConfig dataclass to track backend usage patterns. Updated parse_backend_config and save_to_file methods to handle the new field. This enables better backend usage analytics and configuration management.