### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -661,7 +661,21 @@ def _handle_pr_merge(
             update_actions = _update_with_base_branch(repo_name, pr_data, config)
             actions.extend(update_actions)
 
-            # Step 6: If base branch update required pushing changes, skip to next PR
+            # Step 6: Check for special cases from base branch update
+
+            # Check if LLM determined merge would degrade code quality
+            if "ACTION_FLAG:DEGRADING_MERGE_SKIP_MERGE" in update_actions:
+                actions.append(f"LLM determined merge would degrade code quality for PR #{pr_number}, proceeding to fix phase")
+                # Proceed to fixing phase - the PR content needs to be fixed
+                if failed_checks:
+                    github_logs = _get_github_actions_logs(repo_name, config, failed_checks, pr_data)  # type: ignore[arg-type]
+                    fix_actions = _fix_pr_issues_with_testing(repo_name, pr_data, config, github_logs)
+                    actions.extend(fix_actions)
+                else:
+                    actions.append(f"No specific failed checks found for PR #{pr_number}")
+                return actions
+
+            # If base branch update required pushing changes, skip to next PR
             if "ACTION_FLAG:SKIP_ANALYSIS" in update_actions or any("Pushed updated branch" in action for action in update_actions):
                 actions.append(f"Updated PR #{pr_number} with base branch, skipping to next PR for GitHub Actions check")
                 return actions
