### PR TITLE
Fix: retry Jules task when PR is closed due to merge conflicts

### DIFF
--- a/src/auto_coder/conflict_resolver.py
+++ b/src/auto_coder/conflict_resolver.py
@@ -575,6 +575,11 @@ def _perform_base_branch_merge_and_conflict_resolution(
                     if repo_name:
                         _close_pr(repo_name, pr_number)
                         _archive_jules_session(repo_name, pr_number, pr_body)
+                        _trigger_fallback_for_conflict_failure(
+                            repo_name,
+                            pr_number,
+                            "Closing PR due to merge conflicts and potential degradation risk.",
+                        )
                     return False
 
                 # Trigger fallback and signal to proceed to fixing

--- a/tests/test_conflict_resolver.py
+++ b/tests/test_conflict_resolver.py
@@ -61,6 +61,7 @@ def test_perform_base_merge_closes_jules_pr_on_degrade_with_linked_issues():
         patch("src.auto_coder.conflict_resolver.create_high_score_backend_manager") as mock_create_backend,
         patch("src.auto_coder.conflict_resolver._archive_jules_session") as mock_archive,
         patch("src.auto_coder.conflict_resolver.check_mergeability_with_llm") as mock_check_mergeability,
+        patch("src.auto_coder.conflict_resolver._trigger_fallback_for_conflict_failure") as mock_trigger_fallback,
     ):
         mock_check_mergeability.return_value = False
         # Setup mocks
@@ -101,6 +102,9 @@ def test_perform_base_merge_closes_jules_pr_on_degrade_with_linked_issues():
         assert ok is False
         mock_client.close_pr.assert_called_once()
         mock_archive.assert_called_once()
+        mock_trigger_fallback.assert_called_once_with(
+            "test/repo", 1253, "Closing PR due to merge conflicts and potential degradation risk."
+        )
 
 
 def test_perform_base_merge_enriches_pr_data_when_missing_fields():


### PR DESCRIPTION
## Description
When a Jules PR is closed due to merge conflicts and potential degradation risk, the system now automatically reuses the existing fallback mechanism (`_trigger_fallback_for_conflict_failure`). This ensures that the original issue is reopened and the attempt count is incremented, allowing the Automation Engine to naturally pick up the issue and restart the Jules task in the next cycle.

## Changes
- Updated `src/auto_coder/conflict_resolver.py` to call `_trigger_fallback_for_conflict_failure` when archiving a Jules session after a conflict closure.
- Added test coverage in `tests/test_conflict_resolver.py` to ensure the fallback mechanism is correctly triggered.