### PR TITLE
Fix issue #1119: Add Tests for Dot Output Positioning with ProgressStage Footer

### DIFF
--- a/tests/test_dot_logging.py
+++ b/tests/test_dot_logging.py
@@ -147,3 +147,140 @@ class TestDotLogging:
         for call_args in calls:
             # Each call should have depth=2
             assert "depth=2" in str(call_args)
+
+    def test_dot_positioning_with_ansi_escape_sequences_tty(self, monkeypatch, _use_real_commands):
+        """Test that dots are printed with ANSI escape sequences when stderr is a TTY."""
+        # Ensure verbose mode is disabled
+        monkeypatch.delenv("AUTOCODER_VERBOSE", raising=False)
+
+        # Create a command that produces some output
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; print('line1'); print('line2'); print('line3')",
+        ]
+
+        # Create a mock stderr that simulates a TTY
+        original_stderr = sys.stderr
+        captured_stderr = StringIO()
+
+        # Mock isatty to return True
+        captured_stderr.isatty = Mock(return_value=True)
+
+        try:
+            # Temporarily replace stderr to capture dots
+            sys.stderr = captured_stderr
+            result = utils.CommandExecutor.run_command(
+                command,
+                timeout=5,
+                stream_output=True,
+                dot_format=True,
+            )
+        finally:
+            sys.stderr = original_stderr
+
+        # Verify command succeeded
+        assert result.success is True
+
+        # Verify ANSI escape sequences are present in the output
+        stderr_content = captured_stderr.getvalue()
+
+        # Check for cursor save/restore and move up sequences
+        assert "\033[s" in stderr_content, "Expected cursor save sequence \\033[s"
+        assert "\033[1A" in stderr_content, "Expected cursor move up sequence \\033[1A"
+        assert "\033[u" in stderr_content, "Expected cursor restore sequence \\033[u"
+
+        # Verify dots are printed
+        assert "." in stderr_content, "Expected dots to be printed"
+
+    def test_dot_positioning_non_tty_fallback(self, monkeypatch, _use_real_commands):
+        """Test graceful fallback when stderr is not a TTY."""
+        # Ensure verbose mode is disabled
+        monkeypatch.delenv("AUTOCODER_VERBOSE", raising=False)
+
+        # Create a command that produces some output
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; print('line1'); print('line2')",
+        ]
+
+        # Create a mock stderr that is NOT a TTY
+        original_stderr = sys.stderr
+        captured_stderr = StringIO()
+
+        # Mock isatty to return False
+        captured_stderr.isatty = Mock(return_value=False)
+
+        try:
+            # Temporarily replace stderr to capture dots
+            sys.stderr = captured_stderr
+            result = utils.CommandExecutor.run_command(
+                command,
+                timeout=5,
+                stream_output=True,
+                dot_format=True,
+            )
+        finally:
+            sys.stderr = original_stderr
+
+        # Verify command succeeded
+        assert result.success is True
+
+        # Verify basic dot printing still works (without ANSI sequences)
+        stderr_content = captured_stderr.getvalue()
+        assert "." in stderr_content, "Expected dots to be printed"
+
+        # Verify ANSI escape sequences are NOT present in non-TTY mode
+        assert "\033[s" not in stderr_content, "Did not expect cursor save sequence in non-TTY mode"
+        assert "\033[1A" not in stderr_content, "Did not expect cursor move up sequence in non-TTY mode"
+
+    def test_dot_positioning_with_progress_stage_footer(self, monkeypatch, _use_real_commands):
+        """Test that dots interact correctly with ProgressStage footer."""
+        # Ensure verbose mode is disabled
+        monkeypatch.delenv("AUTOCODER_VERBOSE", raising=False)
+
+        # Import ProgressStage for testing interaction
+        from src.auto_coder.progress_footer import ProgressStage, clear_progress
+
+        # Create a command that produces some output
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; print('line1'); print('line2')",
+        ]
+
+        # Create a mock stderr that simulates a TTY
+        original_stderr = sys.stderr
+        captured_stderr = StringIO()
+        captured_stderr.isatty = Mock(return_value=True)
+
+        try:
+            # Set up a progress stage
+            with ProgressStage("Issue", 1119, "Testing dots"):
+                # Temporarily replace stderr to capture dots
+                sys.stderr = captured_stderr
+
+                # Run command with dot_format=True
+                result = utils.CommandExecutor.run_command(
+                    command,
+                    timeout=5,
+                    stream_output=True,
+                    dot_format=True,
+                )
+
+                # Restore stderr before exiting context
+                sys.stderr = original_stderr
+        finally:
+            sys.stderr = original_stderr
+            clear_progress()
+
+        # Verify command succeeded
+        assert result.success is True
+
+        # Verify that dots were printed with ANSI sequences
+        stderr_content = captured_stderr.getvalue()
+        assert "." in stderr_content, "Expected dots to be printed"
+
+        # Verify ANSI escape sequences are present (cursor positioning)
+        assert "\033[s" in stderr_content or "\033[1A" in stderr_content, "Expected ANSI sequences for cursor positioning"


### PR DESCRIPTION
Closes #1119

This PR addresses issue #1119.

# Add Tests for Dot Output Positioning with ProgressStage Footer

Depends on #PARENT_ISSUE_SUB1

## Objective

Add tests to verify that dot output is correctly positioned one line above the ProgressSt