### PR TITLE
Fix issue #1073: Implement logic for --body-file option

### DIFF
--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -22,7 +22,7 @@ class TestCodexClient:
     def test_init_checks_cli(self, mock_get_config, mock_run):
         """CodexClient should check codex --version at init."""
         mock_run.return_value.returncode = 0
-        
+
         # Mock config to return default codex model
         mock_backend = MagicMock()
         mock_backend.model = "codex"
@@ -451,7 +451,7 @@ class TestCodexClient:
     def test_model_name_default_with_custom_config(self, mock_get_config, mock_run):
         """CodexClient should use default model when model_name is None with custom config."""
         mock_run.return_value.returncode = 0
-        
+
         # Mock config
         mock_backend = MagicMock()
         mock_backend.model = "codex"

--- a/utils/github-sub-issue/src/github_sub_issue/cli.py
+++ b/utils/github-sub-issue/src/github_sub_issue/cli.py
@@ -69,6 +69,7 @@ def add(ctx: click.Context, parent: str, sub_issues: tuple[str, ...], replace_pa
 @click.option("--parent", "-p", required=True, help="Parent issue number or URL")
 @click.option("--title", "-t", required=True, help="Issue title")
 @click.option("--body", "-b", help="Issue body")
+@click.option("--body-file", help="Path to file containing issue body")
 @click.option("--label", "-l", multiple=True, help="Label (can be specified multiple times)")
 @click.option("--assignee", "-a", multiple=True, help="User to assign (can be specified multiple times)")
 @click.pass_context
@@ -77,6 +78,7 @@ def create(
     parent: str,
     title: str,
     body: Optional[str],
+    body_file: Optional[str],
     label: tuple[str, ...],
     assignee: tuple[str, ...],
 ) -> None:
@@ -92,8 +94,9 @@ def create(
             body=body,
             labels=list(label) if label else None,
             assignees=list(assignee) if assignee else None,
+            body_file=body_file,
         )
-        
+
         click.echo(f"✅ Created sub-issue #{result['number']}: {result['title']}")
         click.echo(f"   URL: {result['url']}")
     except Exception as e:

--- a/utils/github-sub-issue/src/github_sub_issue/github_api.py
+++ b/utils/github-sub-issue/src/github_sub_issue/github_api.py
@@ -262,6 +262,7 @@ class GitHubSubIssueAPI:
         body: Optional[str] = None,
         labels: Optional[List[str]] = None,
         assignees: Optional[List[str]] = None,
+        body_file: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a new sub-issue.
 
@@ -271,6 +272,7 @@ class GitHubSubIssueAPI:
             body: Issue body
             labels: List of labels
             assignees: List of users to assign
+            body_file: Path to file containing issue body
 
         Returns:
             Created issue information
@@ -282,14 +284,18 @@ class GitHubSubIssueAPI:
 
         # Create issue first
         cmd = ["gh", "issue", "create", "--repo", parent_repo, "--title", title]
-        
+
+        # Handle body and body_file options
+        # If both body and body_file are provided, body takes precedence (following gh behavior)
         if body:
             cmd.extend(["--body", body])
-        
+        elif body_file:
+            cmd.extend(["--body-file", body_file])
+
         if labels:
             for label in labels:
                 cmd.extend(["--label", label])
-        
+
         if assignees:
             for assignee in assignees:
                 cmd.extend(["--assignee", assignee])

--- a/utils/github-sub-issue/tests/test_cli.py
+++ b/utils/github-sub-issue/tests/test_cli.py
@@ -182,6 +182,40 @@ class TestCLI:
             body="Description",
             labels=["bug"],
             assignees=["user1"],
+            body_file=None,
+        )
+
+    @patch("github_sub_issue.cli.GitHubSubIssueAPI")
+    def test_create_command_with_body_file(self, mock_api_class: MagicMock) -> None:
+        """Verify that create command works correctly with --body-file option."""
+        mock_api = MagicMock()
+        mock_api.create_sub_issue.return_value = {
+            "number": 789,
+            "title": "New Issue",
+            "url": "https://github.com/owner/repo/issues/789",
+        }
+        mock_api_class.return_value = mock_api
+
+        result = self.runner.invoke(
+            main,
+            [
+                "create",
+                "--parent", "123",
+                "--title", "New Issue",
+                "--body-file", "/path/to/body.txt",
+                "--label", "bug",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created sub-issue #789: New Issue" in result.output
+        mock_api.create_sub_issue.assert_called_once_with(
+            "123",
+            "New Issue",
+            body=None,
+            labels=["bug"],
+            assignees=None,
+            body_file="/path/to/body.txt",
         )
 
     @patch("github_sub_issue.cli.GitHubSubIssueAPI")

--- a/utils/github-sub-issue/tests/test_github_api.py
+++ b/utils/github-sub-issue/tests/test_github_api.py
@@ -226,3 +226,102 @@ class TestGitHubSubIssueAPI:
         assert "--assignee" in args
         assert "user1" in args
 
+    @patch("subprocess.run")
+    def test_create_sub_issue_with_body_file(self, mock_run: MagicMock) -> None:
+        """Verify that a new sub-issue can be created with body from file."""
+        mock_run.side_effect = [
+            # gh issue create
+            MagicMock(stdout="https://github.com/owner/repo/issues/789\n", returncode=0),
+            # _get_issue_id (parent)
+            MagicMock(stdout="I_parent\n", returncode=0),
+            # _get_issue_id (new issue)
+            MagicMock(stdout="I_new\n", returncode=0),
+            # addSubIssue mutation
+            MagicMock(
+                stdout=json.dumps({
+                    "data": {
+                        "addSubIssue": {
+                            "issue": {"number": 123, "title": "Parent"},
+                            "subIssue": {"number": 789, "title": "New Issue"},
+                        }
+                    }
+                }),
+                returncode=0,
+            ),
+        ]
+
+        api = GitHubSubIssueAPI(repo="owner/repo")
+        result = api.create_sub_issue(
+            "123",
+            "New Issue",
+            body_file="/path/to/body.txt",
+            labels=["bug"],
+        )
+
+        assert result["number"] == 789
+        assert result["title"] == "New Issue"
+        assert "https://github.com/owner/repo/issues/789" in result["url"]
+
+        # Verify gh issue create call
+        create_call = mock_run.call_args_list[0]
+        args = create_call[0][0]
+        assert args[0] == "gh"
+        assert args[1] == "issue"
+        assert args[2] == "create"
+        assert "--title" in args
+        assert "New Issue" in args
+        assert "--body-file" in args
+        assert "/path/to/body.txt" in args
+        assert "--label" in args
+        assert "bug" in args
+        # Should not have --body when body_file is used
+        body_indices = [i for i, x in enumerate(args) if x == "--body"]
+        assert len(body_indices) == 0
+
+    @patch("subprocess.run")
+    def test_create_sub_issue_body_precedence(self, mock_run: MagicMock) -> None:
+        """Verify that body takes precedence over body_file when both are provided."""
+        mock_run.side_effect = [
+            # gh issue create
+            MagicMock(stdout="https://github.com/owner/repo/issues/789\n", returncode=0),
+            # _get_issue_id (parent)
+            MagicMock(stdout="I_parent\n", returncode=0),
+            # _get_issue_id (new issue)
+            MagicMock(stdout="I_new\n", returncode=0),
+            # addSubIssue mutation
+            MagicMock(
+                stdout=json.dumps({
+                    "data": {
+                        "addSubIssue": {
+                            "issue": {"number": 123, "title": "Parent"},
+                            "subIssue": {"number": 789, "title": "New Issue"},
+                        }
+                    }
+                }),
+                returncode=0,
+            ),
+        ]
+
+        api = GitHubSubIssueAPI(repo="owner/repo")
+        result = api.create_sub_issue(
+            "123",
+            "New Issue",
+            body="Direct body text",
+            body_file="/path/to/body.txt",
+        )
+
+        assert result["number"] == 789
+        assert result["title"] == "New Issue"
+
+        # Verify gh issue create call - body should take precedence over body-file
+        create_call = mock_run.call_args_list[0]
+        args = create_call[0][0]
+        assert args[0] == "gh"
+        assert args[1] == "issue"
+        assert args[2] == "create"
+        assert "--body" in args
+        assert "Direct body text" in args
+        # Should not have --body-file when body is also provided
+        body_file_indices = [i for i, x in enumerate(args) if x == "--body-file"]
+        assert len(body_file_indices) == 0
+


### PR DESCRIPTION
Closes #1073

This PR addresses issue #1073.

Implement the logic for `--body-file` option.

## Changes
- Modify `src/github_sub_issue/github_api.py`: Update `create_sub_issue` to accept `body_file` and use it in `gh` command.
- Modify `src/githu