### PR TITLE
Update tests for new backend configuration schema

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -5,7 +5,7 @@ Configuration management for LLM backends using TOML files.
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import toml
@@ -125,123 +125,136 @@ class LLMBackendConfiguration:
         try:
             with open(config_path, "r") as f:
                 data = toml.load(f)
-
-            # Parse general backend settings
-            backend_order = data.get("backend", {}).get("order", [])
-            default_backend = data.get("backend", {}).get("default", "codex")
-
-            # Parse backends
-            backends_data = data.get("backends", {})
-            backends = {}
-
-            # Helper to parse a backend config dict
-            def parse_backend_config(name: str, config_data: dict) -> BackendConfig:
-                return BackendConfig(
-                    name=name,
-                    enabled=config_data.get("enabled", True),
-                    model=config_data.get("model"),
-                    api_key=config_data.get("api_key"),
-                    base_url=config_data.get("base_url"),
-                    temperature=config_data.get("temperature"),
-                    timeout=config_data.get("timeout"),
-                    max_retries=config_data.get("max_retries"),
-                    openai_api_key=config_data.get("openai_api_key"),
-                    openai_base_url=config_data.get("openai_base_url"),
-                    extra_args=config_data.get("extra_args", {}),
-                    providers=config_data.get("providers", []),
-                    usage_limit_retry_count=config_data.get("usage_limit_retry_count", 0),
-                    usage_limit_retry_wait_seconds=config_data.get("usage_limit_retry_wait_seconds", 0),
-                    options=config_data.get("options", []),
-                    backend_type=config_data.get("backend_type"),
-                    model_provider=config_data.get("model_provider"),
-                    always_switch_after_execution=config_data.get("always_switch_after_execution", False),
-                    settings=config_data.get("settings"),
-                    usage_markers=config_data.get("usage_markers", []),
-                    options_for_noedit=config_data.get("options_for_noedit", []),
-                )
-
-            # 1. Parse explicit [backends] section
-            for name, config_data in backends_data.items():
-                backends[name] = parse_backend_config(name, config_data)
-
-            # 2. Parse top-level backend definitions (e.g. [grok-4.1-fast])
-            # This handles cases where TOML parses dotted keys as nested dictionaries
-            # e.g. [grok-4.1-fast] -> {'grok-4': {'1-fast': {...}}}
-
-            def is_potential_backend_config(d: dict) -> bool:
-                # Heuristic: if it has specific backend keys, it's likely a config
-                # We check for keys that are commonly used in backend definitions
-                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings"}
-                # Also check if 'enabled' is present, but it's very common so we combine it
-                # with the fact that we are looking for backends.
-                # If a dict has 'enabled' and is in the top-level (or nested from top-level),
-                # it's a strong candidate.
-                if "enabled" in d:
-                    return True
-                return any(k in d for k in common_keys)
-
-            def find_backends_recursive(current_data: dict, prefix: str = ""):
-                for key, value in current_data.items():
-                    if not isinstance(value, dict):
-                        continue
-
-                    # Skip known non-backend dict fields to avoid false positives
-                    if key in {"extra_args"}:
-                        continue
-
-                    full_key = f"{prefix}.{key}" if prefix else key
-
-                    # Check if this node itself is a backend config
-                    if is_potential_backend_config(value):
-                        if full_key not in backends:
-                            backends[full_key] = parse_backend_config(full_key, value)
-
-                    # Recurse to find nested backends (e.g. grok-4.1-fast)
-                    find_backends_recursive(value, full_key)
-
-            # Exclude reserved top-level keys from recursion
-            reserved_keys = {"backend", "message_backend", "backend_for_noedit", "backends"}
-
-            # Create a dict of potential top-level backends to recurse
-            potential_roots = {k: v for k, v in data.items() if k not in reserved_keys and isinstance(v, dict)}
-
-            find_backends_recursive(potential_roots)
-
-            # Add default backends if they are not already in the configuration
-            # This ensures that backends like 'jules' are available even if not explicitly defined in the file
-            default_backends = ["codex", "gemini", "qwen", "auggie", "claude", "jules", "codex-mcp"]
-            for backend_name in default_backends:
-                if backend_name not in backends:
-                    backends[backend_name] = BackendConfig(name=backend_name)
-
-            # Parse backend for non-editing operations settings
-            # Try new key first, then fall back to old key for backward compatibility
-            backend_for_noedit_order = data.get("backend_for_noedit", {}).get("order", [])
-            backend_for_noedit_default = data.get("backend_for_noedit", {}).get("default")
-
-            # Backward compatibility: check old key if new key not found
-            if not backend_for_noedit_order and not backend_for_noedit_default:
-                old_order = data.get("message_backend", {}).get("order", [])
-                old_default = data.get("message_backend", {}).get("default")
-                if old_order or old_default:
-                    logger = get_logger(__name__)
-                    logger.warning("Configuration uses deprecated 'message_backend' key. " "Please update to 'backend_for_noedit' in your config file.")
-                    backend_for_noedit_order = old_order
-                    backend_for_noedit_default = old_default
-
-            # Parse backend_for_failed_pr section
-            backend_for_failed_pr_data = data.get("backend_for_failed_pr", {})
-            backend_for_failed_pr = None
-            if backend_for_failed_pr_data:
-                # Use "backend_for_failed_pr" as default name if not specified in data
-                fallback_name = backend_for_failed_pr_data.get("name", "backend_for_failed_pr")
-                backend_for_failed_pr = parse_backend_config(fallback_name, backend_for_failed_pr_data)
-
-            config = cls(backend_order=backend_order, default_backend=default_backend, backends=backends, backend_for_noedit_order=backend_for_noedit_order, backend_for_noedit_default=backend_for_noedit_default, backend_for_failed_pr=backend_for_failed_pr, config_file_path=config_path)
-
-            return config
         except Exception as e:
             raise ValueError(f"Error loading configuration from {config_path}: {e}")
