### PR TITLE
Rename message_backend to backend_for_noedit in config schema

### DIFF
--- a/docs/llm_backend_config.example.toml
+++ b/docs/llm_backend_config.example.toml
@@ -11,9 +11,10 @@ default = "qwen-openrouter"
 # Order of backends to try (only enabled backends will be used)
 order = ["qwen-openrouter", "qwen", "gemini", "codex", "claude"]
 
-[message_backend]
-# Separate configuration for message generation (commit messages, PR descriptions)
+[backend_for_noedit]
+# Separate configuration for non-editing operations (message generation, commit messages, PR descriptions)
 # If not specified, falls back to general backend configuration
+# Note: This was previously called [message_backend] in older versions
 default = "qwen-openrouter"
 order = ["qwen-openrouter", "qwen", "gemini"]
 
@@ -278,7 +279,7 @@ backend_type = "codex"
 # --------------------
 # Environment variables can override configuration values:
 #    - AUTO_CODER_DEFAULT_BACKEND
-#    - AUTO_CODER_MESSAGE_DEFAULT_BACKEND
+#    - AUTO_CODER_BACKEND_FOR_NOEDIT_DEFAULT_BACKEND (or AUTO_CODER_MESSAGE_DEFAULT_BACKEND for backward compatibility)
 #    - AUTO_CODER_<BACKEND>_API_KEY (e.g., AUTO_CODER_GEMINI_API_KEY)
 #    - AUTO_CODER_<BACKEND>_OPENAI_API_KEY (e.g., AUTO_CODER_CODEX_OPENAI_API_KEY)
 #    - AUTO_CODER_<BACKEND>_OPENAI_BASE_URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-coder"
-version = "2025.11.30.15+g2464e8c"
+version = "2025.12.01.0+g2464e8c"
 description = "Automated application development using Gemini CLI and GitHub integration"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/auto_coder/__init__.py
