### PR TITLE
{"title": "Document parent issue auto-reopen behavior", "body": "Added documentation for the parent issue auto-reopen behavior when processing child issues. Updated docs/client-features.yaml to explain that closed parents are automatically reopened and that subsequent branch/base selection uses the parent context."}

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,35 @@ auto-coder process --only 704
 auto-coder process --check-labels
 ```
 
+## Parent Issue Auto-Reopen
+
+When processing child issues in a parent-child relationship, Auto-Coder automatically handles closed parent issues:
+
+### Auto-Reopen Behavior
+
+**When processing a child issue whose parent is closed:**
+1. The system automatically reopens the parent issue before continuing
+2. Branch selection and base branch selection use the parent issue context
+3. Attempt tracking operates within the parent issue context
+4. This ensures proper workflow continuity and prevents branch naming conflicts
+
+### Why This Matters
+
+This behavior is critical for maintaining consistency when:
+- Working with hierarchical issue structures
+- Managing parent-child issue dependencies
+- Ensuring branch and attempt tracking remain coherent
+- Preventing branch naming and base selection issues during child issue processing
+
+### Example
+
+If you have issue #100 (parent) with child issue #101:
+- Issue #101 is being processed
+- Issue #100 (parent) is closed
+- Auto-Coder automatically reopens #100
+- All branch operations and attempts now use #100's context
+- Processing continues with proper parent context maintained
+
 ## Configuration
 
 ### Configuration File Locations

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -257,6 +257,10 @@ This fork maintains full attribution to the original author Riley Lemm. The orig
       - "Backend fallback provides a fresh perspective using a different LLM after multiple failed attempts, improving chances of successful PR resolution."
     propagation:
       - "increment_attempt also reopens closed sub-issues and bumps their counters to keep parent/child attempts in sync."
+    parent_handling:
+      - "When processing a child issue whose parent issue is closed, the system automatically reopens the parent issue before continuing"
+      - "This ensures branch selection, base branch selection, and attempt tracking use the parent issue context"
+      - "Reopening closed parents maintains proper workflow continuity and prevents branch naming and base selection issues"
 
 ## Lock Mechanism
 


### PR DESCRIPTION
Closes #927

--------
workdir: /workspaces/auto-coder
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ad36a-fc73-7d03-811f-841359196111
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #927: Docs: document parent issue auto-reopen behavior
Issue Description:
Depends on #925\n\n## Goal\nDocument that child-issue processing will reopen a closed parent before continuing, and that branch/base selection and attempts then use the parent context.\n\n## Scope\n- Update attempt/parent handling section in docs/client-features.yaml.\n- Add a brief note in README.md or GLOBAL_BACKEND_MANAGER_USAGE.md if user-facing behavior needs mention (keep ≤3 files total).\n\n## Files to change\n- docs/client-features.yaml\n- README.md or GLOBAL_BACKEND_MANAGER_USAGE.md (pi

Changes Summary:
## Summary

I've successfully documented the parent issue auto-reopen behavior as requested in issue #927. The changes were made to 2 files with a total of 33 lines added (well under the 100-line limit).

### Changes Made:

**1. docs/client-features.yaml** (4 lines added)
   - Added a new `parent_handling` subsection under the `Attempt Mechanism` section
   - Documents that closed parent issues are automatically reopened when processing child issues
   - Explains that branch/base selection and a

Commit History Since Branch Creation:
Auto-Coder: Address issue #927

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return the response as a JSON object with "title" and "body" fields
- Do NOT include any markdown formatting, headers, or extra text

Example format:
{"title": "Fix authentication bug in login flow", "body": "Updated the authentication logic to properly handle edge cases when users have special characters in their passwords. This resolves the login failures reported in the issue."}
mcp: github starting
mcp: github failed: MCP client for `github` failed to start: MCP startup failed: Environment variable GITHUB_PERSONAL_ACCESS_TOKEN for MCP server 'github' is not set
mcp startup: failed: github
codex
{"title": "Document parent issue auto-reopen behavior", "body": "Added documentation for the parent issue auto-reopen behavior when processing child issues. Updated docs/client-features.yaml to explain that closed parents are automatically reopened and that subsequent branch/base selection uses the parent context."}