### PR TITLE
Migrate AuggieClient to use configurable options

### DIFF
--- a/src/auto_coder/auggie_client.py
+++ b/src/auto_coder/auggie_client.py
@@ -44,11 +44,19 @@ class AuggieClient(LLMClientBase):
             self.model_name = (config_backend and config_backend.model) or "GPT-5"
             # Store usage_markers from config
             self.usage_markers = (config_backend and config_backend.usage_markers) or []
+            # Store options from config
+            self.options = (config_backend and config_backend.options) or []
+            # Store options_for_noedit from config
+            self.options_for_noedit = (config_backend and config_backend.options_for_noedit) or []
         else:
             config_backend = config.get_backend_config("auggie")
             self.model_name = (config_backend and config_backend.model) or "GPT-5"
             # Store usage_markers from config
             self.usage_markers = (config_backend and config_backend.usage_markers) or []
+            # Store options from config
+            self.options = (config_backend and config_backend.options) or []
+            # Store options_for_noedit from config
+            self.options_for_noedit = (config_backend and config_backend.options_for_noedit) or []
 
         self.default_model = self.model_name
         self.conflict_model = self.model_name
@@ -153,10 +161,12 @@ class AuggieClient(LLMClientBase):
         escaped_prompt = self._escape_prompt(prompt)
         cmd = [
             "auggie",
-            "--print",
             "--model",
             self.model_name,
         ]
+
+        # Add configured options
+        cmd.extend(self.options)
 
         extra_args = self.consume_extra_args()
         if extra_args:
@@ -166,7 +176,7 @@ class AuggieClient(LLMClientBase):
 
         logger.warning("LLM invocation: auggie CLI is being called. Keep LLM calls minimized.")
         logger.debug(f"Running auggie CLI with prompt length: {len(prompt)} characters")
-        logger.info("🤖 Running: auggie --print --model %s [prompt]" % self.model_name)
+        logger.info("🤖 Running: auggie --model %s [prompt]" % self.model_name)
         logger.info("=" * 60)
 
         try:

--- a/tests/test_auggie_client_daily_limit.py
+++ b/tests/test_auggie_client_daily_limit.py
@@ -2,6 +2,7 @@ import io
 import json
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -40,7 +41,7 @@ class RecordingPopen:
         return 0
 
 
-def test_auggie_usage_counter_persists(monkeypatch, tmp_path):
+def test_augmie_usage_counter_persists(monkeypatch, tmp_path):
     monkeypatch.setenv("AUTO_CODER_AUGGIE_USAGE_DIR", str(tmp_path))
     RecordingPopen.calls = []
     _patch_subprocess(monkeypatch, RecordingPopen)
@@ -103,3 +104,142 @@ def test_auggie_usage_resets_when_date_changes(monkeypatch, tmp_path):
     state = json.loads(state_path.read_text())
     assert state["count"] == 1
     assert state["date"] == datetime.now().date().isoformat()