+++ b/src/auto_coder/__init__.py
@@ -2,7 +2,7 @@
 Auto-Coder: Automated application development using Gemini CLI and GitHub integration.
 """
 
-__version__ = "2025.11.30.15+g2464e8c"
+__version__ = "2025.12.01.0+g2464e8c"
 __author__ = "Auto-Coder Team"
 __description__ = "Automated application development using Gemini CLI and GitHub integration"
 

--- a/src/auto_coder/cli_commands_config.py
+++ b/src/auto_coder/cli_commands_config.py
@@ -575,8 +575,8 @@ def import_config(config_file: Optional[str], source_file: str) -> None:
         config = LLMBackendConfiguration()
         config.backend_order = imported_data.get("backend", {}).get("order", [])
         config.default_backend = imported_data.get("backend", {}).get("default", "codex")
-        config.message_backend_order = imported_data.get("message_backend", {}).get("order", [])
-        config.message_default_backend = imported_data.get("message_backend", {}).get("default")
+        config.backend_for_noedit_order = imported_data.get("backend_for_noedit", {}).get("order", imported_data.get("message_backend", {}).get("order", []))
+        config.backend_for_noedit_default = imported_data.get("backend_for_noedit", {}).get("default", imported_data.get("message_backend", {}).get("default"))
 
         # Import backends
         config.backends = {}
@@ -1015,9 +1015,9 @@ def config_to_dict(config: LLMBackendConfiguration) -> Dict[str, Any]:
             "extra_args": backend_config.extra_args,
         }
 
-    result["message_backend"] = {
-        "order": config.message_backend_order,
-        "default": config.message_default_backend,
+    result["backend_for_noedit"] = {
+        "order": config.backend_for_noedit_order,
+        "default": config.backend_for_noedit_default,
     }
 
     # Validate the result before returning
@@ -1087,12 +1087,12 @@ def config_validate(config: LLMBackendConfiguration) -> List[str]:
     if not isinstance(config.default_backend, str):
         errors.append("backend.default must be a string")  # type: ignore[unreachable]
 
-    # Validate message_backend_order - should be list
-    if not isinstance(config.message_backend_order, list):
-        errors.append("message_backend.order must be a list")  # type: ignore[unreachable]
+    # Validate backend_for_noedit_order - should be list
+    if not isinstance(config.backend_for_noedit_order, list):
+        errors.append("backend_for_noedit.order must be a list")  # type: ignore[unreachable]
 
-    # Validate message_default_backend - should be str or None
-    if config.message_default_backend is not None and not isinstance(config.message_default_backend, str):
-        errors.append("message_backend.default must be a string")  # type: ignore[unreachable]
+    # Validate backend_for_noedit_default - should be str or None
+    if config.backend_for_noedit_default is not None and not isinstance(config.backend_for_noedit_default, str):
+        errors.append("backend_for_noedit.default must be a string")  # type: ignore[unreachable]
 
     return errors

--- a/src/auto_coder/cli_helpers.py
+++ b/src/auto_coder/cli_helpers.py
@@ -720,9 +720,9 @@ def build_message_backend_manager(
 
     # Use configuration values as defaults if not provided
     if selected_backends is None:
-        selected_backends = config.get_active_message_backends()
+        selected_backends = config.get_active_noedit_backends()
     if primary_backend is None:
-        primary_backend = config.get_message_default_backend()
+        primary_backend = config.get_noedit_default_backend()
     if models is None:
         # Build models map using configuration
         models = {}

--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -96,8 +96,8 @@ class LLMBackendConfiguration:
     # Individual backend configurations
     backends: Dict[str, BackendConfig] = field(default_factory=dict)
     # Message backend configuration (separate from general LLM operations)
-    message_backend_order: List[str] = field(default_factory=list)
-    message_default_backend: Optional[str] = None
+    backend_for_noedit_order: List[str] = field(default_factory=list)
+    backend_for_noedit_default: Optional[str] = None
     # Fallback backend configuration for failed PRs
     backend_for_failed_pr: Optional[BackendConfig] = None
     # Environment variable overrides
@@ -203,7 +203,7 @@ class LLMBackendConfiguration:
                     find_backends_recursive(value, full_key)
 
             # Exclude reserved top-level keys from recursion
-            reserved_keys = {"backend", "message_backend", "backends"}
+            reserved_keys = {"backend", "message_backend", "backend_for_noedit", "backends"}
 
             # Create a dict of potential top-level backends to recurse
             potential_roots = {k: v for k, v in data.items() if k not in reserved_keys and isinstance(v, dict)}
@@ -217,9 +217,22 @@ class LLMBackendConfiguration:
                 if backend_name not in backends:
                     backends[backend_name] = BackendConfig(name=backend_name)
 
-            # Parse message backend settings
-            message_backend_order = data.get("message_backend", {}).get("order", [])
-            message_default_backend = data.get("message_backend", {}).get("default")
+            # Parse backend_for_noedit settings with backward compatibility
+            backend_for_noedit_order = data.get("backend_for_noedit", {}).get("order", [])
+            backend_for_noedit_default = data.get("backend_for_noedit", {}).get("default")
+
+            # Check old key for backward compatibility
+            if not backend_for_noedit_order:
+                backend_for_noedit_order = data.get("message_backend", {}).get("order", [])
+                if backend_for_noedit_order:
+                    logger = get_logger(__name__)
+                    logger.warning("Config uses deprecated 'message_backend', use 'backend_for_noedit' instead")
+
+            if not backend_for_noedit_default:
+                backend_for_noedit_default = data.get("message_backend", {}).get("default")
+                if backend_for_noedit_default:
+                    logger = get_logger(__name__)
+                    logger.warning("Config uses deprecated 'message_backend', use 'backend_for_noedit' instead")
 
             # Parse backend_for_failed_pr section
             backend_for_failed_pr_data = data.get("backend_for_failed_pr", {})
@@ -229,7 +242,7 @@ class LLMBackendConfiguration:
                 fallback_name = backend_for_failed_pr_data.get("name", "backend_for_failed_pr")
                 backend_for_failed_pr = parse_backend_config(fallback_name, backend_for_failed_pr_data)
 
-            config = cls(backend_order=backend_order, default_backend=default_backend, backends=backends, message_backend_order=message_backend_order, message_default_backend=message_default_backend, backend_for_failed_pr=backend_for_failed_pr, config_file_path=config_path)
+            config = cls(backend_order=backend_order, default_backend=default_backend, backends=backends, backend_for_noedit_order=backend_for_noedit_order, backend_for_noedit_default=backend_for_noedit_default, backend_for_failed_pr=backend_for_failed_pr, config_file_path=config_path)
 
             return config
         except Exception as e:
@@ -300,7 +313,7 @@ class LLMBackendConfiguration:
                 "usage_markers": config.usage_markers,
             }
 
-        data = {"backend": {"order": self.backend_order, "default": self.default_backend}, "message_backend": {"order": self.message_backend_order, "default": self.message_default_backend or self.default_backend}, "backends": backend_data}
+        data = {"backend": {"order": self.backend_order, "default": self.default_backend}, "backend_for_noedit": {"order": self.backend_for_noedit_order, "default": self.backend_for_noedit_default or self.default_backend}, "backends": backend_data}
 
         # Add backend_for_failed_pr section if configured
         if backend_for_failed_pr_data:
@@ -323,33 +336,54 @@ class LLMBackendConfiguration:
             # If no order is specified, return all enabled backends
             return [name for name, config in self.backends.items() if config.enabled]
 
+    def get_active_noedit_backends(self) -> List[str]:
+        """Get list of enabled noedit backends in the configured order.
+
+        Returns noedit backend order if specifically configured, otherwise falls back to general backends.
+        """
+        if self.backend_for_noedit_order:
+            # Filter to only include enabled backends that are in noedit order
+            return [name for name in self.backend_for_noedit_order if self.backends.get(name, BackendConfig(name=name)).enabled]
+        else:
+            # Fall back to using the general backend order for noedit
+            return self.get_active_backends()
+
+    def get_noedit_default_backend(self) -> str:
+        """Get the default backend for noedit operations (message generation).
+
+        Returns noedit backend default if specifically configured, otherwise falls back to general default.
+        """
+        if self.backend_for_noedit_default and self.backends.get(self.backend_for_noedit_default, BackendConfig(name=self.backend_for_noedit_default)).enabled:
+            return self.backend_for_noedit_default
+        return self.default_backend
+
+    # Backward compatibility methods
     def get_active_message_backends(self) -> List[str]:
         """Get list of enabled message backends in the configured order.
 
+        DEPRECATED: Use get_active_noedit_backends() instead.
         Returns message backend order if specifically configured, otherwise falls back to general backends.
         """
-        if self.message_backend_order:
-            # Filter to only include enabled backends that are in message order
-            return [name for name in self.message_backend_order if self.backends.get(name, BackendConfig(name=name)).enabled]
-        else:
-            # Fall back to using the general backend order for messages
-            return self.get_active_backends()
+        logger = get_logger(__name__)
+        logger.warning("get_active_message_backends() is deprecated, use get_active_noedit_backends() instead")
+        return self.get_active_noedit_backends()
 
     def get_message_default_backend(self) -> str:
         """Get the default backend for message generation.
 
+        DEPRECATED: Use get_noedit_default_backend() instead.
         Returns message backend default if specifically configured, otherwise falls back to general default.
         """
-        if self.message_default_backend and self.backends.get(self.message_default_backend, BackendConfig(name=self.message_default_backend)).enabled:
-            return self.message_default_backend
-        return self.default_backend
+        logger = get_logger(__name__)
+        logger.warning("get_message_default_backend() is deprecated, use get_noedit_default_backend() instead")
+        return self.get_noedit_default_backend()
 
     def has_dual_configuration(self) -> bool:
-        """Check if both general backend and message backend configurations are explicitly set."""
-        # Check if message-specific configurations exist
-        has_message_config = bool(self.message_backend_order or self.message_default_backend)
+        """Check if both general backend and noedit backend configurations are explicitly set."""
+        # Check if noedit-specific configurations exist
+        has_noedit_config = bool(self.backend_for_noedit_order or self.backend_for_noedit_default)
         has_general_config = bool(self.backend_order or self.default_backend)
-        return has_message_config and has_general_config
+        return has_noedit_config and has_general_config
 
     def get_backend_for_failed_pr(self) -> Optional[BackendConfig]:
         """Get the fallback backend configuration for failed PRs.
@@ -400,9 +434,9 @@ class LLMBackendConfiguration:
         if default_backend_env:
             self.default_backend = default_backend_env
 
-        message_default_backend_env = os.environ.get("AUTO_CODER_MESSAGE_DEFAULT_BACKEND")
-        if message_default_backend_env:
-            self.message_default_backend = message_default_backend_env
+        backend_for_noedit_default_env = os.environ.get("AUTO_CODER_BACKEND_FOR_NOEDIT_DEFAULT_BACKEND") or os.environ.get("AUTO_CODER_MESSAGE_DEFAULT_BACKEND")
+        if backend_for_noedit_default_env:
+            self.backend_for_noedit_default = backend_for_noedit_default_env
 
 
 # Global instance to be used throughout the application

--- a/tests/test_llm_backend_config.py
+++ b/tests/test_llm_backend_config.py
@@ -120,8 +120,8 @@ class TestLLMBackendConfiguration:
         # Check default settings
         assert config.default_backend == "codex"
         assert config.backend_order == []
-        assert config.message_backend_order == []
-        assert config.message_default_backend is None
+        assert config.backend_for_noedit_order == []
+        assert config.backend_for_noedit_default is None
         assert config.env_prefix == "AUTO_CODER_"
         assert config.config_file_path == "~/.auto-coder/llm_config.toml"
 
@@ -135,14 +135,14 @@ class TestLLMBackendConfiguration:
             backend_order=["gemini", "codex"],
             default_backend="gemini",
             backends=backends,
-            message_backend_order=["codex"],
-            message_default_backend="codex",
+            backend_for_noedit_order=["codex"],
+            backend_for_noedit_default="codex",
         )
 
         assert config.default_backend == "gemini"
         assert config.backend_order == ["gemini", "codex"]
-        assert config.message_backend_order == ["codex"]
-        assert config.message_default_backend == "codex"
+        assert config.backend_for_noedit_order == ["codex"]
+        assert config.backend_for_noedit_default == "codex"
         assert config.backends["gemini"].model == "gemini-pro"
         assert config.backends["codex"].enabled is False
 
@@ -286,68 +286,68 @@ class TestLLMBackendConfiguration:
         assert "codex" not in active
         assert "qwen" in active
 
-    def test_get_active_message_backends(self):
-        """Test getting active message backends."""
+    def test_get_active_noedit_backends(self):
+        """Test getting active noedit backends."""
         config = LLMBackendConfiguration()
         config.get_backend_config("gemini").enabled = False
         config.get_backend_config("codex").enabled = True
         config.get_backend_config("qwen").enabled = False
-        config.message_backend_order = ["codex", "gemini", "qwen"]
+        config.backend_for_noedit_order = ["codex", "gemini", "qwen"]
 
-        active = config.get_active_message_backends()
+        active = config.get_active_noedit_backends()
         assert "codex" in active
         assert "gemini" not in active
         assert "qwen" not in active
 
-    def test_get_active_message_backends_fallback(self):
-        """Test message backends fall back to general backends when not configured."""
+    def test_get_active_noedit_backends_fallback(self):
+        """Test noedit backends fall back to general backends when not configured."""
         config = LLMBackendConfiguration()
         config.get_backend_config("gemini").enabled = False
         config.get_backend_config("codex").enabled = True
         config.backend_order = ["codex", "gemini", "qwen"]
-        # No message_backend_order set
+        # No backend_for_noedit_order set
 
-        active = config.get_active_message_backends()
+        active = config.get_active_noedit_backends()
         assert "codex" in active
         # Should fall back to general backends
 
-    def test_get_message_default_backend(self):
-        """Test getting default message backend."""
+    def test_get_noedit_default_backend(self):
+        """Test getting default noedit backend."""
         config = LLMBackendConfiguration()
         config.get_backend_config("codex").enabled = True
-        config.message_default_backend = "codex"
+        config.backend_for_noedit_default = "codex"
         config.default_backend = "gemini"
 
-        assert config.get_message_default_backend() == "codex"
+        assert config.get_noedit_default_backend() == "codex"
 
