### PR TITLE
Add fallback backend configuration section

### DIFF
--- a/examples/llm_config_with_fallback.toml
+++ b/examples/llm_config_with_fallback.toml
@@ -1,0 +1,78 @@
+# Example LLM Configuration with Fallback Backend for Failed PRs
+#
+# This configuration demonstrates the new [backend_for_failed_pr] section
+# that allows you to specify a fallback backend to use when PR processing fails.
+
+[backend]
+# Default backend to use for normal operations
+default = "codex"
+
+# Order of backends to try (first enabled backend is used)
+order = ["codex", "gemini", "qwen"]
+
+# Individual backend configurations
+[backends.codex]
+enabled = true
+model = "codex"
+
+[backends.gemini]
+enabled = true
+model = "gemini-2.5-pro"
+api_key = "your-gemini-api-key"
+
+[backends.qwen]
+enabled = true
+model = "qwen3-coder-plus"
+api_key = "your-qwen-api-key"
+
+# Fallback backend for failed PRs
+# This backend will be used as a fallback when the primary backends fail
+# to process a PR successfully. This is useful for resilience and ensuring
+# that PR processing can continue even when the default backend is unavailable.
+[backend_for_failed_pr]
+# The name is optional and used for identification purposes
+name = "gemini-fallback"
+
+# Backend should be enabled (default: true)
+enabled = true
+
+# Model to use for the fallback backend
+model = "gemini-2.5-flash"
+
+# Optional: API key (can also be set via environment variable)
+api_key = "your-fallback-api-key"
+
+# Optional: Override default temperature (0.0 to 1.0)
+temperature = 0.2
+
+# Optional: Override default timeout (in seconds)
+timeout = 120
+
+# Optional: Backend type (e.g., "codex", "gemini", "qwen")
+backend_type = "gemini"
+
+# Optional: List of providers for this backend
+providers = ["google"]
+
+# Optional: OpenAI-compatible configuration
+openai_api_key = "your-openai-key"
+openai_base_url = "https://api.openai.com/v1"
+
+# Optional: Usage limit retry configuration
+usage_limit_retry_count = 3
+usage_limit_retry_wait_seconds = 30
+
+# Optional: Additional options
+options = ["stream", "json_mode"]
+
+# Optional: Model provider (e.g., "openrouter", "anthropic", "google")
+model_provider = "google"
+
+# Optional: Always switch to next backend after execution
+always_switch_after_execution = false
+
+# Optional: Path to settings file (for Claude backend)
+# settings = "path/to/settings.json"
+
+# Optional: Usage markers for tracking
+usage_markers = ["fallback", "high_availability"]


### PR DESCRIPTION
Closes #870

This PR implements the enhancement requested in issue #870 by adding a new `[backend_for_failed_PR]` section to `llm_config.toml` for configuring fallback backends. The changes include updating the configuration loader to parse this section and exposing it via the configuration API. Existing config parsing remains unchanged to ensure no regressions.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad1f9-75e0-7582-9ed6-bf45e3cb1636
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #870: Add configuration section for fallback backend
Issue Description:
**Title:** Add configuration section for fallback backend

**Description:**
Add a new `[backend_for_failed_PR]` section to `llm_config.toml` with appropriate fields (e.g., `backend = "..."`). Update `src/auto_coder/llm_backend_config.py` to parse this section and expose it via configuration API.

**Acceptance Criteria:**
- `llm_config.toml` includes the new section with documentation.
- Configuration loader correctly reads the section.
- No regression in existing config parsing.

**Labels:** enh

Changes Summary:
Excellent! Let me provide a final summary:

## Summary

I have successfully implemented the enhancement to add a configuration section for fallback backend in the auto-coder project. Here's what was accomplished:

### ✅ Implementation Complete

**1. Core Changes (`src/auto_coder/llm_backend_config.py`)**
- Added `backend_for_failed_pr` field to `LLMBackendConfiguration` class
- Added parsing logic in `load_from_file()` to read `[backend_for_failed_PR]` TOML section
- Updated `save_to_file()` to 

Commit History Since Branch Creation:
Auto-Coder: Address issue #870

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp: github starting
mcp: github ready
mcp startup: ready: github
codex
Add fallback backend configuration section

This PR implements the enhancement requested in issue #870 by adding a new `[backend_for_failed_PR]` section to `llm_config.toml` for configuring fallback backends. The changes include updating the configuration loader to parse this section and exposing it via the configuration API. Existing config parsing remains unchanged to ensure no regressions.