### PR TITLE
{"title": "Add tests for auto-reopen flow of closed parent issues", "body": "Added new test coverage to verify that closed parent issues are properly reopened and that the correct base branch is selected. The test ensures reopen_issue() is invoked and that branch selection logic works correctly while maintaining existing open-parent behavior."}

### DIFF
--- a/tests/test_issue_processor_parent_state.py
+++ b/tests/test_issue_processor_parent_state.py
@@ -77,3 +77,51 @@ def test_apply_issue_actions_directly_open_parent(mock_cmd_executor_class, mock_
                 break
 
     assert found_parent_check, "Should have checked for parent branch issue-101"
+
+
+@patch("auto_coder.issue_processor.cmd")
+@patch("auto_coder.issue_processor.get_current_attempt")
+@patch("auto_coder.issue_processor.branch_context")
+@patch("auto_coder.issue_processor.get_llm_backend_manager")
+@patch("auto_coder.git_info.CommandExecutor")
+def test_apply_issue_actions_directly_closed_parent_reopens(mock_cmd_executor_class, mock_get_llm_backend_manager, mock_branch_context, mock_get_current_attempt, mock_cmd, mock_github_client, mock_config):
+    # Setup
+    repo_name = "owner/repo"
+    issue_data = {"number": 125, "title": "Test Issue Closed Parent", "body": "Body", "labels": []}
+
+    # Mock parent issue details as CLOSED
+    mock_github_client.get_parent_issue_details.return_value = {"number": 102, "title": "Parent Issue Closed", "state": "CLOSED", "url": "http://github.com/owner/repo/issues/102"}
+
+    # Mock git commands - use return_value to handle any number of calls
+    mock_cmd.run_command.return_value = _cmd_result(success=True, returncode=0, stdout="main")
+
+    # Mock CommandExecutor used by get_current_branch
+    mock_git_info_cmd = MagicMock()
+    mock_git_info_cmd.run_command.return_value = _cmd_result(success=True, returncode=0, stdout="main")
+    mock_cmd_executor_class.return_value = mock_git_info_cmd
+
+    # Mock get_current_attempt
+    mock_get_current_attempt.return_value = 1
+
+    # Run
+    _apply_issue_actions_directly(repo_name, issue_data, mock_config, mock_github_client)
+
+    # Verify
+    # Should call get_parent_issue_details
+    mock_github_client.get_parent_issue_details.assert_called_with(repo_name, 125)
+
+    # Verify that reopen_issue was called with the correct parameters
+    expected_audit_comment = "Auto-Coder: Reopened this parent issue to process child issue #125. Branch and base selection will use the parent context."
+    mock_github_client.reopen_issue.assert_called_with(repo_name, 102, expected_audit_comment)
+
+    # Verify that after reopening, it checks for parent branch existence (same as open parent)
+    found_parent_check = False
+    for call in mock_cmd.run_command.call_args_list:
+        args, _ = call
+        cmd_list = args[0]
+        if "rev-parse" in cmd_list and "--verify" in cmd_list:
+            if "issue-102" in cmd_list[3]:
+                found_parent_check = True
+                break
+
+    assert found_parent_check, "Should have checked for parent branch issue-102 after reopening"


### PR DESCRIPTION
Closes #926

--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad363-b826-7223-91a9-a98f016eb95d
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #926: Tests: parent issue auto-reopen flow
Issue Description:
Depends on #925\n\n## Goal\nAdd/adjust tests covering the auto-reopen behavior when a parent issue starts closed, ensuring branch/base selection uses the reopened parent and open-parent behavior remains intact.\n\n## Scope\n- Extend tests/test_issue_processor_parent_state.py with assertions for reopen_issue invocation and base-branch selection when parent is initially closed.\n- Keep existing open-parent scenario passing.\n- Add shared fixtures only if necessary (e.g., in tests/conftest.py).\n\n

Changes Summary:
Perfect! All tests pass. Let me verify the solution meets all the acceptance criteria from the issue:

## Summary

I've successfully implemented the tests for issue #926 to cover the auto-reopen behavior for closed parent issues.

### Changes Made

**File Modified:** `tests/test_issue_processor_parent_state.py` (lines 82-127)
- Added new test: `test_apply_issue_actions_directly_closed_parent_reopens`

### What the Test Verifies

1. **Reopen invocation**: Confirms `reopen_issue()` is called with 

Commit History Since Branch Creation:
Auto-Coder: Address issue #926

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Example format:
{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
mcp: github starting
mcp: github failed: MCP client for `github` failed to start: MCP startup failed: Environment variable GITHUB_PERSONAL_ACCESS_TOKEN for MCP server 'github' is not set
mcp startup: failed: github
codex
{"title": "Add tests for auto-reopen flow of closed parent issues", "body": "Added new test coverage to verify that closed parent issues are properly reopened and that the correct base branch is selected. The test ensures reopen_issue() is invoked and that branch selection logic works correctly while maintaining existing open-parent behavior."}