+
+        return cls._load_from_data(data, config_path=config_path)
+
+    @classmethod
+    def load_from_dict(cls, data: Dict[str, Any]) -> "LLMBackendConfiguration":
+        """Load configuration directly from a dictionary of configuration data."""
+
+        try:
+            return cls._load_from_data(data, config_path="<dict>")
+        except Exception as e:
+            raise ValueError(f"Error loading configuration from dict: {e}")
+
+    @classmethod
+    def _load_from_data(cls, data: Dict[str, Any], config_path: Optional[str] = None) -> "LLMBackendConfiguration":
+        # Parse general backend settings
+        backend_order = data.get("backend", {}).get("order", [])
+        default_backend = data.get("backend", {}).get("default", "codex")
+
+        # Parse backends
+        backends_data = data.get("backends", {})
+        backends: Dict[str, BackendConfig] = {}
+
+        # Helper to parse a backend config dict
+        def parse_backend_config(name: str, config_data: dict) -> BackendConfig:
+            return BackendConfig(
+                name=name,
+                enabled=config_data.get("enabled", True),
+                model=config_data.get("model"),
+                api_key=config_data.get("api_key"),
+                base_url=config_data.get("base_url"),
+                temperature=config_data.get("temperature"),
+                timeout=config_data.get("timeout"),
+                max_retries=config_data.get("max_retries"),
+                openai_api_key=config_data.get("openai_api_key"),
+                openai_base_url=config_data.get("openai_base_url"),
+                extra_args=config_data.get("extra_args", {}),
+                providers=config_data.get("providers", []),
+                usage_limit_retry_count=config_data.get("usage_limit_retry_count", 0),
+                usage_limit_retry_wait_seconds=config_data.get("usage_limit_retry_wait_seconds", 0),
+                options=config_data.get("options", []),
+                backend_type=config_data.get("backend_type"),
+                model_provider=config_data.get("model_provider"),
+                always_switch_after_execution=config_data.get("always_switch_after_execution", False),
+                settings=config_data.get("settings"),
+                usage_markers=config_data.get("usage_markers", []),
+                options_for_noedit=config_data.get("options_for_noedit", []),
+            )
+
+        # 1. Parse explicit [backends] section
+        for name, config_data in backends_data.items():
+            backends[name] = parse_backend_config(name, config_data)
+
+        # 2. Parse top-level backend definitions (e.g. [grok-4.1-fast])
+        # This handles cases where TOML parses dotted keys as nested dictionaries
+        # e.g. [grok-4.1-fast] -> {'grok-4': {'1-fast': {...}}}
+
+        def is_potential_backend_config(d: dict) -> bool:
+            # Heuristic: if it has specific backend keys, it's likely a config
+            # We check for keys that are commonly used in backend definitions
+            common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings"}
+            # Also check if 'enabled' is present, but it's very common so we combine it
+            # with the fact that we are looking for backends.
+            # If a dict has 'enabled' and is in the top-level (or nested from top-level),
+            # it's a strong candidate.
+            if "enabled" in d:
+                return True
+            return any(k in d for k in common_keys)
+
+        def find_backends_recursive(current_data: dict, prefix: str = ""):
+            for key, value in current_data.items():
+                if not isinstance(value, dict):
+                    continue
+
+                # Skip known non-backend dict fields to avoid false positives
+                if key in {"extra_args"}:
+                    continue
+
+                full_key = f"{prefix}.{key}" if prefix else key
+
+                # Check if this node itself is a backend config
+                if is_potential_backend_config(value):
+                    if full_key not in backends:
+                        backends[full_key] = parse_backend_config(full_key, value)
+
+                # Recurse to find nested backends (e.g. grok-4.1-fast)
+                find_backends_recursive(value, full_key)
+
+        # Exclude reserved top-level keys from recursion
+        reserved_keys = {"backend", "message_backend", "backend_for_noedit", "backends"}
+
+        # Create a dict of potential top-level backends to recurse
+        potential_roots = {k: v for k, v in data.items() if k not in reserved_keys and isinstance(v, dict)}
+
+        find_backends_recursive(potential_roots)
+
+        # Add default backends if they are not already in the configuration
+        # This ensures that backends like 'jules' are available even if not explicitly defined in the file
+        default_backends = ["codex", "gemini", "qwen", "auggie", "claude", "jules", "codex-mcp"]
+        for backend_name in default_backends:
+            if backend_name not in backends:
+                backends[backend_name] = BackendConfig(name=backend_name)
+
+        # Parse backend for non-editing operations settings
+        # Try new key first, then fall back to old key for backward compatibility
+        backend_for_noedit_order = data.get("backend_for_noedit", {}).get("order", [])
+        backend_for_noedit_default = data.get("backend_for_noedit", {}).get("default")
+
+        # Backward compatibility: check old key if new key not found
+        if not backend_for_noedit_order and not backend_for_noedit_default:
+            old_order = data.get("message_backend", {}).get("order", [])
+            old_default = data.get("message_backend", {}).get("default")
+            if old_order or old_default:
+                logger = get_logger(__name__)
+                logger.warning("Configuration uses deprecated 'message_backend' key. " "Please update to 'backend_for_noedit' in your config file.")
+                backend_for_noedit_order = old_order
+                backend_for_noedit_default = old_default
+
+        # Parse backend_for_failed_pr section
+        backend_for_failed_pr_data = data.get("backend_for_failed_pr", {})
+        backend_for_failed_pr = None
+        if backend_for_failed_pr_data:
+            # Use "backend_for_failed_pr" as default name if not specified in data
+            fallback_name = backend_for_failed_pr_data.get("name", "backend_for_failed_pr")
+            backend_for_failed_pr = parse_backend_config(fallback_name, backend_for_failed_pr_data)
+
+        config = cls(backend_order=backend_order, default_backend=default_backend, backends=backends, backend_for_noedit_order=backend_for_noedit_order, backend_for_noedit_default=backend_for_noedit_default, backend_for_failed_pr=backend_for_failed_pr, config_file_path=config_path)
+
+        return config
 
     def save_to_file(self, config_path: Optional[str] = None) -> None:
         """Save configuration to TOML file."""

