### PR TITLE
Fix issue #1150: Archive Jules Session on Merge

### DIFF
--- a/src/auto_coder/jules_client.py
+++ b/src/auto_coder/jules_client.py
@@ -212,6 +212,47 @@ class JulesClient(LLMClientBase):
             logger.error(f"Failed to end Jules session {session_id}: {e}")
             return False
 
+    def archive_session(self, session_id: str) -> bool:
+        """Archive a Jules session.
+
+        Args:
+            session_id: The session ID to archive
+
+        Returns:
+            True if session was archived successfully, False otherwise
+        """
+        try:
+            # Prepare the request
+            url = f"{self.base_url}/sessions/{session_id}:archive"
+
+            logger.info(f"Archiving Jules session: {session_id}")
+            logger.info(f"🤖 POST {url}")
+            logger.info("=" * 60)
+
+            response = self.session.post(url, json={}, timeout=self.timeout)
+
+            logger.info("=" * 60)
+
+            # Check if request was successful
+            if response.status_code == 200:
+                # Remove from active sessions
+                if session_id in self.active_sessions:
+                    del self.active_sessions[session_id]
+
+                logger.info(f"Archived Jules session: {session_id}")
+                return True
+            else:
+                error_msg = f"HTTP {response.status_code}: {response.text}"
+                logger.error(f"Failed to archive Jules session {session_id}: {error_msg}")
+                return False
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to archive Jules session {session_id}: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to archive Jules session {session_id}: {e}")
+            return False
+
     def _run_llm_cli(self, prompt: str, is_noedit: bool = False) -> str:
         """Run Jules HTTP API with the given prompt and return response.
 


### PR DESCRIPTION
Closes #1150

This PR addresses issue #1150.

Archive the corresponding Jules session when a PR created by Jules is merged.

Modify `src/auto_coder/pr_processor.py` (specifically `_merge_pr` or related success path).
Use `POST https://jules.googl