### PR TITLE
Create Jules configuration and client skeleton

### DIFF
--- a/src/auto_coder/jules_client.py
+++ b/src/auto_coder/jules_client.py
@@ -1,0 +1,73 @@
+"""
+Jules client for Auto-Coder.
+
+This module provides JulesClient, a client for interacting with Jules,
+which adds the 'jules' label to issues in Jules mode.
+"""
+
+from typing import Optional
+
+from .llm_client_base import LLMClientBase
+from .logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class JulesClient(LLMClientBase):
+    """Jules client for handling Jules mode operations.
+
+    Jules adds the 'jules' label to issues and handles them with specific
+    processing logic.
+    """
+
+    def __init__(self, backend_name: Optional[str] = None) -> None:
+        """Initialize Jules client.
+
+        Args:
+            backend_name: Backend name for configuration lookup (optional).
+        """
+        self.backend_name = backend_name
+
+    def _run_llm_cli(self, prompt: str) -> str:
+        """Execute LLM with the given prompt.
+
+        Args:
+            prompt: The prompt to send to the LLM
+
+        Returns:
+            The LLM's response as a string
+
+        Raises:
+            NotImplementedError: This method is not implemented for JulesClient
+        """
+        # Jules client doesn't run LLM directly
+        # It adds labels and delegates to other backends
+        raise NotImplementedError("JulesClient does not run LLM directly")
+
+    def check_mcp_server_configured(self, server_name: str) -> bool:
+        """Check if a specific MCP server is configured for this LLM client.
+
+        Args:
+            server_name: Name of the MCP server to check (e.g., 'graphrag', 'mcp-pdb')
+
+        Returns:
+            True if the MCP server is configured, False otherwise
+        """
+        # Jules client doesn't use MCP servers
+        # This is a placeholder implementation
+        return False
+
+    def add_mcp_server_config(self, server_name: str, command: str, args: list[str]) -> bool:
+        """Add MCP server configuration for this LLM client.
+
+        Args:
+            server_name: Name of the MCP server (e.g., 'graphrag', 'mcp-pdb')
+            command: Command to run the MCP server (e.g., 'uv', '/path/to/script.sh')
+            args: Arguments for the command (e.g., ['run', 'main.py'] or [])
+
+        Returns:
+            True if configuration was added successfully, False otherwise
+        """
+        # Jules client doesn't use MCP servers
+        # This is a placeholder implementation
+        return False

