### PR TITLE
Fix issue #1085: Implement general placeholder replacement system in BackendConfig

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -121,6 +121,7 @@ The system supports extensive backend configuration options. Key fields include:
     - The system automatically adds required flags for each backend type during execution (e.g., `--dangerously-bypass-approvals-and-sandbox` for Codex)
     - Custom options specified here are appended to the automatically-added flags
     - Different backends may interpret options differently
+    - Supports placeholder replacement for dynamic values (see Placeholder Replacement System below)
   - Configuration file: "~/.auto-coder/llm_config.toml"
   - Optional field: Backward compatible with existing configurations
 
@@ -171,6 +172,42 @@ The system supports extensive backend configuration options. Key fields include:
     - Replace environment variable `AUTO_CODER_MESSAGE_DEFAULT_BACKEND` with `AUTO_CODER_NOEDIT_DEFAULT_BACKEND`
   - Configuration file: "~/.auto-coder/llm_config.toml"
   - Optional field: Defaults to general backend configuration if not specified
+
+#### Placeholder Replacement System
+
+- **Purpose**: Enable dynamic configuration values in option lists using placeholders
+- **Supported Placeholders**:
+  - `[model_name]` - Replaced with the actual model name at runtime
+  - `[sessionId]` - Replaced with the session identifier for session-based backends
+- **Implementation**: The `BackendConfig.replace_placeholders()` method processes all three option lists (`options`, `options_for_noedit`, `options_for_resume`)
+- **Behavior**:
+  - Placeholders are replaced with provided values at runtime
+  - If a placeholder value is not provided, the placeholder remains unchanged
+  - The method returns a new dictionary with processed lists, leaving the original configuration unmodified
+  - Multiple occurrences of the same placeholder in a list are all replaced
+- **Example Configuration**:
+  ```toml
+  [backends.codex]
+  model = "gpt-5.1-codex-max"
+  options = ["--model", "[model_name]", "--json", "--dangerously-bypass-approvals-and-sandbox"]
+  options_for_noedit = ["--model", "[model_name]", "--json"]
+  options_for_resume = ["--model", "[model_name]"]
+  ```
+- **Usage in Code**:
+  ```python
+  config = BackendConfig(name="codex", ...)
+  processed = config.replace_placeholders(
+      model_name="gpt-5.1-codex-max",
+      session_id="sess_20241204"
+  )
+  # processed['options'] = ["--model", "gpt-5.1-codex-max", "--json", "--dangerously-bypass-approvals-and-sandbox"]
+  ```
+- **Benefits**:
+  - Single configuration template can be used with different models
+  - Session-based backends can dynamically inject session IDs
+  - Reduces configuration duplication
+  - Supports dynamic runtime values without modifying configuration files
+- **Backward Compatibility**: Fully backward compatible - configurations without placeholders work unchanged
 
 #### Backend Management
 


### PR DESCRIPTION
Closes #1085

This PR addresses issue #1085.

## Summary

Implement a general placeholder replacement system in `BackendConfig` class to support dynamic values like `[model_name]`, `[sessionId]`, etc. in configuration options.

## Files to Modify