### PR TITLE
Fix issue #1033: Integration: Update issue_processor.py to use find_closing_pr

### DIFF
--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -377,20 +377,19 @@ def _process_parent_issue(
                 sub_issues_details.append(sub_issue_dict)
 
                 # Check if this sub-issue has a closing PR
-                # Search for PRs that might close this issue
-                prs = github_client.get_open_pull_requests(repo_name, limit=100)
-                for pr in prs:
-                    closing_issues = github_client.get_pr_closing_issues(repo_name, pr.number)
-                    if sub_issue_number in closing_issues:
-                        sub_issues_with_prs.append(
-                            {
-                                "issue_number": sub_issue_number,
-                                "pr_number": pr.number,
-                                "pr_state": pr.state,
-                                "mergeable": pr.mergeable,
-                            }
-                        )
-                        break
+                closing_pr_number = github_client.find_closing_pr(repo_name, sub_issue_number)
+                if closing_pr_number is not None:
+                    # Get the PR details
+                    repo = github_client.get_repository(repo_name)
+                    pr = repo.get_pull(closing_pr_number)
+                    sub_issues_with_prs.append(
+                        {
+                            "issue_number": sub_issue_number,
+                            "pr_number": pr.number,
+                            "pr_state": pr.state,
+                            "mergeable": pr.mergeable,
+                        }
+                    )
 
             except Exception as e:
                 logger.warning(f"Failed to get details for sub-issue #{sub_issue_number}: {e}")

--- a/tests/test_issue_processor_parent_issue.py
+++ b/tests/test_issue_processor_parent_issue.py
@@ -366,8 +366,8 @@ class TestProcessParentIssue:
         mock_pr.number = 201
         mock_pr.state = "MERGED"
         mock_pr.mergeable = True
-        github_client.get_open_pull_requests.return_value = [mock_pr]
-        github_client.get_pr_closing_issues.return_value = [101]
+        github_client.find_closing_pr.return_value = 201
+        mock_repo.get_pull.return_value = mock_pr
 
         # Mock LLM response
         mock_run_llm.return_value = """```json


### PR DESCRIPTION
Closes #1033

This PR addresses issue #1033.

Update `src/auto_coder/issue_processor.py` to use the new `find_closing_pr` method.
- Remove the loop over `get_open_pull_requests` around line 381.
- Call `github_client.find_closing_pr(repo_name, su