@@ -868,7 +882,7 @@ def _update_with_base_branch(
             actions.append(f"Merge conflict detected for PR #{pr_number}, using common subroutine for resolution...")
 
             # Use the common subroutine for conflict resolution
-            from .conflict_resolver import _perform_base_branch_merge_and_conflict_resolution
+            from .conflict_resolver import _perform_base_branch_merge_and_conflict_resolution, scan_conflict_markers
 
             conflict_resolved = _perform_base_branch_merge_and_conflict_resolution(
                 pr_number,
@@ -882,7 +896,13 @@ def _update_with_base_branch(
                 actions.append(f"Successfully resolved merge conflicts for PR #{pr_number}")
                 actions.append("ACTION_FLAG:SKIP_ANALYSIS")
             else:
-                actions.append(f"Failed to resolve merge conflicts for PR #{pr_number}")
+                # Check if conflicts are still present (indicating LLM determined degradation)
+                remaining_conflicts = scan_conflict_markers()
+                if remaining_conflicts:
+                    actions.append(f"LLM determined merge would degrade code quality for PR #{pr_number}, skipping merge attempt")
+                    actions.append("ACTION_FLAG:DEGRADING_MERGE_SKIP_MERGE")
+                else:
+                    actions.append(f"Failed to resolve merge conflicts for PR #{pr_number}")
 
     except Exception as e:
         actions.append(f"Error updating with base branch for PR #{pr_number}: {e}")

--- a/src/auto_coder/prompts.yaml
+++ b/src/auto_coder/prompts.yaml
@@ -64,6 +64,34 @@ pr:
 
     Please proceed with resolving these merge conflicts now.
 
+  mergeability_check: |-
+    You are analyzing merge conflicts for PR #$pr_number: $pr_title
+
+    PR Description:
+    $pr_body...
+
+    Merge Conflict Information:
+    $conflict_info
+
+    Commit History Since Branch Creation:
+    $commit_log
+
+    Your task is to determine if this merge can be performed WITHOUT DEGRADING CODE QUALITY.
+
+    IMPORTANT: Be slightly pessimistic - favor re-implementation (skip merge) if unsure.
+
+    Return ONLY one of these exact responses:
+    - "SAFE_TO_MERGE" - if you are confident the merge can be done without code quality degradation
+    - "DEGRADING_MERGE" - if the merge might degrade code quality or introduce bugs, or if you're uncertain
+
+    Consider:
+    1. Are the conflicts in critical code paths?
+    2. Do the conflicting changes seem to have architectural implications?
+    3. Is there significant risk of introducing bugs or breaking functionality?
+    4. Would re-implementing the PR changes be safer?
+
+    Please analyze and respond with either "SAFE_TO_MERGE" or "DEGRADING_MERGE".
+
   github_actions_fix: |-
     Fix the following GitHub Actions test failures for PR #$pr_number:
 


### PR DESCRIPTION
Closes #792

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac3a0-b11e-7062-ad1e-56a006fea8be
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #792: Improve PR Merge and Re-implementation Logic
Issue Description:
# Improve PR Merge and Re-implementation Logic

## Description
Currently, there is an issue where both re-implementation (fixing) and merging are performed for the same PR in `auto-coder`. This behavior is unintended; only one should occur based on the situation.
Additionally, when conflicts exist, we want to intelligently decide whether to attempt a merge (conflict resolution) or proceed to re-implementation based on whether the merge would degrade the code.

## Goal
1. Fix the bug where `_hand

Changes Summary:
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: x-ai/grok-4.1-fast:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac398-1e8f-7c92-9a60-9556254b70a1
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Analyze the following GitHub issue and take appropriate actions:

Repository: kitamura-tetsuo/auto-coder
Issue #792: Improve PR Merge and Re-implementation Logic

Issue Description:
# Improve PR Mer

Commit History Since Branch Creation:
Auto-Coder: Address issue #794 (#800)
Auto-Coder: Address issue #793 (#798)

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
Reconnecting... 1/5
Reconnecting... 2/5
exec
bash -lc 'gh pr view 792 --repo kitamura-tetsuo/auto-coder' in /workspaces/auto-coder exited 1 in 399ms:
GraphQL: Could not resolve to a PullRequest with the number of 792. (repository.pullRequest)
codex
It seems that issue #792 is not a pull request, but likely an issue in the repository. Let me check for information about this issue directly.


exec
bash -lc 'gh issue view 792 --repo kitamura-tetsuo/auto-coder' in /workspaces/auto-coder exited 1 in 445ms:
GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience, see: https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/. (repository.issue.projectCards)
codex
Let me try a different approach to get information about this issue.


exec
bash -lc 'gh issue list --repo kitamura-tetsuo/auto-coder | grep -i "792"' in /workspaces/auto-coder succeeded in 475ms:
792	OPEN	Improve PR Merge and Re-implementation Logic	@auto-coder	2025-11-27 04:35:13 +0000 UTC
Reconnecting... 1/5
codex
Now I have confirmed the issue exists. Let me get more details about issue #792.


exec
bash -lc 'gh issue view 792 --repo kitamura-tetsuo/auto-coder' in /workspaces/auto-coder exited 1 in 484ms:
GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience, see: https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/. (repository.issue.projectCards)
Reconnecting... 1/5
Reconnecting... 2/5
Reconnecting... 3/5
Reconnecting... 4/5
codex
Let me try getting the issue details without the project cards which seems to be causing an error:


exec
bash -lc 'gh issue view 792 --repo kitamura-tetsuo/auto-coder --json title,body,author,state' in /workspaces/auto-coder succeeded in 417ms:
{"author":{"id":"MDQ6VXNlcjEyNjcxNDU2","is_bot":false,"login":"kitamura-tetsuo","name":"tetsuo"},"body":"# Improve PR Merge and Re-implementation Logic\n\n## Description\nCurrently, there is an issue where both re-implementation (fixing) and merging are performed for the same PR in `auto-coder`. This behavior is unintended; only one should occur based on the situation.\nAdditionally, when conflicts exist, we want to intelligently decide whether to attempt a merge (conflict resolution) or proceed to re-implementation based on whether the merge would degrade the code.\n\n## Goal\n1. Fix the bug where `_handle_pr_merge` falls through to the fixing phase even after a successful merge.\n2. Add an LLM-based check to decide if a \"degrade-free appropriate merge\" is possible when conflicts exist.\n\n## Sub-issues\n- [ ] Fix double execution of merge and re-implementation <!-- id: 1 -->\n- [ ] Implement LLM-based mergeability check <!-- id: 2 -->\n","state":"OPEN","title":"Improve PR Merge and Re-implementation Logic"}
exec
bash -lc 'git log --oneline -n 10' in /workspaces/auto-coder succeeded in 11ms:
29ad7e2 Auto-Coder: Address issue #794 (#800)
ff0e884 Auto-Coder: Address issue #793 (#798)
12d8d50 I'll generate a concise pull request message for the configurable usage markers issue. Let me first check if there's more information needed about the implementation. (#790)
e6540c9 Fix branch checkout failure with conflicting branch names (#785)
7b79234 OpenAI Codex v0.63.0 (research preview) (#780)
6b6513a Fix WIP branch processing when \@auto-coder label exists (#779)
14f100e fix: prevent basing new issue branches on closed parent issues (#776)
c745815 Make `enabled = true` the default for LLM backend configurations (#766)
97a1ac5 Add model_provider field to LLM backend config (#761)
35054e8 Add settings field support to Claude backend configuration (#754)
exec
bash -lc 'git branch -a | grep -i "792"' in /workspaces/auto-coder succeeded in 19ms:
* issue-792
  remotes/origin/issue-792
exec
bash -lc 'git log --oneline origin/issue-792..issue-792' in /workspaces/auto-coder succeeded in 10ms:

exec
bash -lc 'git log --oneline origin/main..issue-792' in /workspaces/auto-coder succeeded in 11ms:
29ad7e2 Auto-Coder: Address issue #794 (#800)
ff0e884 Auto-Coder: Address issue #793 (#798)
exec
bash -lc 'git log --oneline issue-792' in /workspaces/auto-coder succeeded in 34ms:
29ad7e2 Auto-Coder: Address issue #794 (#800)
ff0e884 Auto-Coder: Address issue #793 (#798)
12d8d50 I'll generate a concise pull request message for the configurable usage markers issue. Let me first check if there's more information needed about the implementation. (#790)
e6540c9 Fix branch checkout failure with conflicting branch names (#785)
7b79234 OpenAI Codex v0.63.0 (research preview) (#780)
6b6513a Fix WIP branch processing when \@auto-coder label exists (#779)
14f100e fix: prevent basing new issue branches on closed parent issues (#776)
c745815 Make `enabled = true` the default for LLM backend configurations (#766)
97a1ac5 Add model_provider field to LLM backend config (#761)
35054e8 Add settings field support to Claude backend configuration (#754)
8e3f25f Update branch naming to use underscores instead of slashes (#752)
2954c22 Refactor LLM clients to use backend configuration system (#750)
132ccdc Fix issue #699: Prioritize Local .auto-coder/llm_config.toml Over Home Directory Configuration (#728)
5c7dfe9 Add model_provider support to CodexClient (#724)
5484988 Fix TOML parsing to support dotted backend names (#704)
9223b9a Add exit on failed branch switch in github_action.py (#698)
fe35947 I'll read the AGENTS.md file first to understand the context before generating the pull request message. (#697)
784f39f Fix backend validation regression for custom backend aliases (#693)
8f57597 update qwen guide
645a011 Refactor auto-coder lock to use Context Manager (#686)
Reconnecting... 1/5
Reconnecting... 2/5
Reconnecting... 3/5
Reconnecting... 4/5
exec
bash -lc 'git diff origin/main issue-792' in /workspaces/auto-coder succeeded in 17ms:
diff --git a/src/auto_coder/conflict_resolver.py b/src/auto_coder/conflict_resolver.py
index 7b2eb23..44dab68 100644
--- a/src/auto_coder/conflict_resolver.py
+++ b/src/auto_coder/conflict_resolver.py
@@ -190,6 +190,71 @@ def scan_conflict_markers() -> List[str]:
         return []
 
 
+def check_mergeability_with_llm(
+    pr_data: Dict[str, Any],
+    conflict_info: str,
+    config: AutomationConfig,
+) -> bool:
+    """Check if merge can be performed without degrading code quality.
+
+    Args:
+        pr_data: PR data dictionary
+        conflict_info: Merge conflict information
+        config: AutomationConfig instance
+