### PR TITLE
Implement Session Resume Support in ClaudeClient

### DIFF
--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -3,8 +3,9 @@ Claude CLI client for Auto-Coder.
 """
 
 import os
+import re
 import subprocess
-from typing import Optional
+from typing import List, Optional
 
 from .exceptions import AutoCoderTimeoutError, AutoCoderUsageLimitError
 from .llm_backend_config import get_llm_config
@@ -58,6 +59,11 @@ class ClaudeClient(LLMClientBase):
         self.conflict_model = "sonnet"
         self.timeout = None
 
+        # Initialize extra args and session tracking
+        self._extra_args: List[str] = []
+        self._last_session_id: Optional[str] = None
+        self._last_output: Optional[str] = None
+
         try:
             result = subprocess.run(["claude", "--version"], capture_output=True, text=True, timeout=10)
             if result.returncode != 0:
@@ -97,6 +103,13 @@ class ClaudeClient(LLMClientBase):
             if self.settings:
                 cmd.extend(["--settings", self.settings])
 
+            # Append extra args if any (e.g., --resume <session_id>)
+            if self._extra_args:
+                cmd.extend(self._extra_args)
+                logger.debug(f"Using extra args: {self._extra_args}")
+                # Clear extra args after use (one-time use)
+                self._extra_args = []
+
             cmd.append(escaped_prompt)
 
             # Prepare environment variables for subprocess
@@ -134,6 +147,12 @@ class ClaudeClient(LLMClientBase):
             full_output = "\n".join(combined_parts) if combined_parts else (result.stderr or result.stdout or "")
             full_output = full_output.strip()
             low = full_output.lower()
+
+            # Store output for session ID extraction
+            self._last_output = full_output
+
+            # Extract and store session ID from output
+            self._extract_and_store_session_id(full_output)
 
             # Check for timeout (returncode -1 and "timed out" in stderr)
             if result.returncode == -1 and "timed out" in low:
@@ -224,3 +243,64 @@ class ClaudeClient(LLMClientBase):
         except Exception as e:
             logger.error(f"Failed to add Claude MCP config: {e}")
             return False
+
+    def set_extra_args(self, args: List[str]) -> None:
+        """Store extra arguments to be used in the next execution.
+
+        Args:
+            args: List of extra arguments to store for the next execution (e.g., ['--resume', 'session_id'])
+        """
+        self._extra_args = args
+        logger.debug(f"Set extra args for next execution: {args}")
+
+    def get_last_session_id(self) -> Optional[str]:
+        """Get the last session ID for session resumption.
+
+        Extracts session ID from the last command output using regex patterns.
+
+        Returns:
+            The last session ID if available, None otherwise
+        """
+        return self._last_session_id
+
+    def _extract_and_store_session_id(self, output: str) -> None:
+        """Extract session ID from Claude CLI output and store it.
+
+        Looks for patterns like:
+        - Session ID: abc123
+        - Session: abc123
+        - session_id=abc123
+        - /sessions/abc123
+
+        Args:
+            output: The output from Claude CLI
+        """
+        if not output:
+            return
+
+        # Pattern 1: Look for "Session ID:" or "Session:" followed by alphanumeric ID
+        session_pattern = r"(?:session\s*id:|session:)\s*([a-zA-Z0-9-_]+)"
+        match = re.search(session_pattern, output, re.IGNORECASE)
+        if match:
+            self._last_session_id = match.group(1)
+            logger.debug(f"Extracted session ID from output: {self._last_session_id}")
+            return
+
+        # Pattern 2: Look for session_id= or session= in URLs/parameters
+        session_param_pattern = r"(?:session_id|session)=([a-zA-Z0-9-_]+)"
+        match = re.search(session_param_pattern, output, re.IGNORECASE)
+        if match:
+            self._last_session_id = match.group(1)
+            logger.debug(f"Extracted session ID from URL parameter: {self._last_session_id}")
+            return
+
+        # Pattern 3: Look for /sessions/abc123 in URLs
+        session_path_pattern = r"/sessions/([a-zA-Z0-9-_]+)"
+        match = re.search(session_path_pattern, output, re.IGNORECASE)
+        if match:
+            self._last_session_id = match.group(1)
+            logger.debug(f"Extracted session ID from path: {self._last_session_id}")
+            return
+
+        # If no session ID found, keep previous value
+        logger.debug("No session ID found in output")

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -195,3 +195,226 @@ class TestClaudeClient:
 
         # Should have empty usage_markers when not configured
         assert client.usage_markers == []
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_set_extra_args(self, mock_run, mock_get_config):
+        """ClaudeClient should store extra args for next execution."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Set extra args
+        client.set_extra_args(["--resume", "session123"])
+        assert client._extra_args == ["--resume", "session123"]
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_get_last_session_id_returns_none_initially(self, mock_run, mock_get_config):
+        """ClaudeClient should return None for session ID initially."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Initially should be None
+        assert client.get_last_session_id() is None
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_from_session_id_label(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID from 'Session ID:' label."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction
+        output = "Some output\nSession ID: abc123def\nMore output"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "abc123def"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_from_session_label(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID from 'Session:' label."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction
+        output = "Session: xyz789"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "xyz789"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_from_url_parameter(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID from URL parameters."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction
+        output = "https://example.com/page?session_id=param123"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "param123"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_from_path(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID from URL paths."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction
+        output = "Visit https://example.com/sessions/path456 for details"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "path456"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_case_insensitive(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID case-insensitively."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction with uppercase
+        output = "SESSION ID: CASE123"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "CASE123"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    def test_extract_session_id_with_dashes_and_underscores(self, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID with dashes and underscores."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = ClaudeClient()
+
+        # Test extraction
+        output = "Session ID: session-abc_123-def"
+        client._extract_and_store_session_id(output)
+        assert client.get_last_session_id() == "session-abc_123-def"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
+    def test_extra_args_used_in_run_llm_cli(self, mock_cmd_exec, mock_run, mock_get_config):
+        """ClaudeClient should use and clear extra args in _run_llm_cli."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        # Mock command executor
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Test output\nSession ID: test123"
+        mock_result.stderr = ""
+        mock_cmd_exec.return_value = mock_result
+
+        client = ClaudeClient()
+
+        # Set extra args
+        client.set_extra_args(["--resume", "session999"])
+
+        # Run LLM
+        client._run_llm_cli("test prompt")
+
+        # Check that extra args were used in command
+        called_cmd = mock_cmd_exec.call_args[0][0]
+        assert "--resume" in called_cmd
+        assert "session999" in called_cmd
+
+        # Check that extra args were cleared
+        assert client._extra_args == []
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
+    def test_session_id_extracted_from_output(self, mock_cmd_exec, mock_run, mock_get_config):
+        """ClaudeClient should extract session ID from command output."""
+        mock_run.return_value.returncode = 0
+
+        # Mock config
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "sonnet"
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        # Mock command executor
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Response output\nSession ID: extracted789"
+        mock_result.stderr = ""
+        mock_cmd_exec.return_value = mock_result
+
+        client = ClaudeClient()
+
+        # Run LLM
+        client._run_llm_cli("test prompt")
+
+        # Check that session ID was extracted
+        assert client.get_last_session_id() == "extracted789"


### PR DESCRIPTION
Closes #898

Added session resume capabilities to ClaudeClient by implementing set_extra_args, updating _run_llm_cli to use stored args, and adding get_last_session_id to parse session IDs from CLI output. This enables persistent sessions across Claude CLI calls.