### PR TITLE
Add options_for_noedit field to BackendConfig dataclass

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -72,6 +72,8 @@ class BackendConfig:
     options: List[str] = field(default_factory=list)
     # Options for resume functionality
     options_for_resume: List[str] = field(default_factory=list)
+    # Options for non-editing operations (message generation)
+    options_for_noedit: List[str] = field(default_factory=list)
     # Type of backend
     backend_type: Optional[str] = None
     # Model provider (e.g., "openrouter", "anthropic", etc.)
@@ -153,6 +155,7 @@ class LLMBackendConfiguration:
                     usage_limit_retry_wait_seconds=config_data.get("usage_limit_retry_wait_seconds", 0),
                     options=config_data.get("options", []),
                     options_for_resume=config_data.get("options_for_resume", []),
+                    options_for_noedit=config_data.get("options_for_noedit", []),
                     backend_type=config_data.get("backend_type"),
                     model_provider=config_data.get("model_provider"),
                     always_switch_after_execution=config_data.get("always_switch_after_execution", False),
@@ -171,7 +174,7 @@ class LLMBackendConfiguration:
             def is_potential_backend_config(d: dict) -> bool:
                 # Heuristic: if it has specific backend keys, it's likely a config
                 # We check for keys that are commonly used in backend definitions
-                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings", "options", "options_for_resume"}
+                common_keys = {"backend_type", "model", "api_key", "base_url", "openai_api_key", "openai_base_url", "providers", "model_provider", "always_switch_after_execution", "settings", "options", "options_for_resume", "options_for_noedit"}
                 # Also check if 'enabled' is present, but it's very common so we combine it
                 # with the fact that we are looking for backends.
                 # If a dict has 'enabled' and is in the top-level (or nested from top-level),
@@ -260,6 +263,7 @@ class LLMBackendConfiguration:
                 "usage_limit_retry_wait_seconds": config.usage_limit_retry_wait_seconds,
                 "options": config.options,
                 "options_for_resume": config.options_for_resume,
+                "options_for_noedit": config.options_for_noedit,
                 "backend_type": config.backend_type,
                 "model_provider": config.model_provider,
                 "always_switch_after_execution": config.always_switch_after_execution,
@@ -288,6 +292,7 @@ class LLMBackendConfiguration:
                 "usage_limit_retry_wait_seconds": config.usage_limit_retry_wait_seconds,
                 "options": config.options,
                 "options_for_resume": config.options_for_resume,
+                "options_for_noedit": config.options_for_noedit,
                 "backend_type": config.backend_type,
                 "model_provider": config.model_provider,
                 "always_switch_after_execution": config.always_switch_after_execution,

--- a/tests/test_llm_backend_config.py
+++ b/tests/test_llm_backend_config.py
@@ -39,6 +39,7 @@ class TestBackendConfig:
         assert config.usage_limit_retry_wait_seconds == 0
         assert config.options == []
         assert config.options_for_resume == []
+        assert config.options_for_noedit == []
         assert config.backend_type is None
         assert config.model_provider is None
         assert config.always_switch_after_execution is False
@@ -63,6 +64,7 @@ class TestBackendConfig:
             usage_limit_retry_wait_seconds=30,
             options=["option1", "option2"],
             options_for_resume=["resume_option1", "resume_option2"],
+            options_for_noedit=["noedit_option1", "noedit_option2"],
             backend_type="custom_type",
             model_provider="openrouter",
             always_switch_after_execution=True,
@@ -84,6 +86,7 @@ class TestBackendConfig:
         assert config.usage_limit_retry_wait_seconds == 30
         assert config.options == ["option1", "option2"]
         assert config.options_for_resume == ["resume_option1", "resume_option2"]
+        assert config.options_for_noedit == ["noedit_option1", "noedit_option2"]
         assert config.backend_type == "custom_type"
         assert config.model_provider == "openrouter"
         assert config.always_switch_after_execution is True
@@ -558,6 +561,33 @@ class TestLLMBackendConfiguration:
             codex_config = loaded_config.get_backend_config("codex")
             assert codex_config.options_for_resume == []
 
+    def test_toml_save_and_load_options_for_noedit(self):
+        """Test that options_for_noedit field is properly saved and loaded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "test_options_for_noedit.toml"
+
+            # Create configuration with options_for_noedit settings
+            config = LLMBackendConfiguration()
+            config.get_backend_config("gemini").options_for_noedit = ["noedit_opt1", "noedit_opt2"]
+            config.get_backend_config("qwen").options_for_noedit = ["noedit_opt3"]
+            config.get_backend_config("codex").options_for_noedit = []
+
+            # Save to file
+            config.save_to_file(str(config_file))
+
+            # Load from file
+            loaded_config = LLMBackendConfiguration.load_from_file(str(config_file))
+
+            # Verify options_for_noedit was persisted
+            gemini_config = loaded_config.get_backend_config("gemini")
+            assert gemini_config.options_for_noedit == ["noedit_opt1", "noedit_opt2"]
+
+            qwen_config = loaded_config.get_backend_config("qwen")
+            assert qwen_config.options_for_noedit == ["noedit_opt3"]
+
+            codex_config = loaded_config.get_backend_config("codex")
+            assert codex_config.options_for_noedit == []
+
     def test_toml_save_and_load_always_switch_after_execution(self):
         """Test that always_switch_after_execution field is properly saved and loaded."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -712,6 +742,51 @@ class TestLLMBackendConfiguration:
             gemini_config = config.get_backend_config("gemini")
             assert gemini_config is not None
             assert gemini_config.options_for_resume == []
+            assert gemini_config.backend_type == "custom_type"
+            assert gemini_config.model == "gemini-pro"
+            assert gemini_config.timeout == 30
+
+    def test_backward_compatibility_old_toml_without_options_for_noedit(self):
+        """Test loading old TOML files that don't have options_for_noedit field."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "old_config_options_for_noedit.toml"
+
+            # Create a TOML file with the old structure (without options_for_noedit field)
+            data = {
+                "backend": {"default": "qwen", "order": ["qwen", "gemini"]},
+                "backends": {
+                    "qwen": {
+                        "enabled": True,
+                        "model": "qwen3-coder-plus",
+                        "providers": ["qwen-open-router"],
+                        "temperature": 0.7,
+                        "options": ["option1", "option2"],
+                    },
+                    "gemini": {
+                        "enabled": True,
+                        "model": "gemini-pro",
+                        "timeout": 30,
+                        "backend_type": "custom_type",
+                    },
+                },
+            }
+            with open(config_file, "w", encoding="utf-8") as fh:
+                toml.dump(data, fh)
+
+            # Load the configuration
+            config = LLMBackendConfiguration.load_from_file(str(config_file))
+
+            # Verify options_for_noedit has default empty list when not present in old TOML
+            qwen_config = config.get_backend_config("qwen")
+            assert qwen_config is not None
+            assert qwen_config.options_for_noedit == []
+            assert qwen_config.options == ["option1", "option2"]
+            assert qwen_config.model == "qwen3-coder-plus"
+            assert qwen_config.temperature == 0.7
+
+            gemini_config = config.get_backend_config("gemini")
+            assert gemini_config is not None
+            assert gemini_config.options_for_noedit == []
             assert gemini_config.backend_type == "custom_type"
             assert gemini_config.model == "gemini-pro"
             assert gemini_config.timeout == 30
@@ -1859,6 +1934,7 @@ class TestBackendForFailedPR:
                 usage_limit_retry_wait_seconds=45,
                 options=["fallback-option1", "fallback-option2"],
                 options_for_resume=["fallback-resume-opt1", "fallback-resume-opt2"],
+                options_for_noedit=["fallback-noedit-opt1", "fallback-noedit-opt2"],
                 backend_type="custom_fallback",
                 model_provider="fallback-provider",
                 always_switch_after_execution=True,
@@ -1890,6 +1966,7 @@ class TestBackendForFailedPR:
             assert fallback.usage_limit_retry_wait_seconds == 45
             assert fallback.options == ["fallback-option1", "fallback-option2"]
             assert fallback.options_for_resume == ["fallback-resume-opt1", "fallback-resume-opt2"]
+            assert fallback.options_for_noedit == ["fallback-noedit-opt1", "fallback-noedit-opt2"]
             assert fallback.backend_type == "custom_fallback"
             assert fallback.model_provider == "fallback-provider"
             assert fallback.always_switch_after_execution is True


### PR DESCRIPTION
Closes #907

Added the options_for_noedit field to support separate CLI options for message generation operations. The field is a list of strings with a default empty list value, and was integrated into the parsing logic in parse_backend_config.