### PR TITLE
{"title": "Implement caching logic in GitHubClient for sub-issues", "body": "Added caching mechanism to `get_open_sub_issues` method using a dictionary to store results keyed by (repo_name, issue_number). This improves performance by avoiding redundant API calls for the same sub-issue queries."}

### DIFF
--- a/src/auto_coder/github_client.py
+++ b/src/auto_coder/github_client.py
@@ -363,6 +363,13 @@ class GitHubClient:
         Returns:
             List of issue numbers that are linked to the issue and are still open.
         """
+        # Construct cache key
+        cache_key = (repo_name, issue_number)
+
+        # Check if result exists in cache
+        if cache_key in self._sub_issue_cache:
+            return self._sub_issue_cache[cache_key]
+
         try:
             owner, repo = repo_name.split("/")
 
@@ -420,6 +427,9 @@ class GitHubClient:
 
             if open_sub_issues:
                 logger.info(f"Issue #{issue_number} has {len(open_sub_issues)} open sub-issue(s): {open_sub_issues}")
+
+            # Store result in cache before returning
+            self._sub_issue_cache[cache_key] = open_sub_issues
 
             return open_sub_issues
 


### PR DESCRIPTION
Closes #883

--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad367-8d7d-7a42-8bed-df626a7c8afe
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #883: Implement Caching Logic in GitHubClient
Issue Description:
Implement the actual caching logic within `GitHubClient`.

**Files to Modify:**
- `src/auto_coder/github_client.py`

**Changes:**
1.  Update `get_open_sub_issues(self, repo_name: str, issue_number: int) -> List[int]`:
    - Construct a cache key (e.g., `(repo_name, issue_number)`).
    - Check if the key exists in `self._sub_issue_cache`.
    - If it exists, return the cached list immediately.
    - If not, proceed with the API call.
    - Store the result in `self._sub_issue_cache` before retur

Changes Summary:
Perfect! Let me create a summary of the changes:

## Summary

I've successfully implemented the caching logic in the `GitHubClient` class as requested in **Issue #883**.

### Changes Made to `/workspaces/auto-coder/src/auto_coder/github_client.py`:

1. **Updated `get_open_sub_issues` method** (lines 356-441):
   - **Line 366-367**: Construct cache key using tuple `(repo_name, issue_number)`
   - **Lines 369-371**: Check if result exists in cache and return immediately if found
   - **Line 432**:

Commit History Since Branch Creation:
Auto-Coder: Address issue #883

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Example format:
{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
mcp: github starting
mcp: github failed: MCP client for `github` failed to start: MCP startup failed: Environment variable GITHUB_PERSONAL_ACCESS_TOKEN for MCP server 'github' is not set
mcp startup: failed: github
codex
{"title": "Implement caching logic in GitHubClient for sub-issues", "body": "Added caching mechanism to `get_open_sub_issues` method using a dictionary to store results keyed by (repo_name, issue_number). This improves performance by avoiding redundant API calls for the same sub-issue queries."}