### PR TITLE
feat: implement LLM backend option inheritance logic

### DIFF
--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -172,6 +172,10 @@ class LLMBackendConfiguration:
 
             # Helper to parse a backend config dict
             def parse_backend_config(name: str, config_data: dict) -> BackendConfig:
+                # Set explicit flags based on whether options were actually specified in config
+                options_explicitly_set = "options" in config_data
+                options_for_noedit_explicitly_set = "options_for_noedit" in config_data
+
                 return BackendConfig(
                     name=name,
                     enabled=config_data.get("enabled", True),
@@ -195,8 +199,8 @@ class LLMBackendConfiguration:
                     settings=config_data.get("settings"),
                     usage_markers=config_data.get("usage_markers", []),
                     options_for_noedit=config_data.get("options_for_noedit", []),
-                    options_explicitly_set=config_data.get("options_explicitly_set", False),
-                    options_for_noedit_explicitly_set=config_data.get("options_for_noedit_explicitly_set", False),
+                    options_explicitly_set=options_explicitly_set,
+                    options_for_noedit_explicitly_set=options_for_noedit_explicitly_set,
                 )
 
             # 1. Parse explicit [backends] section
@@ -245,6 +249,18 @@ class LLMBackendConfiguration:
             potential_roots = {k: v for k, v in data.items() if k not in reserved_keys and isinstance(v, dict)}
 
             find_backends_recursive(potential_roots)
+
+            # Post-processing: inherit options from parent backend if backend_type matches
+            # and options were not explicitly set in the child configuration
+            for backend_name, backend_config in backends.items():
+                if backend_config.backend_type and backend_config.backend_type in backends:
+                    parent_config = backends[backend_config.backend_type]
+                    # Inherit options if not explicitly set
+                    if not backend_config.options_explicitly_set:
+                        backend_config.options = list(parent_config.options)
+                    # Inherit options_for_noedit if not explicitly set
+                    if not backend_config.options_for_noedit_explicitly_set:
+                        backend_config.options_for_noedit = list(parent_config.options_for_noedit)
 
             # Add default backends if they are not already in the configuration
             # This ensures that backends like 'jules' are available even if not explicitly defined in the file
@@ -303,6 +319,10 @@ class LLMBackendConfiguration:
 
         # Helper to parse a backend config dict
         def parse_backend_config(name: str, config_data: dict) -> BackendConfig:
+            # Set explicit flags based on whether options were actually specified in config
+            options_explicitly_set = "options" in config_data
+            options_for_noedit_explicitly_set = "options_for_noedit" in config_data
+
             return BackendConfig(
                 name=name,
                 enabled=config_data.get("enabled", True),
@@ -326,8 +346,8 @@ class LLMBackendConfiguration:
                 usage_markers=config_data.get("usage_markers", []),
                 options_for_noedit=config_data.get("options_for_noedit", []),
                 options_for_resume=config_data.get("options_for_resume", []),
-                options_explicitly_set=config_data.get("options_explicitly_set", False),
-                options_for_noedit_explicitly_set=config_data.get("options_for_noedit_explicitly_set", False),
+                options_explicitly_set=options_explicitly_set,
+                options_for_noedit_explicitly_set=options_for_noedit_explicitly_set,
             )
 
         # 1. Parse explicit [backends] section
@@ -376,6 +396,18 @@ class LLMBackendConfiguration:
         potential_roots = {k: v for k, v in data.items() if k not in reserved_keys and isinstance(v, dict)}
 
         find_backends_recursive(potential_roots)
+
+        # Post-processing: inherit options from parent backend if backend_type matches
+        # and options were not explicitly set in the child configuration
+        for backend_name, backend_config in backends.items():
+            if backend_config.backend_type and backend_config.backend_type in backends:
+                parent_config = backends[backend_config.backend_type]
+                # Inherit options if not explicitly set
+                if not backend_config.options_explicitly_set:
+                    backend_config.options = list(parent_config.options)
+                # Inherit options_for_noedit if not explicitly set
+                if not backend_config.options_for_noedit_explicitly_set:
+                    backend_config.options_for_noedit = list(parent_config.options_for_noedit)
 
         # Add default backends if they are not already in the configuration
         # This ensures that backends like 'jules' are available even if not explicitly defined in the file