+
+
+@patch("src.auto_coder.auggie_client.get_llm_config")
+def test_auggie_client_options_from_config(mock_get_config, monkeypatch):
+    """Test that options are loaded from config and used in CLI commands."""
+    RecordingPopen.calls = []
+    _patch_subprocess(monkeypatch, RecordingPopen)
+
+    # Mock config to provide options
+    mock_config = Mock()
+    mock_backend_config = Mock()
+    mock_backend_config.model = "GPT-5"
+    mock_backend_config.options = ["--print"]
+    mock_backend_config.options_for_noedit = ["--print"]
+    mock_backend_config.usage_markers = []
+    mock_config.get_backend_config.return_value = mock_backend_config
+    mock_get_config.return_value = mock_config
+
+    client = AuggieClient(backend_name="auggie")
+    output = client._run_auggie_cli("test prompt")
+
+    # Check that the command was called with options from config
+    assert len(RecordingPopen.calls) == 1
+    cmd = RecordingPopen.calls[0]
+    assert cmd[0] == "auggie"
+    assert cmd[1] == "--model"
+    assert cmd[2] == "GPT-5"
+    assert "--print" in cmd
+    assert "test prompt" in cmd
+
+
+@patch("src.auto_coder.auggie_client.get_llm_config")
+def test_auggie_client_multiple_options_from_config(mock_get_config, monkeypatch):
+    """Test that multiple options are loaded from config and used in CLI commands."""
+    RecordingPopen.calls = []
+    _patch_subprocess(monkeypatch, RecordingPopen)
+
+    # Mock config to provide multiple options
+    mock_config = Mock()
+    mock_backend_config = Mock()
+    mock_backend_config.model = "GPT-5"
+    mock_backend_config.options = ["--print", "--debug", "--verbose"]
+    mock_backend_config.options_for_noedit = ["--print"]
+    mock_backend_config.usage_markers = []
+    mock_config.get_backend_config.return_value = mock_backend_config
+    mock_get_config.return_value = mock_config
+
+    client = AuggieClient(backend_name="auggie")
+    output = client._run_auggie_cli("test prompt")
+
+    # Check that the command was called with all options from config
+    assert len(RecordingPopen.calls) == 1
+    cmd = RecordingPopen.calls[0]
+    assert cmd[0] == "auggie"
+    assert cmd[1] == "--model"
+    assert cmd[2] == "GPT-5"
+    assert "--print" in cmd
+    assert "--debug" in cmd
+    assert "--verbose" in cmd
+    assert "test prompt" in cmd
+
+
+@patch("src.auto_coder.auggie_client.get_llm_config")
+def test_auggie_client_empty_options_default(mock_get_config, monkeypatch):
+    """Test that empty options list works (backward compatibility)."""
+    RecordingPopen.calls = []
+    _patch_subprocess(monkeypatch, RecordingPopen)
+
+    # Mock config with empty options
+    mock_config = Mock()
+    mock_backend_config = Mock()
+    mock_backend_config.model = "GPT-5"
+    mock_backend_config.options = []
+    mock_backend_config.options_for_noedit = []
+    mock_backend_config.usage_markers = []
+    mock_config.get_backend_config.return_value = mock_backend_config
+    mock_get_config.return_value = mock_config
+
+    client = AuggieClient(backend_name="auggie")
+    output = client._run_auggie_cli("test prompt")
+
+    # Check that the command was called without extra options
+    assert len(RecordingPopen.calls) == 1
+    cmd = RecordingPopen.calls[0]
+    assert cmd[0] == "auggie"
+    assert cmd[1] == "--model"
+    assert cmd[2] == "GPT-5"
+    # Should not have --print or other extra options
+    assert "--print" not in cmd
+    assert "--debug" not in cmd
+    assert "test prompt" in cmd
+
+
+@patch("src.auto_coder.auggie_client.get_llm_config")
+def test_auggie_client_no_backend_config_default(mock_get_config, monkeypatch):
+    """Test that None backend config results in empty options (backward compatibility)."""
+    RecordingPopen.calls = []
+    _patch_subprocess(monkeypatch, RecordingPopen)
+
+    # Mock config to return None for backend
+    mock_config = Mock()
+    mock_config.get_backend_config.return_value = None
+    mock_get_config.return_value = mock_config
+
+    client = AuggieClient(backend_name="auggie")
+    output = client._run_auggie_cli("test prompt")
+
+    # Check that the command was called without extra options
+    assert len(RecordingPopen.calls) == 1
+    cmd = RecordingPopen.calls[0]
+    assert cmd[0] == "auggie"
+    assert cmd[1] == "--model"
+    assert "GPT-5" in cmd  # Default model
+    # Should not have --print or other extra options
+    assert "--print" not in cmd
+    assert "test prompt" in cmd
+
+
+@patch("src.auto_coder.auggie_client.get_llm_config")
+def test_auggie_client_options_for_noedit_stored(mock_get_config, monkeypatch):
+    """Test that options_for_noedit is stored from config."""
+    RecordingPopen.calls = []
+    _patch_subprocess(monkeypatch, RecordingPopen)
+
+    # Mock config to provide options_for_noedit
+    mock_config = Mock()
+    mock_backend_config = Mock()
+    mock_backend_config.model = "GPT-5"
+    mock_backend_config.options = ["--print"]
+    mock_backend_config.options_for_noedit = ["--print", "--no-edit"]
+    mock_backend_config.usage_markers = []
+    mock_config.get_backend_config.return_value = mock_backend_config
+    mock_get_config.return_value = mock_config
+
+    client = AuggieClient(backend_name="auggie")
+
+    # Check that options_for_noedit is stored
+    assert client.options_for_noedit == ["--print", "--no-edit"]
+    assert client.options == ["--print"]


### PR DESCRIPTION
Closes #918

Updated AuggieClient to load options and options_for_noedit from backend configuration instead of using hardcoded --print flag. This follows the same pattern as other LLM clients and improves configurability.