### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/src/auto_coder/prompts.yaml
+++ b/src/auto_coder/prompts.yaml
@@ -147,6 +147,12 @@ pr:
     Local test command used:
     $test_command
 
+    $if(attempt_history)
+    Previous Fix Attempts (for context - avoid repeating the same mistakes):
+    $attempt_history
+
+    $endif
+
     BRANCH NAMING: If you need to create new branches for any reason, always use the 'issue-<number>' naming convention (e.g., 'issue-123'). NEVER create branches with 'pr-<number>' pattern (e.g., 'pr-123').
 
     Please analyze the test failures and provide specific code fixes.


### PR DESCRIPTION
Closes #807

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac57d-561c-7552-8992-771aabf01480
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #807: Include Past LLM Outputs in Local Test Fix Prompt
Issue Description:
# Include Past LLM Outputs in Local Test Fix Prompt

## Description
In `pr_processor.py`, `_apply_local_test_fix` is called in a loop within `_fix_pr_issues_with_testing`. Currently, each attempt is independent, and the LLM has no context of previous failed attempts for the same test. This can lead to the LLM repeating the same incorrect fixes.

## Requirements
1.  **Track History**: Modify `_fix_pr_issues_with_testing` in `src/auto_coder/pr_processor.py` to track previous LLM outputs and attemp

Changes Summary:
Perfect! Let me provide a summary of the implementation:

## Summary

I have successfully implemented the feature to include past LLM outputs in the local test fix prompt as requested in issue #807. Here's what was done:

### Changes Made:

1. **Updated `_fix_pr_issues_with_testing` function** (`src/auto_coder/pr_processor.py:1361-1438`):
   - Added `attempt_history` list to track previous LLM outputs and test results
   - Modified the function to capture and store LLM responses after each fix a

Commit History Since Branch Creation:
Auto-Coder: Address issue #807

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers