### PR TITLE
Add session resume support to LLMClientBase interface

### DIFF
--- a/src/auto_coder/llm_client_base.py
+++ b/src/auto_coder/llm_client_base.py
@@ -3,7 +3,7 @@ Base class for LLM clients.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import List, Optional
 
 
 class LLMClientBase(ABC):
@@ -11,6 +11,13 @@ class LLMClientBase(ABC):
 
     All LLM clients must implement the _run_llm_cli method and MCP configuration methods.
     """
+
+    def __init__(self) -> None:
+        """Initialize the LLM client base.
+
+        This is optional and can be overridden by subclasses.
+        """
+        self._extra_args: List[str] = []
 
     @abstractmethod
     def _run_llm_cli(self, prompt: str) -> str:
@@ -90,6 +97,28 @@ class LLMClientBase(ABC):
         Default implementation does nothing.
         """
         pass
+
+    def get_last_session_id(self) -> Optional[str]:
+        """Get the last session ID for session resumption.
+
+        This is optional and can be overridden by subclasses.
+        Default implementation returns None.
+
+        Returns:
+            The last session ID if available, None otherwise
+        """
+        return None
+
+    def set_extra_args(self, args: List[str]) -> None:
+        """Store extra arguments to be used in the next execution.
+
+        This is optional and can be overridden by subclasses.
+        Default implementation stores the args internally.
+
+        Args:
+            args: List of extra arguments to store for the next execution
+        """
+        self._extra_args = args
 
 
 class LLMBackendManagerBase(LLMClientBase):


### PR DESCRIPTION
Closes #896

Implemented the required interface changes for session resumption support in LLM clients. Added get_last_session_id() method that returns the last session ID for resumption, and set_extra_args() method to store arguments for next execution. Both methods have default implementations for backward compatibility.