### PR TITLE
OpenAI Codex v0.63.0 (research preview)

### DIFF
--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -156,6 +156,7 @@ class AutomationConfig:
         object.__setattr__(self, "ENABLE_ACTIONS_HISTORY_FALLBACK", True)
         object.__setattr__(self, "MERGE_METHOD", "--squash")
         object.__setattr__(self, "MERGE_AUTO", True)
+        object.__setattr__(self, "AUTO_MERGE_DEPENDABOT_PRS", True)
         object.__setattr__(self, "PR_LABEL_COPYING_ENABLED", True)
         object.__setattr__(self, "PR_LABEL_MAX_COUNT", 3)
         object.__setattr__(
@@ -496,6 +497,10 @@ class AutomationConfig:
     # Enable/disable auto-merge feature
     # Default: True (auto-merge enabled)
     AUTO_MERGE: bool = True
+
+    # Enable/disable auto-merge for Dependabot PRs
+    # Default: True (auto-merge for Dependabot enabled)
+    AUTO_MERGE_DEPENDABOT_PRS: bool = True
 
     # PR label copying configuration
     # Enable or disable copying semantic labels from issues to PRs

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -57,6 +57,11 @@ logger = get_logger(__name__)
     help="Enable auto-merge of PRs when checks pass and PR is mergeable (default: enabled)",
 )
 @click.option(
+    "--auto-merge-dependabot-prs/--no-auto-merge-dependabot-prs",
+    default=True,
+    help="Enable auto-merge of Dependabot PRs when checks pass and PR is mergeable (default: enabled)",
+)
+@click.option(
     "--force-clean-before-checkout/--no-force-clean-before-checkout",
     default=False,
     help="Force clean workspace (git reset --hard + git clean -fd) before PR checkout (default: do not force clean)",
@@ -94,6 +99,7 @@ def process_issues(
     skip_main_update: bool,
     ignore_dependabot_prs: bool,
     auto_merge: bool,
+    auto_merge_dependabot_prs: bool,
     force_clean_before_checkout: bool,
     only_target: Optional[str],
     enable_graphrag: bool,
@@ -148,6 +154,7 @@ def process_issues(
     logger.info(f"Verbose logging: {verbose}")
     logger.info(f"Ignore Dependabot PRs: {ignore_dependabot_prs}")
     logger.info(f"Auto-merge: {auto_merge}")
+    logger.info(f"Auto-merge Dependabot PRs: {auto_merge_dependabot_prs}")
     logger.info(f"Force clean before checkout: {force_clean_before_checkout}")
 
     # Explicitly show base branch update policy for PR checks failure
@@ -164,6 +171,7 @@ def process_issues(
     click.echo(f"Main update before fixes when PR checks fail: {policy_str}")
     click.echo(f"Ignore Dependabot PRs: {ignore_dependabot_prs}")
     click.echo(f"Auto-merge: {auto_merge}")
+    click.echo(f"Auto-merge Dependabot PRs: {auto_merge_dependabot_prs}")
     click.echo(f"Force clean before checkout: {force_clean_before_checkout}")
     click.echo(f"Force reindex: {force_reindex}")
     click.echo(f"Verbose logging: {verbose}")
@@ -218,6 +226,7 @@ def process_issues(
     engine_config.SKIP_MAIN_UPDATE_WHEN_CHECKS_FAIL = bool(skip_main_update)
     engine_config.IGNORE_DEPENDABOT_PRS = bool(ignore_dependabot_prs)
     engine_config.AUTO_MERGE = bool(auto_merge)
+    engine_config.AUTO_MERGE_DEPENDABOT_PRS = bool(auto_merge_dependabot_prs)
     engine_config.DISABLE_LABELS = bool(disable_labels)
     engine_config.FORCE_CLEAN_BEFORE_CHECKOUT = bool(force_clean_before_checkout)
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -41,6 +41,12 @@ class TestCLIMain:
         # New option should appear in help
         assert "--ignore-dependabot-prs" in result.output
 
+    def test_process_issues_help_includes_auto_merge_dependabot_prs_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(process_issues, ["--help"])
+        assert result.exit_code == 0
+        assert "--auto-merge-dependabot-prs" in result.output
+
     def test_process_issues_help(self):
         """Test process-issues command help."""
         runner = CliRunner()


### PR DESCRIPTION
Closes #811

workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac5b3-8c75-7363-a0a7-beaf346dfb9f
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #811: Add Auto-Merge Option: CLI & Config
Issue Description:
Add `--auto-merge-dependabot-prs` CLI option and Config

## Description
Add the new CLI option and update the configuration class.

## Tasks
- [ ] Add `--auto-merge-dependabot-prs/--no-auto-merge-dependabot-prs` to `process_issues` command in `src/auto_coder/cli_commands_main.py`. Default to `True`.
- [ ] Pass `auto_merge_dependabot_prs` to `AutomationConfig` in `src/auto_coder/cli_commands_main.py`.
- [ ] Add `AUTO_MERGE_DEPENDABOT_PRS` field to `AutomationConfig` class in `src/auto_coder/autom

Changes Summary:
I will add the `--auto-merge-dependabot-prs` CLI option and update the `AutomationConfig` class as requested. First, I will add the new field to the `AutomationConfig` class, then I will add the CLI option to the `process_issues` command, and finally, I will add a test to verify the new functionality.
Right, plan's set. First, update `src/auto_coder/automation_config.py`. Reading the file now.
Gotta read `src/auto_coder/automation_config.py` to know the layout, then I'll code.
Okay, I'll update 

Commit History Since Branch Creation:
feat: Add --auto-merge-dependabot-prs option

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers