### PR TITLE
Implement Jules Client Logic for Issue #824

### DIFF
--- a/src/auto_coder/jules_client.py
+++ b/src/auto_coder/jules_client.py
@@ -5,8 +5,12 @@ This module provides JulesClient, a client for interacting with Jules,
 which adds the 'jules' label to issues in Jules mode.
 """
 
+import os
 from typing import Optional
 
+import requests
+
+from .jules_config import JulesConfig
 from .llm_client_base import LLMClientBase
 from .logger_config import get_logger
 
@@ -27,6 +31,79 @@ class JulesClient(LLMClientBase):
             backend_name: Backend name for configuration lookup (optional).
         """
         self.backend_name = backend_name
+        self.config = JulesConfig.load_from_file()
+        self.base_url = os.environ.get("JULES_API_URL", "http://localhost:8000")
+
+    def start_session(self, prompt: str) -> str:
+        """Start a new Jules session.
+
+        Args:
+            prompt: The prompt to send to Jules
+
+        Returns:
+            The session ID as a string
+
+        Raises:
+            requests.RequestException: If the API request fails
+        """
+        url = f"{self.base_url}/sessions"
+        payload = {"prompt": prompt, "AUTO_CREATE_PR": True}
+
+        logger.debug(f"Starting Jules session at {url}")
+        logger.debug(f"Sending payload: {payload}")
+
+        try:
+            response = requests.post(url, json=payload, timeout=30)
+            response.raise_for_status()
+
+            # Extract session ID from response
+            data = response.json()
+            session_id = data.get("session_id") or data.get("id")
+
+            if not session_id:
+                raise ValueError("No session_id in response")
+
+            logger.info(f"Started Jules session with ID: {session_id}")
+            return session_id
+
+        except requests.RequestException as e:
+            logger.error(f"Failed to start Jules session: {e}")
+            raise
+        except (ValueError, KeyError) as e:
+            logger.error(f"Invalid response from Jules API: {e}")
+            raise
+
+    def send_message(self, session_id: str, message: str) -> str:
+        """Send a message to an existing Jules session.
+
+        Args:
+            session_id: The session ID from start_session
+            message: The message to send
+
+        Returns:
+            The response from Jules
+
+        Raises:
+            requests.RequestException: If the API request fails
+        """
+        url = f"{self.base_url}/sessions/{session_id}/messages"
+        payload = {"message": message}
+
+        logger.debug(f"Sending message to Jules session {session_id} at {url}")
+        logger.debug(f"Sending payload: {payload}")
+
+        try:
+            response = requests.post(url, json=payload, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            logger.info(f"Received response from Jules session {session_id}")
+
+            return data
+
+        except requests.RequestException as e:
+            logger.error(f"Failed to send message to Jules session {session_id}: {e}")
+            raise
 
     def _run_llm_cli(self, prompt: str) -> str:
         """Execute LLM with the given prompt.

--- a/tests/test_jules_client.py
+++ b/tests/test_jules_client.py
@@ -1,5 +1,7 @@
 """Tests for jules_client module."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from src.auto_coder.jules_client import JulesClient
@@ -82,3 +84,103 @@ class TestJulesClient:
         assert hasattr(client, "ensure_mcp_server_configured")
         assert hasattr(client, "switch_to_default_model")
         assert hasattr(client, "close")
+
+    @patch("requests.post")
+    def test_start_session_success(self, mock_post):
+        """Test start_session returns session ID on successful API call."""
+        client = JulesClient()
+
+        # Mock successful API response
+        mock_response = Mock()
+        mock_response.json.return_value = {"session_id": "test-session-123"}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        session_id = client.start_session("Test prompt")
+
+        assert session_id == "test-session-123"
+        mock_post.assert_called_once()
+
+    @patch("requests.post")
+    def test_start_session_with_id_field(self, mock_post):
+        """Test start_session handles 'id' field in response."""
+        client = JulesClient()
+
+        # Mock successful API response with 'id' instead of 'session_id'
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-session-456"}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        session_id = client.start_session("Test prompt")
+
+        assert session_id == "test-session-456"
+
+    @patch("requests.post")
+    def test_start_session_api_error(self, mock_post):
+        """Test start_session raises exception on API error."""
+        client = JulesClient()
+
+        # Mock API error response
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = Exception("API Error")
+        mock_post.return_value = mock_response
+
+        with pytest.raises(Exception):
+            client.start_session("Test prompt")
+
+    @patch("requests.post")
+    def test_start_session_no_session_id(self, mock_post):
+        """Test start_session raises exception when session_id is missing."""
+        client = JulesClient()
+
+        # Mock response without session_id
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        with pytest.raises(ValueError):
+            client.start_session("Test prompt")
+
+    @patch("requests.post")
+    def test_send_message_success(self, mock_post):
+        """Test send_message returns response on successful API call."""
+        client = JulesClient()
+
+        # Mock successful API response
+        mock_response = Mock()
+        mock_response.json.return_value = {"response": "Test response"}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        response = client.send_message("test-session-123", "Test message")
+
+        assert response == {"response": "Test response"}
+
+    @patch("requests.post")
+    def test_send_message_api_error(self, mock_post):
+        """Test send_message raises exception on API error."""
+        client = JulesClient()
+
+        # Mock API error response
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = Exception("API Error")
+        mock_post.return_value = mock_response
+
+        with pytest.raises(Exception):
+            client.send_message("test-session-123", "Test message")
+
+    def test_init_with_custom_base_url(self, monkeypatch):
+        """Test JulesClient uses custom base URL from environment variable."""
+        monkeypatch.setenv("JULES_API_URL", "http://custom-jules:9000")
+
+        client = JulesClient()
+
+        assert client.base_url == "http://custom-jules:9000"
+
+    def test_init_with_default_base_url(self):
+        """Test JulesClient uses default base URL when env var not set."""
+        client = JulesClient()
+
+        assert client.base_url == "http://localhost:8000"


### PR DESCRIPTION
Closes #824

Added start_session and send_message methods to the JulesClient using the requests library. The implementation includes proper configuration loading and base URL handling for connecting to the Jules service.
[ERROR] [ImportProcessor] Failed to import dataclass: ENOENT: no such file or directory, access '/workspaces/auto-coder/dataclass'