--- a/src/auto_coder/jules_config.py
+++ b/src/auto_coder/jules_config.py
@@ -1,0 +1,87 @@
+"""
+Configuration management for Jules.
+
+This module provides JulesConfig to load and manage Jules-specific
+configuration from ~/.auto-coder/config.toml.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import toml
+
+logger = None  # Will be set in __init__.py
+
+
+@dataclass
+class JulesConfig:
+    """Jules configuration settings.
+
+    Loads configuration from the [jules] section in ~/.auto-coder/config.toml.
+    """
+
+    # Path to config file
+    config_file_path: str = field(default="~/.auto-coder/config.toml")
+
+    # Jules-specific settings
+    enabled: bool = field(default=True)
+
+    # Additional configuration options from [jules] section
+    extra_config: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def load_from_file(cls, config_path: Optional[str] = None) -> "JulesConfig":
+        """Load Jules configuration from TOML file.
+
+        Args:
+            config_path: Optional path to config file. If None, uses default path.
+
+        Returns:
+            JulesConfig instance loaded from the config file
+        """
+        if config_path is None:
+            config_path = cls().config_file_path
+
+        config_path = os.path.expanduser(config_path)
+
+        if not os.path.exists(config_path):
+            # Return default config if file doesn't exist
+            return cls(config_file_path=config_path)
+
+        try:
+            with open(config_path, "r") as f:
+                data = toml.load(f)
+
+            # Parse jules section
+            jules_data = data.get("jules", {})
+
+            # Extract known fields with defaults
+            enabled = jules_data.get("enabled", True)
+            extra_config = {k: v for k, v in jules_data.items() if k not in {"enabled"}}
+
+            return cls(config_file_path=config_path, enabled=enabled, extra_config=extra_config)
+        except Exception as e:
+            # Return default config on error
+            return cls(config_file_path=config_path)
+
+    def get_jules_section(self) -> Dict[str, str]:
+        """Get the raw [jules] section from config as a dictionary.
+
+        Returns:
+            Dictionary containing the [jules] section configuration
+        """
+        import toml
+
+        config_file_path = os.path.expanduser(self.config_file_path)
+
+        if not os.path.exists(config_file_path):
+            return {}
+
+        try:
+            with open(config_file_path, "r") as f:
+                config = toml.load(f)
+                return config.get("jules", {})
+        except Exception:
+            return {}

--- a/tests/test_jules_client.py
+++ b/tests/test_jules_client.py
@@ -1,0 +1,84 @@
+"""Tests for jules_client module."""
+
+import pytest
+
+from src.auto_coder.jules_client import JulesClient
+from src.auto_coder.llm_client_base import LLMClientBase
+
+
+class TestJulesClient:
+    """Test cases for JulesClient class."""
+
+    def test_jules_client_inherits_from_llm_client_base(self):
+        """Test that JulesClient inherits from LLMClientBase."""
+        assert issubclass(JulesClient, LLMClientBase)
+
+    def test_jules_client_init_default(self):
+        """Test JulesClient initialization with default parameters."""
+        client = JulesClient()
+        # Client should initialize without error
+        assert isinstance(client, JulesClient)
+
+    def test_jules_client_init_with_backend_name(self):
+        """Test JulesClient initialization with backend_name parameter."""
+        client = JulesClient(backend_name="test_backend")
+        # Client should initialize with backend_name
+        assert isinstance(client, JulesClient)
+        assert hasattr(client, "backend_name")
+
+    def test_jules_client_run_llm_cli_raises_not_implemented(self):
+        """Test that _run_llm_cli raises NotImplementedError."""
+        client = JulesClient()
+
+        with pytest.raises(NotImplementedError) as excinfo:
+            client._run_llm_cli("test prompt")
+
+        assert "JulesClient does not run LLM directly" in str(excinfo.value)
+
+    def test_jules_client_check_mcp_server_configured_returns_false(self):
+        """Test that check_mcp_server_configured returns False."""
+        client = JulesClient()
+
+        result = client.check_mcp_server_configured("graphrag")
+
+        assert result is False
+
+    def test_jules_client_check_mcp_server_configured_various_servers(self):
+        """Test check_mcp_server_configured with various server names."""
+        client = JulesClient()
+
+        # Should return False for any server name
+        assert client.check_mcp_server_configured("graphrag") is False
+        assert client.check_mcp_server_configured("mcp-pdb") is False
+        assert client.check_mcp_server_configured("unknown") is False
+        assert client.check_mcp_server_configured("") is False
+
+    def test_jules_client_add_mcp_server_config_returns_false(self):
+        """Test that add_mcp_server_config returns False."""
+        client = JulesClient()
+
+        result = client.add_mcp_server_config("graphrag", "uv", ["run", "main.py"])
+
+        assert result is False
+
+    def test_jules_client_add_mcp_server_config_various_params(self):
+        """Test add_mcp_server_config with various parameters."""
+        client = JulesClient()
+
+        # Should always return False regardless of parameters
+        assert client.add_mcp_server_config("graphrag", "uv", ["run"]) is False
+        assert client.add_mcp_server_config("mcp-pdb", "/path/script.sh", []) is False
+        assert client.add_mcp_server_config("", "", []) is False
+        assert client.add_mcp_server_config("test", "command", ["arg1", "arg2"]) is False
+
+    def test_jules_client_is_abstract_base_subclass(self):
+        """Test that JulesClient properly implements the ABC interface."""
+        client = JulesClient()
+
+        # Should have abstract methods from LLMClientBase
+        assert hasattr(client, "_run_llm_cli")
+        assert hasattr(client, "check_mcp_server_configured")
+        assert hasattr(client, "add_mcp_server_config")
+        assert hasattr(client, "ensure_mcp_server_configured")
+        assert hasattr(client, "switch_to_default_model")
+        assert hasattr(client, "close")

--- a/tests/test_jules_config.py
+++ b/tests/test_jules_config.py
@@ -1,0 +1,158 @@
+"""Tests for jules_config module."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+import toml
+
+from src.auto_coder.jules_config import JulesConfig
+
+
+class TestJulesConfig:
+    """Test cases for JulesConfig class."""
+
+    def test_jules_config_default_values(self):
+        """Test creating JulesConfig with default values."""
+        config = JulesConfig()
+        assert config.config_file_path == "~/.auto-coder/config.toml"
+        assert config.enabled is True
+        assert config.extra_config == {}
+
+    def test_jules_config_custom_values(self):
+        """Test creating JulesConfig with custom values."""
+        config = JulesConfig(config_file_path="/custom/path/config.toml", enabled=False, extra_config={"key1": "value1"})
+        assert config.config_file_path == "/custom/path/config.toml"
+        assert config.enabled is False
+        assert config.extra_config == {"key1": "value1"}
+
+    def test_jules_config_load_from_file_default_path(self):
+        """Test loading JulesConfig from default config file."""
+        with patch("os.path.exists", return_value=False):
+            config = JulesConfig.load_from_file()
+
+            assert config.enabled is True
+            # The path should be expanded
+            assert ".auto-coder/config.toml" in config.config_file_path
+
+    def test_jules_config_load_from_file_custom_path(self):
+        """Test loading JulesConfig from a specific config file."""
+        custom_path = "/custom/config.toml"
+
+        with patch("os.path.exists", return_value=False):
+            config = JulesConfig.load_from_file(custom_path)
+
+            assert config.config_file_path == custom_path
+            assert config.enabled is True
+
+    def test_jules_config_load_from_file_nonexistent(self):
+        """Test loading JulesConfig from a non-existent config file."""
+        with patch("os.path.exists", return_value=False):
+            with patch("builtins.open", mock_open(read_data="")) as mock_file:
+                config = JulesConfig.load_from_file("/nonexistent/config.toml")
+
+                # Should return default config without error
+                assert config.enabled is True
+                assert config.config_file_path == "/nonexistent/config.toml"
+                mock_file.assert_not_called()
+
+    def test_jules_config_load_from_file_with_jules_section(self):
+        """Test loading JulesConfig with [jules] section in TOML."""
+        toml_content = """
+[jules]
+enabled = false
+option1 = "value1"
+option2 = "value2"
+"""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=toml_content)):
+                with patch("toml.load") as mock_toml:
+                    mock_toml.return_value = {"jules": {"enabled": False, "option1": "value1", "option2": "value2"}}
+                    config = JulesConfig.load_from_file("/test/config.toml")
+
+                    assert config.enabled is False
+                    assert config.extra_config == {"option1": "value1", "option2": "value2"}
+
+    def test_jules_config_load_from_file_no_jules_section(self):
+        """Test loading JulesConfig without [jules] section."""
+        toml_content = """
+[backend]
+default = "codex"
+"""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=toml_content)):
+                with patch("toml.load") as mock_toml:
+                    mock_toml.return_value = {"backend": {"default": "codex"}}
+                    config = JulesConfig.load_from_file("/test/config.toml")
+
+                    # Should use defaults
+                    assert config.enabled is True
+                    assert config.extra_config == {}
+
+    def test_jules_config_load_from_file_toml_error(self):
+        """Test loading JulesConfig when TOML loading fails."""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data="invalid")):
+                with patch("toml.load", side_effect=Exception("Parse error")):
+                    config = JulesConfig.load_from_file("/test/config.toml")
+
+                    # Should return default config on error
+                    assert config.enabled is True
+                    assert config.config_file_path == "/test/config.toml"
+
+    def test_get_jules_section_returns_dict(self):
+        """Test that get_jules_section returns a dictionary."""
+        toml_content = """
+[jules]
+enabled = true
+option1 = "value1"
+"""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=toml_content)):
+                with patch("toml.load") as mock_toml:
+                    mock_toml.return_value = {"jules": {"enabled": True, "option1": "value1"}}
+                    config = JulesConfig(config_file_path="/test/config.toml")
+
+                    result = config.get_jules_section()
+
+                    assert result == {"enabled": True, "option1": "value1"}
+
+    def test_get_jules_section_no_jules_section(self):
+        """Test get_jules_section when [jules] section doesn't exist."""
+        toml_content = """
+[backend]
+default = "codex"
+"""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=toml_content)):
+                with patch("toml.load") as mock_toml:
+                    mock_toml.return_value = {"backend": {"default": "codex"}}
+                    config = JulesConfig(config_file_path="/test/config.toml")
+
+                    result = config.get_jules_section()
+
+                    assert result == {}
+
+    def test_get_jules_section_file_not_exists(self):
+        """Test get_jules_section when config file doesn't exist."""
+        with patch("os.path.exists", return_value=False):
+            with patch("builtins.open") as mock_file:
+                config = JulesConfig(config_file_path="/test/config.toml")
+
+                result = config.get_jules_section()
+
+                assert result == {}
+                mock_file.assert_not_called()
+
+    def test_get_jules_section_load_error(self):
+        """Test get_jules_section when TOML loading fails."""
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data="invalid")):
+                with patch("toml.load", side_effect=Exception("Parse error")):
+                    config = JulesConfig(config_file_path="/test/config.toml")
+
+                    result = config.get_jules_section()
+
+                    # Should return empty dict on error
+                    assert result == {}


