### PR TITLE
feat(ui): add Spinner.step() method for smoother progress updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-29 - [CLI Spinner Step Pattern]
+**Learning:** CLI Spinners often leave debris when updating messages to shorter strings.
+**Action:** Use `Spinner.step(message)` which handles padding/clearing automatically instead of direct message assignment.

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -341,7 +341,7 @@ def process_issues(
             else:
                 result = automation_engine.process_single(repo_name, target_type, number)
 
-            spinner.message = f"Processed single {target_type} #{number}"
+            spinner.step(f"Processed single {target_type} #{number}")
 
         # Prepare summary for completion message
         completion_summary: Dict[str, Any] = {"Repository": repo_name, "Target": f"{target_type} #{number}", "Status": "Success" if not result.get("errors") else "Completed with errors"}
@@ -535,7 +535,7 @@ def create_feature_issues(
     created_issues = []
     with Spinner("Analyzing repository for features...", show_timer=True) as spinner:
         created_issues = automation_engine.create_feature_issues(repo_name)
-        spinner.message = f"Created {len(created_issues)} feature issue(s)"
+        spinner.step(f"Created {len(created_issues)} feature issue(s)")
 
     # Prepare summary
     completion_summary: Dict[str, Any] = {"Repository": repo_name, "Issues Created": len(created_issues)}

--- a/src/auto_coder/cli_ui.py
+++ b/src/auto_coder/cli_ui.py
@@ -254,10 +254,15 @@ class Spinner:
             return f"{m}m {s:02d}s"
         return f"{s}s"
 
+    def step(self, message: str) -> None:
+        """Update the spinner message safely."""
+        self.message = message
+
     def spin(self) -> None:
         spinner_frames = SPINNER_FRAMES_ASCII if self.no_color else SPINNER_FRAMES_UNICODE
         idx = 0
         start_time = self.start_time or time.time()
+        last_msg_len = 0
 
         while not self.stop_event.is_set():
             frame = spinner_frames[idx % len(spinner_frames)]
@@ -273,7 +278,13 @@ class Spinner:
             else:
                 msg = click.style(f"{frame} {current_msg}", fg="cyan")
 
-            sys.stdout.write(f"\r{msg}")
+            # Calculate visible length for padding
+            visible_msg = click.unstyle(msg)
+            current_len = len(visible_msg)
+            padding = " " * max(0, last_msg_len - current_len)
+            last_msg_len = current_len
+
+            sys.stdout.write(f"\r{msg}{padding}")
             sys.stdout.flush()
 
             # Wait for delay or stop event

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -281,3 +281,30 @@ def test_spinner_final_message_with_timer(mock_time, mock_stdout):
 
     final_msg = final_messages[-1]
     assert "(2s)" in final_msg, f"Final message did not include duration: {final_msg}"
+
+
+@patch("sys.stdout")
+def test_spinner_step(mock_stdout):
+    """Test that Spinner step updates message and handles cleanup."""
+    mock_stdout.isatty.return_value = True
+
+    # Use a very small delay so the spinner thread loops frequently
+    spinner = cli_ui.Spinner("Initial", delay=0.001)
+
+    with spinner:
+        time.sleep(0.01)  # Let it spin a bit with "Initial"
+        spinner.step("Updated Long Message")
+        time.sleep(0.01)  # Let it spin with longer message
+        spinner.step("Short")
+        time.sleep(0.01)  # Let it spin with shorter message
+
+    writes = [args[0] for args, _ in mock_stdout.write.call_args_list]
+
+    # Verify initial message was printed
+    assert any("Initial" in w for w in writes)
+
+    # Verify updated long message was printed
+    assert any("Updated Long Message" in w for w in writes)
+
+    # Verify short message was printed
+    assert any("Short" in w for w in writes)


### PR DESCRIPTION
🎨 Palette: Improved CLI Spinner UX

💡 **What:** Added a `step()` method to the `Spinner` class and updated the spinning logic to properly clear the line when messages update.
🎯 **Why:** Previously, updating the spinner message to a shorter string would leave "debris" (characters from the previous longer message) on the screen.
📸 **Before/After:**
  - Before: `Processing item #123... Analysis` -> `Processing item #123... Doneysis` (if "Done" is shorter than "Analysis")
  - After: `Processing item #123... Analysis` -> `Processing item #123... Done` (clean update)
♿ **Accessibility:** Reduces visual noise and confusion in the CLI output.

---
*PR created automatically by Jules for task [18272773211188207503](https://jules.google.com/task/18272773211188207503) started by @kitamura-tetsuo*