### PR TITLE
Update ClaudeClient to use configured usage_markers

### DIFF
--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -40,6 +40,8 @@ class ClaudeClient(LLMClientBase):
             self.openai_api_key = config_backend and config_backend.openai_api_key
             self.openai_base_url = config_backend and config_backend.openai_base_url
             self.settings = config_backend and config_backend.settings
+            # Store usage_markers from config
+            self.usage_markers = (config_backend and config_backend.usage_markers) or []
         else:
             # Fall back to default claude config
             config_backend = config.get_backend_config("claude")
@@ -49,6 +51,8 @@ class ClaudeClient(LLMClientBase):
             self.openai_api_key = config_backend and config_backend.openai_api_key
             self.openai_base_url = config_backend and config_backend.openai_base_url
             self.settings = config_backend and config_backend.settings
+            # Store usage_markers from config
+            self.usage_markers = (config_backend and config_backend.usage_markers) or []
 
         self.default_model = self.model_name
         self.conflict_model = "sonnet"
@@ -111,7 +115,12 @@ class ClaudeClient(LLMClientBase):
             logger.info(f"🤖 Running: claude --print --dangerously-skip-permissions " f"--allow-dangerously-skip-permissions --model {self.model_name} [prompt]")
             logger.info("=" * 60)
 
-            usage_markers = ('api error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"usage limit exceeded', "5-hour limit reached · resets")
+            # Use configured usage_markers if available, otherwise fall back to defaults
+            if self.usage_markers:
+                usage_markers = self.usage_markers
+            else:
+                # Default hardcoded usage markers
+                usage_markers = ('api error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"usage limit exceeded', "5-hour limit reached · resets")
 
             result = CommandExecutor.run_command(
                 cmd,

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -157,3 +157,41 @@ class TestClaudeClient:
 
         escaped = client._escape_prompt("  Hello world  ")
         assert escaped == "Hello world"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_usage_markers_from_config(self, mock_run, mock_get_config):
+        """ClaudeClient should use configured usage_markers from backend config."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_backend.usage_markers = ["custom marker 1", "custom marker 2"]
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Should have loaded usage_markers from config
+        assert client.usage_markers == ["custom marker 1", "custom marker 2"]
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_usage_markers_fallback_to_empty(self, mock_run, mock_get_config):
+        """ClaudeClient should fall back to empty usage_markers when not configured."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_backend.usage_markers = []
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Should have empty usage_markers when not configured
+        assert client.usage_markers == []


### PR DESCRIPTION
Closes #745

Modified ClaudeClient to retrieve and use usage_markers from backend configuration
instead of relying solely on hardcoded defaults. The client now falls back to
default markers if no configuration is provided.
[ERROR] [ImportProcessor] Failed to import dataclass: ENOENT: no such file or directory, access '/workspaces/auto-coder/dataclass'