### PR TITLE
Fix issue #1118: Modify Dot Output Logic to Print One Line Above ProgressStage Footer

### DIFF
--- a/<MagicMock name='stdout' id='129688887037136'>
+++ b/<MagicMock name='stdout' id='129688887037136'>
@@ -1,0 +1,1 @@
+[32m2025-12-06 23:42:55.246[0m | [1mINFO    [0m | tests/test_logger_config.py:176 in [36mtest_logger_console_format_with_colors[0m - [1mTest colored message[0m


### PR DESCRIPTION
Closes #1118

This PR addresses issue #1118.

# Modify Dot Output Logic to Print One Line Above ProgressStage Footer

## Objective

Modify the `CommandExecutor._run_with_streaming` method to print dots one line above the current cursor position w