### PR TITLE
Add explicit option flags to BackendConfig dataclass

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -98,6 +98,9 @@ class BackendConfig:
     usage_markers: List[str] = field(default_factory=list)
     # Additional options for message generation (non-code-editing) operations
     options_for_noedit: List[str] = field(default_factory=list)
+    # Flags to track if options were explicitly set in configuration
+    options_explicitly_set: bool = False
+    options_for_noedit_explicitly_set: bool = False
 
     def validate_required_options(self) -> List[str]:
         """Validate that required options are configured.
@@ -192,6 +195,8 @@ class LLMBackendConfiguration:
                     settings=config_data.get("settings"),
                     usage_markers=config_data.get("usage_markers", []),
                     options_for_noedit=config_data.get("options_for_noedit", []),
+                    options_explicitly_set=config_data.get("options_explicitly_set", False),
+                    options_for_noedit_explicitly_set=config_data.get("options_for_noedit_explicitly_set", False),
                 )
 
             # 1. Parse explicit [backends] section
@@ -321,6 +326,8 @@ class LLMBackendConfiguration:
                 usage_markers=config_data.get("usage_markers", []),
                 options_for_noedit=config_data.get("options_for_noedit", []),
                 options_for_resume=config_data.get("options_for_resume", []),
+                options_explicitly_set=config_data.get("options_explicitly_set", False),
+                options_for_noedit_explicitly_set=config_data.get("options_for_noedit_explicitly_set", False),
             )
 
         # 1. Parse explicit [backends] section
@@ -438,6 +445,8 @@ class LLMBackendConfiguration:
                 "always_switch_after_execution": config.always_switch_after_execution,
                 "settings": config.settings,
                 "usage_markers": config.usage_markers,
+                "options_explicitly_set": config.options_explicitly_set,
+                "options_for_noedit_explicitly_set": config.options_for_noedit_explicitly_set,
             }
 
         # Prepare backend_for_failed_pr data
@@ -467,6 +476,8 @@ class LLMBackendConfiguration:
                 "always_switch_after_execution": config.always_switch_after_execution,
                 "settings": config.settings,
                 "usage_markers": config.usage_markers,
+                "options_explicitly_set": config.options_explicitly_set,
+                "options_for_noedit_explicitly_set": config.options_for_noedit_explicitly_set,
             }
 
         data = {"backend": {"order": self.backend_order, "default": self.default_backend}, "backend_for_noedit": {"order": self.backend_for_noedit_order, "default": self.backend_for_noedit_default or self.default_backend}, "backends": backend_data}


### PR DESCRIPTION
Closes #1010

Updated BackendConfig to track when options are explicitly set by users. This addresses issue #1010 by adding options_explicitly_set and options_for_noedit_explicitly_set boolean flags to the dataclass. These flags will help distinguish between default values and user-specified configuration options.