### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file permissions for reports and test logs

### DIFF
--- a/src/auto_coder/local_test_log_collector.py
+++ b/src/auto_coder/local_test_log_collector.py
@@ -123,6 +123,8 @@ def collect_and_run():
                 try:
                     shutil.move(str(log_file), str(raw_log_dir))
                     raw_log_file_path = str(raw_log_dir / log_file.name)
+                    # Secure the moved file
+                    os.chmod(raw_log_file_path, 0o600)
                     print(f"Moved raw log file: {log_file} to {raw_log_file_path}")
                     # For now, just handle the first found log file
                     break


### PR DESCRIPTION
This PR enhances security by ensuring that generated reports and raw test logs are created with restricted file permissions (0o600), preventing unauthorized access by other users on the system.

Changes:
- `src/auto_coder/automation_engine.py`: Replaced `open()` with `os.open(..., 0o600)` and `os.fdopen()` in `_save_report`. Added `os.chmod()` for robustness.
- `src/auto_coder/local_test_log_collector.py`: Added `os.chmod(..., 0o600)` after moving raw log files.
- `tests/test_automation_engine.py`: Updated `test_save_report_success` and `test_save_report_with_repo_name` to mock `os.open`, `os.chmod`, and `os.fdopen`.

Verification:
- Verified file permissions using a reproduction script.
- Verified test log permissions using a custom verification script.
- Passed relevant unit tests.

---
*PR created automatically by Jules for task [10574439379966564793](https://jules.google.com/task/10574439379966564793) started by @kitamura-tetsuo*