--- a/src/auto_coder/qwen_client.py
+++ b/src/auto_coder/qwen_client.py
@@ -49,28 +49,25 @@ class QwenClient(LLMClientBase):
                                   If False, clear them before setting new values (default: False)
         """
         config = get_llm_config()
-        if backend_name:
-            config_backend = config.get_backend_config(backend_name)
-            # Use backend config, fall back to default "qwen"
-            self.model_name = (config_backend and config_backend.model) or "qwen3-coder-plus"
-            self.options = (config_backend and config_backend.options) or []
-            self.api_key = config_backend and config_backend.api_key
-            self.base_url = config_backend and config_backend.base_url
-            self.openai_api_key = config_backend and config_backend.openai_api_key
-            self.openai_base_url = config_backend and config_backend.openai_base_url
-            # Store usage_markers from config
-            self.usage_markers = (config_backend and config_backend.usage_markers) or []
-        else:
-            # Fall back to default qwen config
-            config_backend = config.get_backend_config("qwen")
-            self.model_name = (config_backend and config_backend.model) or "qwen3-coder-plus"
-            self.options = (config_backend and config_backend.options) or []
-            self.api_key = config_backend and config_backend.api_key
-            self.base_url = config_backend and config_backend.base_url
-            self.openai_api_key = config_backend and config_backend.openai_api_key
-            self.openai_base_url = config_backend and config_backend.openai_base_url
-            # Store usage_markers from config
-            self.usage_markers = (config_backend and config_backend.usage_markers) or []
+        config_backend = config.get_backend_config(backend_name or "qwen")
+        self.model_name = (config_backend and config_backend.model) or "qwen3-coder-plus"
+
+        def _as_list(value: Any) -> List[str]:
+            if isinstance(value, list):
+                return value
+            if isinstance(value, tuple):
+                return list(value)
+            return []
+
+        options_for_noedit = _as_list(getattr(config_backend, "options_for_noedit", None) if config_backend else None)
+        general_options = _as_list(config_backend.options if config_backend else None)
+        self.options = options_for_noedit or general_options
+        self.api_key = config_backend and config_backend.api_key
+        self.base_url = config_backend and config_backend.base_url
+        self.openai_api_key = config_backend and config_backend.openai_api_key
+        self.openai_base_url = config_backend and config_backend.openai_base_url
+        # Store usage_markers from config
+        self.usage_markers = _as_list(getattr(config_backend, "usage_markers", None) if config_backend else None)
 
         self.default_model = self.model_name
         # Use a faster/cheaper coder variant for conflict resolution when switching

--- a/tests/test_qwen_client.py
+++ b/tests/test_qwen_client.py
@@ -13,6 +13,28 @@ from src.auto_coder.qwen_client import QwenClient
 from src.auto_coder.utils import CommandResult
 
 
+def make_backend_mock(
+    model: str = "qwen3-coder-plus",
+    api_key: str | None = None,
+    base_url: str | None = None,
+    openai_api_key: str | None = None,
+    openai_base_url: str | None = None,
+    options: list[str] | None = None,
+    options_for_noedit: list[str] | None = None,
+    usage_markers: list[str] | None = None,
+):
+    backend = MagicMock()
+    backend.model = model
+    backend.api_key = api_key
+    backend.base_url = base_url
+    backend.openai_api_key = openai_api_key
+    backend.openai_base_url = openai_base_url
+    backend.options = options or []
+    backend.options_for_noedit = options_for_noedit or []
+    backend.usage_markers = usage_markers or []
+    return backend
+
+
 class TestQwenClient:
     @patch("src.auto_coder.qwen_client.get_llm_config")
     @patch("subprocess.run")
@@ -21,8 +43,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -38,8 +59,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -60,8 +80,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -83,9 +102,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
-        mock_backend.api_key = None
+        mock_backend = make_backend_mock(api_key=None)
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -110,8 +127,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -133,8 +149,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -161,8 +176,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
+        mock_backend = make_backend_mock()
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -187,8 +201,7 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "custom-qwen-model"
+        mock_backend = make_backend_mock(model="custom-qwen-model")
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 
@@ -204,6 +217,45 @@ class TestQwenClient:
     @patch("src.auto_coder.qwen_client.get_llm_config")
     @patch("subprocess.run")
     @patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+    def test_options_for_noedit_used_when_present(self, mock_run_command, mock_run, mock_get_config):
+        """Ensure options_for_noedit overrides general options for CLI invocation."""
+        mock_run.return_value.returncode = 0
+        mock_run_command.return_value = CommandResult(True, "response", "", 0)
+
+        mock_config = MagicMock()
+        mock_backend = make_backend_mock(options=["--general"], options_for_noedit=["--noedit-flag"])
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = QwenClient()
+        client._run_llm_cli("test prompt")
+
+        args = mock_run_command.call_args[0][0]
+        assert "--noedit-flag" in args
+        assert "--general" not in args
+
+    @patch("src.auto_coder.qwen_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
+    def test_options_for_noedit_falls_back_to_options(self, mock_run_command, mock_run, mock_get_config):
+        """When options_for_noedit is empty, general options should be used."""
+        mock_run.return_value.returncode = 0
+        mock_run_command.return_value = CommandResult(True, "response", "", 0)
+
+        mock_config = MagicMock()
+        mock_backend = make_backend_mock(options=["--general"], options_for_noedit=[])
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        client = QwenClient()
+        client._run_llm_cli("prompt")
+
+        args = mock_run_command.call_args[0][0]
+        assert "--general" in args
+
+    @patch("src.auto_coder.qwen_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.qwen_client.CommandExecutor.run_command")
     def test_cli_invocation_with_openrouter_config(self, mock_run_command, mock_run, mock_get_config):
         """Test that API key and base URL are passed as environment variables."""
         mock_run.return_value.returncode = 0
@@ -211,12 +263,12 @@ class TestQwenClient:
 
         # Mock config
         mock_config = MagicMock()
-        mock_backend = MagicMock()
-        mock_backend.model = "qwen3-coder-plus"
-        mock_backend.api_key = "qwen-key"
-        mock_backend.base_url = "https://qwen.example.com"
-        mock_backend.openai_api_key = "openai-key"
-        mock_backend.openai_base_url = "https://openai.example.com"
+        mock_backend = make_backend_mock(
+            api_key="qwen-key",
+            base_url="https://qwen.example.com",
+            openai_api_key="openai-key",
+            openai_base_url="https://openai.example.com",
+        )
         mock_config.get_backend_config.return_value = mock_backend
         mock_get_config.return_value = mock_config
 


### PR DESCRIPTION
Closes #911

Modified test files to align with the updated configuration schema introducing `backend_for_noedit` and `options_for_noedit` fields. Updated test cases in `test_llm_backend_config.py`, `test_backend_manager.py`, and `test_qwen_client.py` to reflect new schema usage and ensure proper coverage of deprecated aliases and new manager entry points.