### PR TITLE
Now that I've read AGENTS.md, I'll create a todo list to track the task of updating the PR message prompt to request JSON output.

### DIFF
--- a/src/auto_coder/prompts.yaml
+++ b/src/auto_coder/prompts.yaml
@@ -458,15 +458,11 @@ pr:
     Requirements:
     - Title: A clear, concise title (max 72 characters) that describes the changes
     - Body: A brief description of what was changed and why (2-3 sentences)
-    - Format: Return ONLY the title on the first line, followed by a blank line, then the body
+    - Format: Return the response as a JSON object with "title" and "body" fields
     - Do NOT include any markdown formatting, headers, or extra text
 
     Example format:
-    Fix authentication bug in login flow
-
-    Updated the authentication logic to properly handle edge cases when users
-    have special characters in their passwords. This resolves the login failures
-    reported in the issue.
+    {"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
 
 issue:
   action: |-


### PR DESCRIPTION
Closes #877

Let me first read the current content of the prompts.yaml file to understand the current PR message prompt:

I can see the current PR message prompt in the file. Let me continue reading to see the complete `pr_message` section:

Perfect! I found the `pr_message` section in the prompts.yaml file. Now I can see that it already has the JSON format requirement, but let me check if it still has the old instructions about returning only the title on the first line that need to be removed. Looking at the current content, I can see that:

1. It already requests JSON format with "Format: Return the response as a JSON object with "title" and "body" fields"
2. It has the example in JSON format: `{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}`

Wait, let me check the issue description again - it seems like the example in the current version is already in JSON format, but the issue description mentions removing instructions about returning only the title on the first line. Let me look more closely at the requirements section:

The current requirements are:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Actually, looking at the current prompt, it already seems to be requesting JSON format. But let me check if there might have been some text that mentioned returning only the title on the first line previously. Let me examine the original issue description again and make sure I understand the change correctly.

According to the issue description, the format should be `{"title": "...", "body": "..."}` and instructions about returning only the title on the first line should be removed. Since the current format already mentions JSON format, I should make sure the prompt is updated to specifically request the JSON format as expected and ensure there are no references to the old format.

Let me update the todo list and mark the first task as completed:

Looking more carefully at the current `pr_message` prompt, I can see that it already requests JSON format, but I need to check if there were older instructions that mentioned returning only the title on the first line that should be removed. Looking at the requirements section:

```
Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text
```

The current version already requests JSON format. However, the issue description mentions "Remove instructions about returning only the title on the first line," which makes me think there might have been previous text in the prompt that I need to look for. Let me look for any references to "first line" in the prompt.

Looking at the current version, I don't see any explicit instruction about "returning only the title on the first line". However, I think the issue might be referring to the example format that was previously in plain text format rather than JSON format. I notice that the example is already in JSON format.

Wait, let me reread the issue description more carefully:

> "Files:
> - src/auto_coder/prompts.yaml
> 
> Changes Summary:
> Perfect! I have successfully analyzed and implemented the requested changes for GitHub issue #877.
> 
> ## Summary
> 
> I've successfully updated the PR message prompt to request JSON output as requested in issue #877.
> 
> ### Changes Implemented
> 
> 1. **Updated `src/auto_coder/prompts.yaml`** (lines 445-465)
>    - Changed format requirement from plain text to JSON
>    - New expected format: `{"title": "...", "body": "..."}`
>    - Removed instructions about returning only title on first line
>    - Updated exampl"

This seems to be an example of what the changes should look like, not the actual current state. The description is suggesting that the format was previously plain text and should be changed to JSON. Let me check if there are any instructions about returning the title on the first line that need to be removed.

Looking at the current content, since I don't see any explicit instructions about returning only the title on the first line, I should still update the prompt to ensure it clearly requests JSON format and make sure there are no remnants of the old format instructions. I'll make the update to ensure it's clear that only JSON format is expected:

Wait, I made a change but I need to make sure I correctly understood the original format. The issue said to remove instructions about returning only the title on the first line. Let me check if there were any such instructions in the original prompt that I may have missed. Let me review the original prompt again more carefully:

Based on the issue description and the original structure, it seems I may have misinterpreted the original prompt. Let me revert my change to examine the original content properly, then apply the correct update:

I see that my edit was applied, but I need to make sure I have the correct original content first. Based on the issue description, there should have been text about returning only the title on the first line that needed to be removed. Let me see if I can determine what the original prompt looked like based on the issue description.

According to the issue, the original format was probably something like the one that required returning only the title on the first line. Let me revert and apply the correct change:

Based on the issue description, the original might have looked something more like this (based on the example format given in the issue):

```
Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
```

So the original might have had instructions about returning the title on the first line before being changed to JSON. Let me update the content properly, reverting my change first by restoring the original expected structure based on the issue description:

Let me first check what the original content should have been using git to see the original content:

Interesting! The content in the repository shows that the prompt already has JSON format required. Let me check the git log to see if there was a previous version that had the old format:

Perfect! Now I can see the issue clearly. The commit was already made to update the prompt to JSON format, changing from the old format that had "Return ONLY the title on the first line, followed by a blank line, then the body" to the JSON format. 

Since it appears the change has already been implemented in the repository according to the git log, let me check the current file to see if my change is correct or if I need to revert to the exact version in the commit:

I see! My edit made additional changes beyond the original commit. The original commit changed from the "first line title" format to "JSON object" format, but I then further modified it to be even more explicit. I should revert my changes and go back to what was in the HEAD commit to match what was originally requested in issue #877:

Now, let me check the current content of the file to see what the actual content is in the HEAD version:

Perfect! Now I can see the actual current state. The original commit for issue #877 has already been made, and the prompt already requests JSON format and has the JSON example. The changes have already been implemented in the repository as specified in the issue.

Let me update my todo list to reflect the correct status:

Let me verify that the changes are correctly implemented according to the requirements:

1. The format requirement has been changed from plain text to JSON
2. The expected format is `{"title": "...", "body": "..."}`
3. Instructions about returning only the title on the first line have been removed
4. The example is in JSON format

Looking at the current content:
- Line 458-464 shows: `Format: Return the response as a JSON object with "title" and "body" fields`
- The example format is: `{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}`

The original format requirement before the change was something like "Return ONLY the title on the first line, followed by a blank line, then the body" which has been replaced with JSON format. This matches what was requested in the issue.

I can confirm that the changes have been correctly implemented. Let me complete the final todo:

Based on my analysis of the issue and the current state of the code, I can see that the changes for issue #877 have already been implemented in the repository. Let me provide the concise pull request message as requested:

## Summary

The changes for issue #877 have already been successfully implemented. The `pr.pr_message` prompt in `src/auto_coder/prompts.yaml` has been updated to request JSON output in the format `{"title": "...", "body": "..."}`.

### Changes Implemented
1. **Updated `src/auto_coder/prompts.yaml`** (lines 458-464)
   - Changed format requirement from plain text to JSON
   - New expected format: `{"title": "...", "body": "..."}`
   - Removed instructions about returning only title on first line
   - Updated example to JSON format

The prompt now correctly requests:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Example format:
```json
{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
```

The implementation is complete and matches the requirements specified in issue #877.
[ERROR] [ImportProcessor] Failed to import dataclass: ENOENT: no such file or directory, access '/workspaces/auto-coder/dataclass'