--- a/tests/test_llm_backend_config.py
+++ b/tests/test_llm_backend_config.py
@@ -873,16 +873,20 @@ class TestLLMBackendConfiguration:
                 LLMBackendConfiguration.load_from_file(str(config_file))
 
     def test_toml_save_and_load_options_explicitly_set_flags(self):
-        """Test that options_explicitly_set and options_for_noedit_explicitly_set flags are properly saved and loaded."""
+        """Test that options_explicitly_set flags are determined by presence of options key in TOML.
+
+        Note: The options_explicitly_set flags are not stored/loaded from TOML.
+        They are computed dynamically based on whether the 'options' or 'options_for_noedit'
+        keys are present in the loaded configuration data.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             config_file = Path(tmpdir) / "test_explicit_flags.toml"
 
-            # Create configuration with explicit flags settings
+            # Create configuration with options set for gemini but not for qwen
             config = LLMBackendConfiguration()
-            config.get_backend_config("gemini").options_explicitly_set = True
-            config.get_backend_config("gemini").options_for_noedit_explicitly_set = False
-            config.get_backend_config("qwen").options_explicitly_set = False
-            config.get_backend_config("qwen").options_for_noedit_explicitly_set = True
+            config.get_backend_config("gemini").options = ["--test-opt"]
+            config.get_backend_config("gemini").options_for_noedit = ["--noedit-opt"]
+            # qwen has no options set (empty list from default)
 
             # Save to file
             config.save_to_file(str(config_file))
@@ -890,17 +894,26 @@ class TestLLMBackendConfiguration:
             # Load from file
             loaded_config = LLMBackendConfiguration.load_from_file(str(config_file))
 
-            # Verify flags were persisted
+            # Gemini should have flags set because options keys are present in saved TOML
             gemini_config = loaded_config.get_backend_config("gemini")
             assert gemini_config.options_explicitly_set is True
-            assert gemini_config.options_for_noedit_explicitly_set is False
+            assert gemini_config.options_for_noedit_explicitly_set is True
+            assert gemini_config.options == ["--test-opt"]
+            assert gemini_config.options_for_noedit == ["--noedit-opt"]
 
+            # Qwen should also have flags set because save_to_file writes all fields
             qwen_config = loaded_config.get_backend_config("qwen")
-            assert qwen_config.options_explicitly_set is False
+            assert qwen_config.options_explicitly_set is True
             assert qwen_config.options_for_noedit_explicitly_set is True
 
     def test_backward_compatibility_old_toml_without_explicitly_set_flags(self):
-        """Test loading old TOML files that don't have options_explicitly_set or options_for_noedit_explicitly_set fields."""
+        """Test loading TOML files with options - flags are determined by presence of options key.
+
+        Note: When options/options_for_noedit keys exist in TOML, the corresponding
+        explicitly_set flags will be True. This is the correct behavior for option
+        inheritance - if a config explicitly sets options (even to a value), it should
+        not inherit from parent.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             config_file = Path(tmpdir) / "old_config_no_explicit_flags.toml"
 
@@ -929,16 +942,17 @@ class TestLLMBackendConfiguration:
             # Load the configuration
             config = LLMBackendConfiguration.load_from_file(str(config_file))
 
-            # Verify flags have default False values when not present in old TOML
+            # When options/options_for_noedit keys exist in TOML, flags should be True
             qwen_config = config.get_backend_config("qwen")
             assert qwen_config is not None
-            assert qwen_config.options_explicitly_set is False
-            assert qwen_config.options_for_noedit_explicitly_set is False
+            assert qwen_config.options_explicitly_set is True
+            assert qwen_config.options_for_noedit_explicitly_set is True
             assert qwen_config.options == ["option1"]
             assert qwen_config.options_for_noedit == ["noedit1"]
             assert qwen_config.model == "qwen3-coder-plus"
             assert qwen_config.temperature == 0.7
 
+            # Gemini doesn't have options key in TOML, so flags should be False
             gemini_config = config.get_backend_config("gemini")
             assert gemini_config is not None
             assert gemini_config.options_explicitly_set is False
@@ -2161,3 +2175,257 @@ model = "gemini-2.5-pro"
             # Verify the deprecated methods still work
             assert loaded_config.get_noedit_default_backend() == "gemini"
             assert loaded_config.get_active_noedit_backends() == ["gemini", "qwen"]
+
+
+class TestOptionInheritance:
+    """Test cases for option inheritance from parent backends."""
+
+    def test_options_inherited_from_parent_backend(self):
+        """Test that options are inherited from parent backend when not explicitly set."""
+        config_data = {
+            "backends": {
+                "codex": {
+                    "enabled": True,
+                    "options": ["--parent-opt1", "--parent-opt2"],
+                    "options_for_noedit": ["--parent-noedit1"],
+                },
+                "child": {
+                    "enabled": True,
+                    "backend_type": "codex",
+                    "model": "child-model",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        child_config = config.get_backend_config("child")
+        assert child_config is not None
+        assert child_config.options == ["--parent-opt1", "--parent-opt2"]
+        assert child_config.options_for_noedit == ["--parent-noedit1"]
+
+    def test_options_not_inherited_when_explicitly_set(self):
+        """Test that options are NOT inherited when explicitly set in child."""
+        config_data = {
+            "backends": {
+                "codex": {
+                    "enabled": True,
+                    "options": ["--parent-opt1", "--parent-opt2"],
+                    "options_for_noedit": ["--parent-noedit1"],
+                },
+                "child": {
+                    "enabled": True,
+                    "backend_type": "codex",
+                    "model": "child-model",
+                    "options": ["--child-opt1"],
+                    "options_for_noedit": ["--child-noedit1"],
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        child_config = config.get_backend_config("child")
+        assert child_config is not None
+        assert child_config.options == ["--child-opt1"]
+        assert child_config.options_for_noedit == ["--child-noedit1"]
+        assert child_config.options_explicitly_set is True
+        assert child_config.options_for_noedit_explicitly_set is True
+
+    def test_options_explicitly_set_flag_detected(self):
+        """Test that options_explicitly_set flag is correctly detected."""
+        config_data = {
+            "backends": {
+                "parent": {
+                    "enabled": True,
+                    "options": ["--parent-opt"],
+                },
+                "child_with_options": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                    "options": [],
+                },
+                "child_without_options": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        # Child with explicitly set options (even empty list)
+        child_with = config.get_backend_config("child_with_options")
+        assert child_with is not None
+        assert child_with.options_explicitly_set is True
+        assert child_with.options == []
+
+        # Child without explicitly set options should inherit
+        child_without = config.get_backend_config("child_without_options")
+        assert child_without is not None
+        assert child_without.options_explicitly_set is False
+        assert child_without.options == ["--parent-opt"]
+
+    def test_options_for_noedit_explicitly_set_flag_detected(self):
+        """Test that options_for_noedit_explicitly_set flag is correctly detected."""
+        config_data = {
+            "backends": {
+                "parent": {
+                    "enabled": True,
+                    "options_for_noedit": ["--parent-noedit"],
+                },
+                "child_with_noedit": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                    "options_for_noedit": [],
+                },
+                "child_without_noedit": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        # Child with explicitly set options_for_noedit (even empty list)
+        child_with = config.get_backend_config("child_with_noedit")
+        assert child_with is not None
+        assert child_with.options_for_noedit_explicitly_set is True
+        assert child_with.options_for_noedit == []
+
+        # Child without explicitly set options_for_noedit should inherit
+        child_without = config.get_backend_config("child_without_noedit")
+        assert child_without is not None
+        assert child_without.options_for_noedit_explicitly_set is False
+        assert child_without.options_for_noedit == ["--parent-noedit"]
+
+    def test_no_inheritance_when_parent_not_found(self):
+        """Test that no inheritance occurs when parent backend doesn't exist."""
+        config_data = {
+            "backends": {
+                "child": {
+                    "enabled": True,
+                    "backend_type": "nonexistent_parent",
+                    "model": "child-model",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        child_config = config.get_backend_config("child")
+        assert child_config is not None
+        assert child_config.options == []
+        assert child_config.options_for_noedit == []
+
+    def test_inheritance_with_load_from_file(self):
+        """Test that option inheritance works with load_from_file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "inheritance_config.toml"
+            data = {
+                "backend": {"default": "child", "order": ["child", "parent"]},
+                "backends": {
+                    "parent": {
+                        "enabled": True,
+                        "options": ["--parent-flag"],
+                        "options_for_noedit": ["--parent-noedit-flag"],
+                    },
+                    "child": {
+                        "enabled": True,
+                        "backend_type": "parent",
+                        "model": "child-model",
+                    },
+                },
+            }
+            with open(config_file, "w", encoding="utf-8") as fh:
+                toml.dump(data, fh)
+
+            config = LLMBackendConfiguration.load_from_file(str(config_file))
+
+            child_config = config.get_backend_config("child")
+            assert child_config is not None
+            assert child_config.backend_type == "parent"
+            assert child_config.options == ["--parent-flag"]
+            assert child_config.options_for_noedit == ["--parent-noedit-flag"]
+            assert child_config.options_explicitly_set is False
+            assert child_config.options_for_noedit_explicitly_set is False
+
+    def test_partial_inheritance(self):
+        """Test that only non-explicitly set options are inherited."""
+        config_data = {
+            "backends": {
+                "parent": {
+                    "enabled": True,
+                    "options": ["--parent-opt"],
+                    "options_for_noedit": ["--parent-noedit"],
+                },
+                "child": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                    "options": ["--child-opt"],
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        child_config = config.get_backend_config("child")
+        assert child_config is not None
+        assert child_config.options == ["--child-opt"]
+        assert child_config.options_for_noedit == ["--parent-noedit"]
+        assert child_config.options_explicitly_set is True
+        assert child_config.options_for_noedit_explicitly_set is False
+
+    def test_inheritance_creates_copy_not_reference(self):
+        """Test that inherited options are copied, not referenced."""
+        config_data = {
+            "backends": {
+                "parent": {
+                    "enabled": True,
+                    "options": ["--parent-opt"],
+                },
+                "child": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        parent_config = config.get_backend_config("parent")
+        child_config = config.get_backend_config("child")
+
+        assert parent_config is not None
+        assert child_config is not None
+
+        child_config.options.append("--child-added-opt")
+        assert "--child-added-opt" not in parent_config.options
+
+    def test_nested_inheritance_not_supported(self):
+        """Test that grandparent inheritance is not directly supported (only immediate parent)."""
+        config_data = {
+            "backends": {
+                "grandparent": {
+                    "enabled": True,
+                    "options": ["--grandparent-opt"],
+                },
+                "parent": {
+                    "enabled": True,
+                    "backend_type": "grandparent",
+                },
+                "child": {
+                    "enabled": True,
+                    "backend_type": "parent",
+                },
+            }
+        }
+
+        config = LLMBackendConfiguration.load_from_dict(config_data)
+
+        parent_config = config.get_backend_config("parent")
+        child_config = config.get_backend_config("child")
+
+        assert parent_config.options == ["--grandparent-opt"]
+        assert child_config.options == ["--grandparent-opt"]


### PR DESCRIPTION
## Summary
- Implement inheritance logic in `LLMBackendConfiguration._load_from_data` for backend options
- In `parse_backend_config`, set explicit flags based on whether `options` and `options_for_noedit` keys exist in config data
- Add post-processing to copy options from parent backend when `backend_type` matches and options are not explicitly set

## Changes
- **`src/auto_coder/llm_backend_config.py`**:
  - Modified `parse_backend_config` in both `load_from_file` and `_load_from_data` to set `options_explicitly_set` and `options_for_noedit_explicitly_set` flags based on key presence
  - Added post-processing loop after backend parsing to inherit options from parent backends

- **`tests/test_llm_backend_config.py`**:
  - Added `TestOptionInheritance` class with 9 comprehensive tests
  - Updated existing tests to reflect the new behavior where flags are determined by key presence

## Test plan
- [x] All 100 tests in `test_llm_backend_config.py` pass
- [x] All 176 tests in related modules pass
- [x] Code quality checks (black, isort, flake8, mypy) pass

Closes #1011
Parent Issue: #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)