### PR TITLE
Implement synchronized attempt increment logic

### DIFF
--- a/src/auto_coder/attempt_manager.py
+++ b/src/auto_coder/attempt_manager.py
@@ -328,7 +328,12 @@ def increment_attempt(repo_name: str, issue_number: int, attempt_number: Optiona
     try:
         # Get current attempt
         current_attempt = get_current_attempt(repo_name, issue_number)
-        new_attempt = current_attempt + 1
+
+        # Use provided attempt_number if available, otherwise increment
+        if attempt_number is not None:
+            new_attempt = attempt_number
+        else:
+            new_attempt = current_attempt + 1
 
         # Create comment with new attempt number
         comment_body = format_attempt_comment(new_attempt)
@@ -357,7 +362,7 @@ def increment_attempt(repo_name: str, issue_number: int, attempt_number: Optiona
                         client.reopen_issue(repo_name, sub_issue_number, reopen_comment)
 
                     # Increment attempt for the sub-issue
-                    increment_attempt(repo_name, sub_issue_number)
+                    increment_attempt(repo_name, sub_issue_number, attempt_number=new_attempt)
 
                 except Exception as e:
                     logger.error(f"Failed to propagate attempt to sub-issue #{sub_issue_number}: {e}")


### PR DESCRIPTION
Closes #990

Added support for using provided attempt_number in increment_attempt function. When attempt_number is provided, it's used directly; otherwise, increments current attempt by 1. This resolves issue #990 by enabling synchronized attempt tracking across sub-issues.