### PR TITLE
🛡️ Sentinel: Fix insecure file permissions in BackendStateManager

### DIFF
--- a/src/auto_coder/backend_state_manager.py
+++ b/src/auto_coder/backend_state_manager.py
@@ -90,12 +90,33 @@ class BackendStateManager:
 
                 # Write state to temporary file first for atomic operation
                 temp_file_path = state_file_path.with_suffix(".tmp")
-                with open(temp_file_path, "w") as f:
+
+                # Use os.open to ensure file is created with 600 permissions
+                try:
+                    fd = os.open(str(temp_file_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                except OSError:
+                    # Fallback to standard open if os.open fails
+                    with open(temp_file_path, "w", encoding="utf-8") as f:
+                        try:
+                            os.chmod(temp_file_path, 0o600)
+                        except OSError:
+                            pass  # Ignore permission errors on systems that don't support it
+                        json.dump(state_data, f, indent=2)
+                else:
+                    # File opened successfully with os.open
                     try:
-                        os.chmod(temp_file_path, 0o600)
-                    except OSError:
-                        pass  # Ignore permission errors on systems that don't support it
-                    json.dump(state_data, f, indent=2)
+                        f = os.fdopen(fd, "w", encoding="utf-8")
+                    except Exception:
+                        os.close(fd)
+                        raise
+
+                    with f:
+                        # Ensure permissions are correct even if file already existed
+                        try:
+                            os.chmod(temp_file_path, 0o600)
+                        except OSError:
+                            pass  # Ignore permission errors on systems that don't support it
+                        json.dump(state_data, f, indent=2)
 
                 # Atomically replace the old file with the new one
                 temp_file_path.replace(state_file_path)

--- a/tests/test_backend_state_security.py
+++ b/tests/test_backend_state_security.py
@@ -1,0 +1,59 @@
+import json
+import os
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from auto_coder.backend_state_manager import BackendStateManager
+
+
+class TestBackendStateSecurity:
+    @patch("auto_coder.backend_state_manager.os.open")
+    @patch("auto_coder.backend_state_manager.os.fdopen")
+    @patch("auto_coder.backend_state_manager.os.chmod")
+    @patch("auto_coder.backend_state_manager.Path")
+    def test_save_state_uses_secure_permissions(self, mock_path, mock_chmod, mock_fdopen, mock_os_open):
+        # Setup mocks
+        mock_file_handle = MagicMock()
+        mock_fdopen.return_value.__enter__.return_value = mock_file_handle
+
+        # Mock Path behavior
+        mock_path_obj = MagicMock()
+        mock_path.return_value = mock_path_obj
+        mock_path_obj.expanduser.return_value = mock_path_obj
+        mock_path_obj.resolve.return_value = mock_path_obj
+        # Setup temp path
+        mock_temp_path = MagicMock()
+        mock_path_obj.with_suffix.return_value = mock_temp_path
+        str(mock_temp_path)  # Should return a string representation
+
+        # Mock os.open return value (file descriptor)
+        mock_os_open.return_value = 123
+
+        # Initialize manager
+        manager = BackendStateManager()
+
+        # Call save_state
+        manager.save_state("test_backend", 12345.67)
+
+        # Verification
+
+        # 1. Verify os.open was called with secure permissions (0o600)
+        # secure_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        # mock_os_open.assert_called_with(str(mock_temp_path), secure_flags, 0o600)
+
+        # Since we are testing BEFORE the fix, we expect this test to FAIL if we assert os.open is called.
+        # But to prove it works later, I will comment out the assertion or expect failure?
+        # Actually, for the "reproduction" step, running it and seeing failure is good.
+
+        # Let's assert what we WANT to happen.
+        mock_os_open.assert_called()
+        args, _ = mock_os_open.call_args
+        # Check permissions arg (3rd argument)
+        assert args[2] == 0o600, f"Expected permissions 0o600, got {oct(args[2]) if len(args) > 2 else 'None'}"
+
+        # 2. Verify os.fdopen was called with the file descriptor
+        mock_fdopen.assert_called_with(123, "w", encoding="utf-8")
+
+        # 3. Verify chmod is still called (defense in depth)
+        mock_chmod.assert_called()


### PR DESCRIPTION
Fixed a potential race condition (TOCTOU) vulnerability in `BackendStateManager.save_state` where the state file was created with default permissions (potentially world-readable) before `os.chmod` was called.

The fix implements the secure file creation pattern:
1. Use `os.open` with `O_CREAT | O_WRONLY | O_TRUNC` and mode `0o600`.
2. Wrap the file descriptor with `os.fdopen`.
3. Fallback to standard `open` + `chmod` if `os.open` fails (for compatibility), but correctly handling the race condition risk where possible.
4. Retain `os.chmod` for defense-in-depth on existing files.

Verification:
- Added `tests/test_backend_state_security.py` which reproduces the issue (fails on old code) and verifies the fix (passes on new code).
- Verified `tests/test_backend_state_manager.py` passes to ensure no functional regression.

---
*PR created automatically by Jules for task [11119118572892373895](https://jules.google.com/task/11119118572892373895) started by @kitamura-tetsuo*