### PR DESCRIPTION
Closes #823

This PR implements the Jules configuration loading and client skeleton as
requested in issue #823. It includes the JulesConfig class for loading settings
from ~/.auto-coder/config.toml and a JulesClient class with initialization and
method stubs. The implementation follows existing codebase patterns.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019acce4-56c3-7850-a735-a582b18894c4
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #823: Create Jules Configuration and Client Skeleton
Issue Description:
- Create `JulesConfig` class to load `[jules]` section from `~/.auto-coder/config.toml`.
- Create `JulesClient` class skeleton with `__init__` and method stubs.

**Files:**
- `src/auto_coder/jules_config.py`
- `src/auto_coder/jules_client.py`


Changes Summary:
Perfect! I've successfully analyzed and implemented the solution for GitHub issue #823. Here's a summary of what was done:

## Summary

I created the Jules configuration and client skeleton as requested in issue #823. The implementation follows the existing codebase patterns and conventions.

### Files Created

1. **`src/auto_coder/jules_config.py`** - A configuration class that:
   - Uses `\@dataclass` decorator following the pattern from `llm_backend_config.py`
   - Loads configuration from the

Commit History Since Branch Creation:
Auto-Coder: Address issue #823

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
codex
Create Jules configuration and client skeleton

This PR implements the Jules configuration loading and client skeleton as
requested in issue #823. It includes the JulesConfig class for loading settings
from ~/.auto-coder/config.toml and a JulesClient class with initialization and
method stubs. The implementation follows existing codebase patterns.