### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure permissions in CloudManager

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -78,3 +78,8 @@
 **Vulnerability:** Switching from `open(mode='a')` to `os.open(O_APPEND)` + `os.fdopen(mode='w')` (to enforce permissions) caused `f.tell()` to return 0, leading to duplicate CSV headers being written.
 **Learning:** `os.fdopen` with mode `w` initializes the file object's position to 0, even if the underlying file descriptor was opened with `O_APPEND`.
 **Prevention:** Use `os.fstat(fd).st_size` to check if the file is empty instead of `f.tell()` when using this secure file creation pattern.
+
+## 2026-01-31 - Insecure Session Storage in CloudManager
+**Vulnerability:** `CloudManager` stored session IDs in `cloud.csv` using standard `open()`, resulting in default file permissions (e.g., world-readable) which could allow session hijacking in multi-user environments.
+**Learning:** User state files (like session tokens) are just as sensitive as configuration files with API keys and require the same strict permission controls.
+**Prevention:** Apply the `os.open(..., 0o600)` and `os.chmod` pattern to all files storing user session data or state, ensuring they are private to the owner.

--- a/src/auto_coder/cloud_manager.py
+++ b/src/auto_coder/cloud_manager.py
@@ -6,6 +6,7 @@ by storing issue number and session ID mappings in CSV files.
 """
 
 import csv
+import os
 import threading
 from pathlib import Path
 from typing import Dict, Optional
@@ -92,7 +93,13 @@ class CloudManager:
         self._ensure_cloud_dir()
 
         try:
-            with open(self.cloud_file_path, "w", newline="", encoding="utf-8") as f:
+            # Secure file opening with restricted permissions (600)
+            fd = os.open(str(self.cloud_file_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+
+            # Ensure permissions are correct even if file already existed
+            os.chmod(self.cloud_file_path, 0o600)
+
+            with os.fdopen(fd, "w", newline="", encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=CSV_FIELDS)
                 writer.writeheader()
 

--- a/tests/test_cloud_manager_security.py
+++ b/tests/test_cloud_manager_security.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.auto_coder.cloud_manager import CloudManager
+
+
+def test_cloud_manager_file_permissions():
+    """Test that CloudManager creates the cloud file with secure permissions (600)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cloud_file = Path(tmpdir) / "cloud.csv"
+        manager = CloudManager("owner/repo", cloud_file_path=cloud_file)
+
+        # Add a session, which should trigger file creation/writing
+        manager.add_session(123, "secure-session-id")
+
+        assert cloud_file.exists()
+
+        # Check permissions
+        st_mode = os.stat(cloud_file).st_mode
+        # Mask with 0o777 to get permission bits
+        permissions = st_mode & 0o777
+
+        # Should be 0o600 (rw-------)
+        assert permissions == 0o600, f"Expected 0o600 but got {oct(permissions)}"
+
+
+def test_cloud_manager_existing_file_permissions():
+    """Test that CloudManager secures an existing insecure file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cloud_file = Path(tmpdir) / "cloud.csv"
+
+        # Create file with insecure permissions (e.g. 644)
+        # We use os.open to be explicit, though standard open() usually does 644 or 664 depending on umask
+        fd = os.open(str(cloud_file), os.O_WRONLY | os.O_CREAT, 0o644)
+        os.close(fd)
+        os.chmod(cloud_file, 0o644)
+
+        assert (os.stat(cloud_file).st_mode & 0o777) == 0o644
+
+        manager = CloudManager("owner/repo", cloud_file_path=cloud_file)
+
+        # Add a session, should fix permissions
+        manager.add_session(123, "secure-session-id")
+
+        permissions = os.stat(cloud_file).st_mode & 0o777
+        assert permissions == 0o600, f"Expected 0o600 but got {oct(permissions)}"


### PR DESCRIPTION
**Vulnerability:**
`CloudManager` was creating `cloud.csv` (which stores session IDs) using standard `open()`, resulting in default file permissions (typically `0o664` or `0o644`). This could allow other users on a shared system to read session IDs and potentially hijack sessions.

**Fix:**
Replaced `open()` with `os.open(..., 0o600)` and added `os.chmod(..., 0o600)` to ensure that the file is only readable and writable by the owner. This applies to both new files and existing files (remediating pre-existing insecure permissions).

**Verification:**
Added `tests/test_cloud_manager_security.py` which asserts that the file mode is `0o600` after `add_session` is called. Verified that existing tests in `tests/test_cloud_manager.py` still pass.

---
*PR created automatically by Jules for task [10517473722883480083](https://jules.google.com/task/10517473722883480083) started by @kitamura-tetsuo*