### PR TITLE
{"title": "Implement JSON parsing logic in Backend Manager", "body": "Added a helper method to parse LLM output as JSON in Backend Manager. The implementation handles both list and dictionary responses, extracting content appropriately. This resolves issue #876 by providing a standardized way to process LLM responses."}

### DIFF
--- a/src/auto_coder/backend_manager.py
+++ b/src/auto_coder/backend_manager.py
@@ -513,6 +513,7 @@ class BackendManager(LLMBackendManagerBase):
         - Text followed by JSON (e.g., "Here's the result: {...}")
         - JSON followed by text (e.g., "{...}\n\nAdditional info")
         - Text, JSON, and more text (e.g., "Result: {...}\nEnd")
+        - Responses that include the prompt content before the final JSON block
 
         For list outputs (conversation history), extracts the content from the last message.
         For dict outputs, returns the dict directly.
@@ -526,46 +527,53 @@ class BackendManager(LLMBackendManagerBase):
         Raises:
             ValueError: If the output cannot be parsed as JSON
         """
-        # Try to find JSON in the output using regex
-        # This handles cases where JSON is embedded in text
-        json_pattern = r"\{.*\}|\[.*\]"
-        match = re.search(json_pattern, output, re.DOTALL)
 
-        if match:
-            json_str = match.group(0)
-        else:
-            # No JSON-like structure found, try the whole string
-            json_str = output
+        def _extract_content(parsed: Any) -> Any:
+            """Extract the relevant content from parsed JSON."""
+            if isinstance(parsed, list):
+                if not parsed:
+                    raise ValueError("Parsed JSON is an empty list")
+                last_message = parsed[-1]
+                if isinstance(last_message, dict):
+                    for key in ("content", "message", "text", "response"):
+                        if key in last_message:
+                            return last_message[key]
+                    return last_message
+                return last_message
+            if isinstance(parsed, dict):
+                return parsed
+            return parsed
 
+        # First, try to parse the entire output (covers primitive JSON values)
+        stripped_output = output.strip()
         try:
-            parsed = json.loads(json_str)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse output as JSON: {e}\nOutput: {output}")
+            parsed_full = json.loads(stripped_output)
+            return _extract_content(parsed_full)
+        except json.JSONDecodeError:
+            pass
 
-        # If the parsed JSON is a list (history), extract the last message content
-        if isinstance(parsed, list):
-            if not parsed:
-                raise ValueError("Parsed JSON is an empty list")
-            # Get the last message in the history
-            last_message = parsed[-1]
-            # Extract the content based on the structure
-            if isinstance(last_message, dict):
-                # Try common keys for message content
-                content_keys = ["content", "message", "text", "response"]
-                for key in content_keys:
-                    if key in last_message:
-                        return last_message[key]
-                # If no known content key found, return the entire last message as fallback
-                return last_message
-            else:
-                # Last message is not a dict, return it directly
-                return last_message
-        elif isinstance(parsed, dict):
-            # If it's a dict, use it directly
-            return parsed
-        else:
-            # For other types (str, int, etc.), return directly
-            return parsed
+        # Fall back to scanning for the last valid JSON block in the output
+        decoder = json.JSONDecoder()
+        json_candidates: List[Any] = []
+        search_pos = 0
+
+        while search_pos < len(output):
+            match = re.search(r"[\\[{]", output[search_pos:])
+            if not match:
+                break
+            start = search_pos + match.start()
+            try:
+                parsed_partial, end = decoder.raw_decode(output[start:])
+                json_candidates.append(parsed_partial)
+                search_pos = start + end
+            except json.JSONDecodeError:
+                search_pos = start + 1
+
+        if not json_candidates:
+            raise ValueError(f"Failed to parse output as JSON: No JSON object could be decoded\nOutput: {output}")
+
+        # Use the last successfully parsed JSON block (handles prompt + JSON scenarios)
+        return _extract_content(json_candidates[-1])
 
     # ---------- Compatibility Helpers ----------
     def switch_to_conflict_model(self) -> None:

--- a/tests/test_backend_manager.py
+++ b/tests/test_backend_manager.py
@@ -797,6 +797,36 @@ def test_parse_json_list_with_prefix_and_suffix_text():
     assert result == "last"
 
 
+def test_parse_json_uses_last_block_when_prompt_included():
+    """When prompt echo precedes response JSON, use the final JSON block."""
+    client = DummyClient("a", "m1", "ok", [])
+    mgr = BackendManager(
+        default_backend="a",
+        default_client=client,
+        factories={"a": lambda: client},
+        order=["a"],
+    )
+
+    output = 'Prompt payload: {"instruction": "do something"}\n{"result": "final"}'
+    result = mgr.parse_llm_output_as_json(output)
+    assert result == {"result": "final"}
+
+
+def test_parse_json_list_after_prompt_block():
+    """Handles prompt JSON followed by response history list."""
+    client = DummyClient("a", "m1", "ok", [])
+    mgr = BackendManager(
+        default_backend="a",
+        default_client=client,
+        factories={"a": lambda: client},
+        order=["a"],
+    )
+
+    output = 'Prompt: {"question": "hi"}\n[{"content": "draft"}, {"content": "final answer"}]'
+    result = mgr.parse_llm_output_as_json(output)
+    assert result == "final answer"
+
+
 def test_parse_json_empty_list_raises_error():
     """Test that parsing an empty list raises ValueError."""
     client = DummyClient("a", "m1", "ok", [])


### PR DESCRIPTION
Closes #876

--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad346-a011-7341-9ef9-1bc156680181
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #876: Implement JSON parsing logic in Backend Manager
Issue Description:
Implement a helper method in `src/auto_coder/backend_manager.py` to parse LLM output as JSON.
- Parse the output as JSON.
- If the parsed JSON is a list (history), extract the content of the last message.
- If it's a dictionary, use it directly.
- Handle cases where the response contains the prompt followed by JSON.
- Return the extracted content.

Files:
- src/auto_coder/backend_manager.py

Changes Summary:
## Summary

I analyzed GitHub issue #876 which requested the implementation of JSON parsing logic in the Backend Manager. Here's what I found and did:

### Current Status: ✅ COMPLETED

The implementation is **already complete** and has been merged via PR #888. I verified the implementation and properly closed the GitHub issue.

### What Was Implemented

The `parse_llm_output_as_json` helper method was successfully implemented in:
- **File**: `src/auto_coder/backend_manager.py` (lines 507-576)

#

Commit History Since Branch Creation:
WIP: Auto-commit before branch checkout

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Example format:
{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
mcp: github starting
mcp: github failed: MCP client for `github` failed to start: MCP startup failed: Environment variable GITHUB_PERSONAL_ACCESS_TOKEN for MCP server 'github' is not set
mcp startup: failed: github
Reconnecting... 1/5
codex
{"title": "Implement JSON parsing logic in Backend Manager", "body": "Added a helper method to parse LLM output as JSON in Backend Manager. The implementation handles both list and dictionary responses, extracting content appropriately. This resolves issue #876 by providing a standardized way to process LLM responses."}