### PR TITLE
Fix issue #1050: Update Issue Processor to retain label on PR creation

### DIFF
--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -1026,6 +1026,10 @@ def _apply_issue_actions_directly(
                                 config=config,
                             )
                         actions.append(pr_creation_result)
+
+                        # Retain the label if PR creation was successful
+                        if pr_creation_result.startswith("Successfully created PR"):
+                            should_process.keep_label()
                 else:
                     actions.append("LLM CLI did not provide a clear response for issue analysis")
 


### PR DESCRIPTION
Closes #1050

This PR addresses issue #1050.

Update Issue Processor to retain label on PR creation.
- In `_apply_issue_actions_directly`, inside the `with LabelManager(...) as should_process:` block:
    - Check if PR creation was successful.
  