### PR TITLE
Update documentation for fallback backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ openai_base_url = "https://openrouter.ai/api/v1"
 
 Supported `backend_type` values: `codex`, `codex-mcp`, `gemini`, `qwen`, `auggie`, `claude`
 
-For detailed configuration examples and troubleshooting, see [Custom Backend Configuration](docs/Custom_Backend_Configuration.md).
+For detailed configuration examples and troubleshooting, including the new fallback backend feature, see [Configuration Guide](docs/configuration.md).
 
 #### Configuring Model Provider
 
@@ -721,7 +721,7 @@ Auto-Coder supports multiple backend types. When using custom backend names, you
 **Important:** Custom backend names require the `backend_type` field. Standard backend names (`codex`, `gemini`, `qwen`, `claude`, `jules`, `auggie`) work without this field.
 
 For more details, see:
-- [Custom Backend Configuration Guide](docs/Custom_Backend_Configuration.md)
+- [Configuration Guide](docs/configuration.md)
 - [OpenRouter Setup Guide](OPENROUTER_SETUP.md)
 - [Example Configuration File](docs/llm_backend_config.example.toml)
 
@@ -1529,7 +1529,7 @@ openai_api_key = "your-key"
 openai_base_url = "https://openrouter.ai/api/v1"
 ```
 
-See [Custom Backend Configuration](docs/Custom_Backend_Configuration.md) for detailed troubleshooting.
+See [Configuration Guide](docs/configuration.md) for detailed troubleshooting.
 
 ### Checking Logs
 


### PR DESCRIPTION
Closes #872

Documented the new `[backend_for_failed_pr]` section in `docs/configuration.md` with its purpose, usage examples, and triggering conditions. This provides clear guidance on how Auto-Coder automatically switches to alternative backends after multiple PR attempt failures.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad22b-4b78-7030-bec7-f3f9091a0e61
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #872: Update documentation for fallback backend
Issue Description:
**Title:** Update documentation for fallback backend

**Description:**
Add documentation to `docs/configuration.md` describing the new `[backend_for_failed_PR]` section, its purpose, and usage examples.

**Acceptance Criteria:**
- Documentation includes the new section with clear examples.
- No broken links or markdown errors.

**Depends on:** #871 

**Labels:** documentation


Changes Summary:
## Summary

I have successfully addressed **Issue #872** - *Update documentation for fallback backend*. Here's what was completed:

### ✅ Documentation Created

**Created `/workspaces/auto-coder/docs/configuration.md`** (316 lines, 8.8KB)

This comprehensive guide includes:
- **Complete overview** of Auto-Coder configuration structure
- **Detailed `[backend_for_failed_pr]` section** documentation with:
  - Purpose and use cases
  - When it's triggered (3+ attempt threshold)
  - All configuration

Commit History Since Branch Creation:
Auto-Coder: Address issue #872

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp: github starting
mcp: github ready
mcp startup: ready: github
Reconnecting... 1/5
codex
Update documentation for fallback backend configuration

Documented the new `[backend_for_failed_pr]` section in `docs/configuration.md` with its purpose, usage examples, and triggering conditions. This provides clear guidance on how Auto-Coder automatically switches to alternative backends after multiple PR attempt failures.