### PR TITLE
Migrate ClaudeClient to use configurable options

### DIFF
--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -44,6 +44,10 @@ class ClaudeClient(LLMClientBase):
             self.settings = config_backend and config_backend.settings
             # Store usage_markers from config
             self.usage_markers = (config_backend and config_backend.usage_markers) or []
+            # Store options from config
+            self.options = (config_backend and config_backend.options) or []
+            # Store options_for_noedit from config
+            self.options_for_noedit = (config_backend and config_backend.options_for_noedit) or []
         else:
             # Fall back to default claude config
             config_backend = config.get_backend_config("claude")
@@ -55,6 +59,10 @@ class ClaudeClient(LLMClientBase):
             self.settings = config_backend and config_backend.settings
             # Store usage_markers from config
             self.usage_markers = (config_backend and config_backend.usage_markers) or []
+            # Store options from config
+            self.options = (config_backend and config_backend.options) or []
+            # Store options_for_noedit from config
+            self.options_for_noedit = (config_backend and config_backend.options_for_noedit) or []
 
         self.default_model = self.model_name
         self.conflict_model = "sonnet"
@@ -95,11 +103,12 @@ class ClaudeClient(LLMClientBase):
             cmd = [
                 "claude",
                 "--print",
-                "--dangerously-skip-permissions",
-                "--allow-dangerously-skip-permissions",
                 "--model",
                 self.model_name,
             ]
+
+            # Add configurable options from config
+            cmd.extend(self.options)
 
             if self.settings:
                 cmd.extend(["--settings", self.settings])
@@ -125,7 +134,9 @@ class ClaudeClient(LLMClientBase):
 
             logger.warning("LLM invocation: claude CLI is being called. Keep LLM calls minimized.")
             logger.debug(f"Running claude CLI with prompt length: {len(prompt)} characters")
-            logger.info(f"🤖 Running: claude --print --dangerously-skip-permissions " f"--allow-dangerously-skip-permissions --model {self.model_name} [prompt]")
+            # Build command string for logging
+            options_str = " ".join(self.options) if self.options else ""
+            logger.info(f"🤖 Running: claude --print {options_str} --model {self.model_name} [prompt]")
             logger.info("=" * 60)
 
             # Use configured usage_markers if available, otherwise fall back to defaults

--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -70,6 +70,8 @@ class BackendConfig:
     usage_limit_retry_wait_seconds: int = 0
     # Additional options for the backend
     options: List[str] = field(default_factory=list)
+    # Options for no-edit functionality (used in Claude CLI)
+    options_for_noedit: List[str] = field(default_factory=list)
     # Options for resume functionality
     options_for_resume: List[str] = field(default_factory=list)
     # Type of backend
@@ -152,6 +154,7 @@ class LLMBackendConfiguration:
                     usage_limit_retry_count=config_data.get("usage_limit_retry_count", 0),
                     usage_limit_retry_wait_seconds=config_data.get("usage_limit_retry_wait_seconds", 0),
                     options=config_data.get("options", []),
+                    options_for_noedit=config_data.get("options_for_noedit", []),
                     options_for_resume=config_data.get("options_for_resume", []),
                     backend_type=config_data.get("backend_type"),
                     model_provider=config_data.get("model_provider"),
@@ -171,7 +174,7 @@ class LLMBackendConfiguration:
             def is_potential_backend_config(d: dict) -> bool:
                 # Heuristic: if it has specific backend keys, it's likely a config
                 # We check for keys that are commonly used in backend definitions
-                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings", "options", "options_for_resume"}
+                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings", "options", "options_for_noedit", "options_for_resume"}
                 # Also check if 'enabled' is present, but it's very common so we combine it
                 # with the fact that we are looking for backends.
                 # If a dict has 'enabled' and is in the top-level (or nested from top-level),
@@ -259,6 +262,7 @@ class LLMBackendConfiguration:
                 "usage_limit_retry_count": config.usage_limit_retry_count,
                 "usage_limit_retry_wait_seconds": config.usage_limit_retry_wait_seconds,
                 "options": config.options,
+                "options_for_noedit": config.options_for_noedit,
                 "options_for_resume": config.options_for_resume,
                 "backend_type": config.backend_type,
                 "model_provider": config.model_provider,
@@ -287,6 +291,7 @@ class LLMBackendConfiguration:
                 "usage_limit_retry_count": config.usage_limit_retry_count,
                 "usage_limit_retry_wait_seconds": config.usage_limit_retry_wait_seconds,
                 "options": config.options,
+                "options_for_noedit": config.options_for_noedit,
                 "options_for_resume": config.options_for_resume,
                 "backend_type": config.backend_type,
                 "model_provider": config.model_provider,


### PR DESCRIPTION
Closes #916

Updated ClaudeClient to use configurable 'options' and 'options_for_noedit' fields from backend configuration instead of hardcoded flags. This allows for more flexible configuration of Claude CLI parameters through the backend configuration system.