-    def test_get_message_default_backend_fallback(self):
-        """Test message default falls back to general default."""
+    def test_get_noedit_default_backend_fallback(self):
+        """Test noedit default falls back to general default."""
         config = LLMBackendConfiguration()
         config.get_backend_config("gemini").enabled = True
         config.default_backend = "gemini"
 
-        # No message_default_backend set
-        assert config.get_message_default_backend() == "gemini"
+        # No backend_for_noedit_default set
+        assert config.get_noedit_default_backend() == "gemini"
 
-    def test_get_message_default_backend_disabled(self):
-        """Test that disabled message default falls back to general default."""
+    def test_get_noedit_default_backend_disabled(self):
+        """Test that disabled noedit default falls back to general default."""
         config = LLMBackendConfiguration()
         config.get_backend_config("codex").enabled = False
-        config.message_default_backend = "codex"
+        config.backend_for_noedit_default = "codex"
         config.default_backend = "gemini"
 
-        # message_default_backend is disabled, should fall back
-        assert config.get_message_default_backend() == "gemini"
+        # backend_for_noedit_default is disabled, should fall back
+        assert config.get_noedit_default_backend() == "gemini"
 
     def test_has_dual_configuration(self):
         """Test detection of dual backend configuration."""
         config1 = LLMBackendConfiguration()
-        config1.message_backend_order = ["codex"]
+        config1.backend_for_noedit_order = ["codex"]
         assert config1.has_dual_configuration() is True
 
         config2 = LLMBackendConfiguration()
         config2.backend_order = ["gemini", "codex"]
-        config2.message_backend_order = ["codex"]
+        config2.backend_for_noedit_order = ["codex"]
         assert config2.has_dual_configuration() is True
 
         config3 = LLMBackendConfiguration()
@@ -355,9 +355,9 @@ class TestLLMBackendConfiguration:
         assert config3.has_dual_configuration() is False
 
         config4 = LLMBackendConfiguration()
-        # Only message config
-        config4.message_backend_order = ["codex"]
-        config4.message_default_backend = "codex"
+        # Only noedit config
+        config4.backend_for_noedit_order = ["codex"]
+        config4.backend_for_noedit_default = "codex"
         assert config4.has_dual_configuration() is True
 
     def test_get_model_for_backend(self):
@@ -400,7 +400,7 @@ class TestLLMBackendConfiguration:
         # Check that environment overrides were applied
         assert config.get_backend_config("gemini").api_key == "env_gemini_key"
         assert config.default_backend == "qwen"
-        assert config.message_default_backend == "claude"
+        assert config.backend_for_noedit_default == "claude"
 
     def test_apply_env_overrides_openai(self):
         """Test applying OpenAI environment variable overrides."""
@@ -1340,8 +1340,8 @@ class TestConfigurationPriorityLogic:
             config = LLMBackendConfiguration()
             config.default_backend = "gemini"
             config.backend_order = ["gemini", "qwen", "codex"]
-            config.message_backend_order = ["codex"]
-            config.message_default_backend = "codex"
+            config.backend_for_noedit_order = ["codex"]
+            config.backend_for_noedit_default = "codex"
 
             # Set detailed backend configs
             config.get_backend_config("gemini").model = "gemini-test-model"
@@ -1373,8 +1373,8 @@ class TestConfigurationPriorityLogic:
                 # Verify all values were correctly loaded
                 assert loaded_config.default_backend == "gemini"
                 assert loaded_config.backend_order == ["gemini", "qwen", "codex"]
-                assert loaded_config.message_backend_order == ["codex"]
-                assert loaded_config.message_default_backend == "codex"
+                assert loaded_config.backend_for_noedit_order == ["codex"]
+                assert loaded_config.backend_for_noedit_default == "codex"
 
                 # Verify gemini backend settings
                 gemini = loaded_config.get_backend_config("gemini")

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "auto-coder"
-version = "2025.11.30.15+g2464e8c"
+version = "2025.12.1.0+g2464e8c"
 source = { editable = "." }
 dependencies = [
     { name = "build" },


### PR DESCRIPTION
Closes #908

Renamed configuration fields from message_backend_order/message_default_backend to backend_for_noedit_order/backend_for_noedit_default for clarity. Added backward compatibility to support old configuration files using the deprecated message_backend key.