### PR TITLE
fix: check stale Jules PRs before the @auto-coder label gates

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -381,6 +381,11 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
       - "Default timeout: 12 hours. Configurable via [jules].pr_ci_timeout_hours in config.toml."
       - "PRs whose CI is still running, or whose CI passed, are never closed by this rule."
       - "The check runs before every '@auto-coder label present' skip (candidate collection, single-target processing, and process_pull_request); a stale PR normally still carries the label from an earlier run and would otherwise never be revisited."
+      - "Closing also releases the issue: the @auto-coder label that the dead Jules session kept on the linked issue is removed, and the issue is processed again in the same run (queued as a candidate in the daemon, processed inline for single-target runs)."
+      - "PRs that are already closed are ignored, so the attempt counter is never incremented twice for the same PR."
+    label_locking:
+      - "Jules mode keeps the @auto-coder label on an issue for the lifetime of its session, so an aborted session would otherwise lock the issue permanently."
+      - "With check_labels=False (--only and WIP-branch resume) an existing @auto-coder label no longer blocks processing; the label is left in place because the run does not own it."
 
 #### Breaking Changes Documentation
 

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -380,6 +380,7 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
       - "The issue is resolved from the PR body links first, then from the Jules session ID, branch name, or PR title."
       - "Default timeout: 12 hours. Configurable via [jules].pr_ci_timeout_hours in config.toml."
       - "PRs whose CI is still running, or whose CI passed, are never closed by this rule."
+      - "The check runs before every '@auto-coder label present' skip (candidate collection, single-target processing, and process_pull_request); a stale PR normally still carries the label from an earlier run and would otherwise never be revisited."
 
 #### Breaking Changes Documentation
 

--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -682,6 +682,21 @@ class CandidateProcessingResult:
 
 
 @dataclass
+class StaleJulesPRResult:
+    """Result of the stale Jules PR check.
+
+    Attributes:
+        closed: True when the PR was closed because Jules could not get CI green in time
+        actions: Human-readable actions taken
+        issue_numbers: Issues that were unlocked and need to be re-processed
+    """
+
+    closed: bool = False
+    actions: List[str] = field(default_factory=list)
+    issue_numbers: List[int] = field(default_factory=list)
+
+
+@dataclass
 class ProcessedPRResult:
     """Result of processing a pull request.
 

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -389,6 +389,8 @@ class AutomationEngine:
 
         candidates: List[Candidate] = []
         candidates_count = 0
+        # Issues queued from the stale-Jules-PR path, to avoid queueing them twice
+        requeued_issue_numbers: set[int] = set()
 
         try:
 
@@ -462,10 +464,20 @@ class AutomationEngine:
                 # This runs before the label and "waiting for Jules" skips below, because a
                 # stale Jules PR normally still carries the @auto-coder label from an earlier
                 # run and would otherwise never be looked at again.
-                stale_jules_actions = _close_stale_jules_pr(self.github, repo_name, pr_data, self.config)
-                if stale_jules_actions:
-                    for action in stale_jules_actions:
+                stale_jules_result = _close_stale_jules_pr(self.github, repo_name, pr_data, self.config)
+                if stale_jules_result.closed:
+                    for action in stale_jules_result.actions:
                         logger.info(f"PR #{pr_number}: {action}")
+                    # Queue the unlocked issue(s) right away so the new attempt starts in
+                    # this cycle instead of waiting for the next poll.
+                    for issue_number in stale_jules_result.issue_numbers:
+                        issue_candidate = self._create_candidate_from_single(repo_name, "issue", issue_number)
+                        if issue_candidate:
+                            issue_candidate.priority = 3
+                            candidates.append(issue_candidate)
+                            requeued_issue_numbers.add(issue_number)
+                            candidates_count += 1
+                            logger.info(f"Queued issue #{issue_number} for a new attempt after closing stale Jules PR #{pr_number}")
                     continue
 
                 # Skip if another instance is processing (@auto-coder label present) using LabelManager check
@@ -654,6 +666,10 @@ class AutomationEngine:
                 # Build map for fast lookup of open issues
                 issue_map = {i["number"]: i for i in all_issues}
 
+                # Numbers of the PRs that are currently open, used to tell a live PR apart
+                # from a closed one still listed in an issue timeline
+                open_pr_numbers = {pr.get("number") for pr in pr_data_list if isinstance(pr.get("number"), int)}
+
                 for issue_data in all_issues:
                     labels = issue_data.get("labels", []) or []
 
@@ -680,6 +696,10 @@ class AutomationEngine:
                     number = issue_data.get("number")
                     if not isinstance(number, int):
                         logger.warning(f"Issue data missing or invalid number: {issue_data}")
+                        continue
+
+                    # Already queued by the stale-Jules-PR path above
+                    if number in requeued_issue_numbers:
                         continue
 
                     # Skip if another instance is processing (@auto-coder label present) using LabelManager check
@@ -725,8 +745,14 @@ class AutomationEngine:
                             logger.debug(f"Skipping issue #{number} - elder sibling(s) still open: {elder_siblings}")
                             continue
 
-                    # Use pre-fetched data
-                    if issue_data.get("has_linked_prs"):
+                    # Skip only while an *open* PR covers the issue; the work happens on that
+                    # PR. Closed or merged PRs stay in the issue timeline forever, so counting
+                    # them here would permanently hide any issue that once had a PR - including
+                    # issues whose stale Jules PR was just closed for a new attempt.
+                    linked_pr_numbers = set(issue_data.get("linked_pr_numbers") or [])
+                    open_linked_prs = linked_pr_numbers & open_pr_numbers
+                    if open_linked_prs:
+                        logger.debug(f"Skipping issue #{number} - open PR(s) {sorted(open_linked_prs)} already cover it")
                         continue
 
                     # Calculate priority
@@ -844,11 +870,14 @@ class AutomationEngine:
             if item_type == "pr":
                 from .pr_processor import _close_stale_jules_pr
 
-                stale_jules_actions = _close_stale_jules_pr(self.github, repo_name, candidate.data, config)
-                if stale_jules_actions:
-                    for action in stale_jules_actions:
+                stale_jules_result = _close_stale_jules_pr(self.github, repo_name, candidate.data, config)
+                if stale_jules_result.closed:
+                    for action in stale_jules_result.actions:
                         logger.info(f"PR #{item_number}: {action}")
-                    result.actions = stale_jules_actions
+                    result.actions = list(stale_jules_result.actions)
+                    # Start the new attempt on the unlocked issue(s) right away
+                    for issue_number in stale_jules_result.issue_numbers:
+                        result.actions.extend(self._process_unlocked_issue(repo_name, issue_number, config, jules_mode))
                     result.success = True
                     return result
 
@@ -921,6 +950,36 @@ class AutomationEngine:
             logger.error(f"Error processing {candidate.type} #{candidate.data.get('number', 'N/A')}: {e}")
 
         return result
+
+    def _process_unlocked_issue(
+        self,
+        repo_name: str,
+        issue_number: int,
+        config: AutomationConfig,
+        jules_mode: bool,
+    ) -> List[str]:
+        """Process an issue whose Jules attempt was just abandoned.
+
+        Args:
+            repo_name: Repository name
+            issue_number: Issue to start the next attempt on
+            config: AutomationConfig instance
+            jules_mode: Whether to use Jules mode for processing
+
+        Returns:
+            Actions taken while processing the issue
+        """
+        issue_candidate = self._create_candidate_from_single(repo_name, "issue", issue_number)
+        if not issue_candidate:
+            logger.warning(f"Could not build a candidate for issue #{issue_number}, skipping the new attempt")
+            return [f"Failed to start a new attempt for issue #{issue_number}"]
+
+        logger.info(f"Starting a new attempt for issue #{issue_number}")
+        issue_result = self._process_single_candidate_unified(repo_name, issue_candidate, config, jules_mode=jules_mode)
+        actions = [f"Started a new attempt for issue #{issue_number}"] + list(issue_result.actions)
+        if issue_result.error:
+            actions.append(f"Error processing issue #{issue_number}: {issue_result.error}")
+        return actions
 
     def _process_single_candidate(self, repo_name: str, candidate: Candidate) -> CandidateProcessingResult:
         """Process a single candidate (issue/PR).
@@ -1821,22 +1880,27 @@ class AutomationEngine:
         try:
             # Handle 'auto' type
             if target_type == "auto":
-                # Prefer PR to avoid mislabeling PR issues
+                # Prefer PR to avoid mislabeling PR issues.
+                # get_pull_request() returns an empty result instead of raising when the
+                # number belongs to an issue, so the number has to be verified.
+                target_type = "issue"
                 try:
-                    # repo = self.github.get_repository(repo_name)
-                    # pr = repo.get_pull(number)
                     pr = self.github.get_pull_request(repo_name, number)
-                    pr_data = self.github.get_pr_details(pr)
-                    target_type = "pr"
+                    pr_data = self.github.get_pr_details(pr) if pr else None
+                    if pr_data and pr_data.get("number"):
+                        target_type = "pr"
                 except Exception:
-                    target_type = "issue"
+                    pass
 
             if target_type == "pr":
                 # Get PR data
                 # repo = self.github.get_repository(repo_name)
                 # pr = repo.get_pull(number)
                 pr = self.github.get_pull_request(repo_name, number)
-                pr_data = self.github.get_pr_details(pr)
+                pr_data = self.github.get_pr_details(pr) if pr else None
+                if not pr_data or not pr_data.get("number"):
+                    logger.error(f"PR #{number} not found in {repo_name}")
+                    return None
                 branch_name = pr_data.get("head_branch")
                 pr_body = pr_data.get("body", "")
                 related_issues = []

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -380,7 +380,7 @@ class AutomationEngine:
         - Creation time ascending (oldest first)
         """
         from .issue_context import extract_linked_issues_from_pr_body
-        from .pr_processor import _is_dependabot_pr, _is_jules_pr
+        from .pr_processor import _close_stale_jules_pr, _is_dependabot_pr, _is_jules_pr
         from .util.github_action import (
             _check_github_actions_status,
             check_github_actions_and_exit_if_in_progress,
@@ -457,6 +457,16 @@ class AutomationEngine:
                             logger.warning(f"Could not mark Jules PR #{pr_number} as ready: missing node_id after fetch attempt")
                     except Exception as e:
                         logger.error(f"Failed to mark Jules PR #{pr_number} as ready: {e}")
+
+                # Close Jules PRs that could not get CI green within the configured timeout.
+                # This runs before the label and "waiting for Jules" skips below, because a
+                # stale Jules PR normally still carries the @auto-coder label from an earlier
+                # run and would otherwise never be looked at again.
+                stale_jules_actions = _close_stale_jules_pr(self.github, repo_name, pr_data, self.config)
+                if stale_jules_actions:
+                    for action in stale_jules_actions:
+                        logger.info(f"PR #{pr_number}: {action}")
+                    continue
 
                 # Skip if another instance is processing (@auto-coder label present) using LabelManager check
                 with LabelManager(
@@ -827,6 +837,20 @@ class AutomationEngine:
             # Ensure item_number is not None
             if item_number is None:
                 raise ValueError(f"Item number is missing for {item_type} #{candidate.data.get('number', 'N/A')}")
+
+            # Close Jules PRs that could not get CI green within the configured timeout.
+            # Checked before the label gate below, which would otherwise skip the PR for as
+            # long as the @auto-coder label from an earlier run stays attached.
+            if item_type == "pr":
+                from .pr_processor import _close_stale_jules_pr
+
+                stale_jules_actions = _close_stale_jules_pr(self.github, repo_name, candidate.data, config)
+                if stale_jules_actions:
+                    for action in stale_jules_actions:
+                        logger.info(f"PR #{item_number}: {action}")
+                    result.actions = stale_jules_actions
+                    result.success = True
+                    return result
 
             # Use LabelManager context manager to handle @auto-coder label automatically
             with LabelManager(

--- a/src/auto_coder/cli_commands_main.py
+++ b/src/auto_coder/cli_commands_main.py
@@ -310,14 +310,10 @@ def process_issues(
         result = {}
         with Spinner(f"Processing {target_type if target_type else 'item'} #{number}...", show_timer=True) as spinner:
             if target_type is None:
-                # Auto-detect: try PR first, then issue
-                try:
-                    result = automation_engine.process_single(repo_name, "pr", number)
-                    target_type = "pr"
-                except Exception:
-                    # Fall back to issue
-                    result = automation_engine.process_single(repo_name, "issue", number)
-                    target_type = "issue"
+                # Auto-detect the type; process_single reports failures in its result
+                # instead of raising, so the detection happens while building the candidate.
+                result = automation_engine.process_single(repo_name, "auto", number)
+                target_type = "pr" if result.get("prs_processed") else "issue"
             else:
                 result = automation_engine.process_single(repo_name, target_type, number)
 

--- a/src/auto_coder/label_manager.py
+++ b/src/auto_coder/label_manager.py
@@ -490,6 +490,12 @@ class LabelManager:
                         self._label_added = True
                         self._context = LabelManagerContext(self, True)
                         return self._context
+                    elif not self.check_labels:
+                        # Explicitly requested work (--only / WIP resume): the label must not
+                        # gate processing. It is left untouched because this run does not own it.
+                        logger.info(f"Processing {self.item_type} #{self.item_number} despite the existing '{self.label_name}' label (check_labels=False)")
+                        self._context = LabelManagerContext(self, True)
+                        return self._context
                     else:
                         logger.info(f"Skipping {self.item_type} #{self.item_number} - '{self.label_name}' label was just added by another instance")
                         self._context = LabelManagerContext(self, False)

--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -174,6 +174,16 @@ def process_pull_request(
 
         pr_number = pr_data["number"]
 
+        # Close Jules PRs that could not get CI green within the configured timeout.
+        # This runs before the @auto-coder label check on purpose: a stale Jules PR
+        # usually still carries the label from an earlier run, and skipping on the
+        # label would leave the PR open forever.
+        stale_jules_actions = _close_stale_jules_pr(github_client, repo_name, pr_data, config)
+        if stale_jules_actions:
+            processed_pr.actions_taken = stale_jules_actions
+            processed_pr.priority = "close"
+            return processed_pr
+
         # Skip immediately if PR already has @auto-coder label
         with LabelManager(
             github_client,
@@ -189,13 +199,6 @@ def process_pull_request(
                 get_trace_logger().log("PR Processing", f"Skipping PR #{pr_number} - already processed", item_type="pr", item_number=pr_number, details={"skip_reason": "already_processed"})
                 processed_pr.actions_taken = ["Skipped - already being processed (@auto-coder label present)"]
                 return processed_pr
-
-        # Close Jules PRs that could not get CI green within the configured timeout
-        stale_jules_actions = _close_stale_jules_pr(github_client, repo_name, pr_data, config)
-        if stale_jules_actions:
-            processed_pr.actions_taken = stale_jules_actions
-            processed_pr.priority = "close"
-            return processed_pr
 
         # Check if we should skip this PR because it's waiting for Jules
         if _should_skip_waiting_for_jules(github_client, repo_name, pr_data, config):

--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -23,7 +23,7 @@ from auto_coder.util.gh_cache import GitHubClient, get_ghapi_client
 from auto_coder.util.github_action import DetailedChecksResult, _check_github_actions_status, _get_github_actions_logs, check_github_actions_and_exit_if_in_progress, get_detailed_checks_from_history
 
 from .attempt_manager import get_current_attempt, increment_attempt
-from .automation_config import AutomationConfig, ProcessedPRResult
+from .automation_config import AutomationConfig, ProcessedPRResult, StaleJulesPRResult
 from .branch_manager import BranchManager
 from .conflict_resolver import _get_merge_conflict_info, resolve_merge_conflicts_with_llm, resolve_pr_merge_conflicts
 from .fix_to_pass_tests_runner import run_local_tests
@@ -178,9 +178,9 @@ def process_pull_request(
         # This runs before the @auto-coder label check on purpose: a stale Jules PR
         # usually still carries the label from an earlier run, and skipping on the
         # label would leave the PR open forever.
-        stale_jules_actions = _close_stale_jules_pr(github_client, repo_name, pr_data, config)
-        if stale_jules_actions:
-            processed_pr.actions_taken = stale_jules_actions
+        stale_jules_result = _close_stale_jules_pr(github_client, repo_name, pr_data, config)
+        if stale_jules_result.closed:
+            processed_pr.actions_taken = stale_jules_result.actions
             processed_pr.priority = "close"
             return processed_pr
 
@@ -446,13 +446,14 @@ def _close_stale_jules_pr(
     pr_data: Dict[str, Any],
     config: AutomationConfig,
     github_checks: Optional[Any] = None,
-) -> List[str]:
+) -> StaleJulesPRResult:
     """Close a Jules PR that failed to get CI green within the configured timeout.
 
     Jules is the only actor allowed to push to its own PR branch, so a Jules PR that
     still has failing CI after ``config.JULES_PR_CI_TIMEOUT_HOURS`` is considered
-    unfixable. The PR is closed and the attempt count of the linked issue(s) is
-    incremented so the issue is picked up again from scratch.
+    unfixable. The PR is closed, the attempt count of the linked issue(s) is
+    incremented, and the ``@auto-coder`` label that the dead Jules run left on those
+    issues is removed so they can be picked up again from scratch.
 
     Args:
         github_client: GitHub client instance
@@ -462,25 +463,29 @@ def _close_stale_jules_pr(
         github_checks: Optional already-fetched GitHub Actions status result
 
     Returns:
-        List of actions taken. Empty when the PR was not closed.
+        StaleJulesPRResult; ``closed`` is False when the PR was left open.
     """
-    actions: List[str] = []
+    result = StaleJulesPRResult()
     pr_number = int(pr_data["number"])
 
     try:
         if not _is_jules_pr(pr_data):
-            return actions
+            return result
+
+        if pr_data.get("state") == "closed":
+            logger.debug(f"PR #{pr_number} is already closed, skipping Jules staleness check")
+            return result
 
         created_at = pr_data.get("created_at")
         if not created_at:
             logger.debug(f"PR #{pr_number} has no created_at timestamp, skipping Jules staleness check")
-            return actions
+            return result
 
         try:
             created_dt = datetime.fromisoformat(str(created_at).replace("Z", "+00:00"))
         except ValueError as e:
             logger.warning(f"Failed to parse created_at '{created_at}' for PR #{pr_number}: {e}")
-            return actions
+            return result
 
         if created_dt.tzinfo is None:
             created_dt = created_dt.replace(tzinfo=timezone.utc)
@@ -488,7 +493,7 @@ def _close_stale_jules_pr(
         age = datetime.now(timezone.utc) - created_dt
         timeout = timedelta(hours=config.JULES_PR_CI_TIMEOUT_HOURS)
         if age <= timeout:
-            return actions
+            return result
 
         # Only close when CI is actually not passing. Completed runs are required:
         # a run still in progress may yet turn green.
@@ -497,11 +502,11 @@ def _close_stale_jules_pr(
 
         if github_checks.success:
             logger.info(f"Jules PR #{pr_number} is older than {config.JULES_PR_CI_TIMEOUT_HOURS}h but CI passed, keeping it open")
-            return actions
+            return result
 
         if getattr(github_checks, "in_progress", False):
             logger.info(f"Jules PR #{pr_number} is older than {config.JULES_PR_CI_TIMEOUT_HOURS}h but CI is still running, keeping it open")
-            return actions
+            return result
 
         logger.info(f"Jules PR #{pr_number} did not pass CI within {config.JULES_PR_CI_TIMEOUT_HOURS} hours. Closing it.")
 
@@ -515,7 +520,8 @@ def _close_stale_jules_pr(
         close_comment = f"Auto-Coder: Closing this PR because Jules did not get CI to pass within {config.JULES_PR_CI_TIMEOUT_HOURS} hours after the PR was created. The linked issue(s) will be retried with an incremented attempt count."
         client = github_client or GitHubClient.get_instance()
         client.close_pr(repo_name, pr_number, close_comment)
-        actions.append(f"Closed stale Jules PR #{pr_number} (no passing CI within {config.JULES_PR_CI_TIMEOUT_HOURS}h)")
+        result.closed = True
+        result.actions.append(f"Closed stale Jules PR #{pr_number} (no passing CI within {config.JULES_PR_CI_TIMEOUT_HOURS}h)")
         get_trace_logger().log(
             "Jules Timeout",
             f"Closed stale Jules PR #{pr_number}",
@@ -526,21 +532,59 @@ def _close_stale_jules_pr(
 
         if not issue_numbers:
             logger.warning(f"No linked issue found for closed Jules PR #{pr_number}, cannot increment attempt")
-            actions.append(f"No linked issue found for PR #{pr_number} to increment attempt")
-            return actions
+            result.actions.append(f"No linked issue found for PR #{pr_number} to increment attempt")
+            return result
 
         for issue_number in issue_numbers:
             try:
                 new_attempt = increment_attempt(repo_name, issue_number)
-                actions.append(f"Incremented attempt for issue #{issue_number} to {new_attempt}")
+                result.actions.append(f"Incremented attempt for issue #{issue_number} to {new_attempt}")
             except Exception as e:
                 logger.error(f"Failed to increment attempt for issue #{issue_number}: {e}")
-                actions.append(f"Failed to increment attempt for issue #{issue_number}: {e}")
+                result.actions.append(f"Failed to increment attempt for issue #{issue_number}: {e}")
+
+            # The dead Jules run kept the @auto-coder label on the issue to mark it as
+            # being worked on. Release it, otherwise the issue is never processed again.
+            if _release_issue_processing_label(github_client, repo_name, issue_number, config):
+                result.actions.append(f"Removed {config.AUTO_CODER_LABEL} label from issue #{issue_number}")
+
+            result.issue_numbers.append(issue_number)
 
     except Exception as e:
         logger.error(f"Error handling stale Jules PR #{pr_number}: {e}")
 
-    return actions
+    return result
+
+
+def _release_issue_processing_label(
+    github_client: Any,
+    repo_name: str,
+    issue_number: int,
+    config: AutomationConfig,
+) -> bool:
+    """Remove the @auto-coder label an aborted run left behind on an issue.
+
+    Args:
+        github_client: GitHub client instance
+        repo_name: Repository name (owner/repo)
+        issue_number: Issue to unlock
+        config: Automation configuration
+
+    Returns:
+        True if the label was removed, False otherwise
+    """
+    label = config.AUTO_CODER_LABEL
+    if not label or config.DISABLE_LABELS:
+        return False
+
+    try:
+        client = github_client or GitHubClient.get_instance()
+        client.remove_labels(repo_name, issue_number, [label], item_type="issue")
+        logger.info(f"Removed '{label}' label from issue #{issue_number} so it can be processed again")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to remove '{label}' label from issue #{issue_number}: {e}")
+        return False
 
 
 def _get_mergeable_state(
@@ -1320,9 +1364,9 @@ def _handle_pr_merge(
         # not passed CI within JULES_PR_CI_TIMEOUT_HOURS. Only an explicit local run that
         # already sits on the PR branch keeps fixing the checkout directly.
         if _is_jules_pr(pr_data) and not already_on_pr_branch:
-            stale_jules_actions = _close_stale_jules_pr(github_client, repo_name, pr_data, config, github_checks)
-            if stale_jules_actions:
-                actions.extend(stale_jules_actions)
+            stale_jules_result = _close_stale_jules_pr(github_client, repo_name, pr_data, config, github_checks)
+            if stale_jules_result.closed:
+                actions.extend(stale_jules_result.actions)
                 return actions
 
             actions.append(f"PR #{pr_number} is a Jules-created PR, sending error logs to Jules session")

--- a/tests/test_automation_engine.py
+++ b/tests/test_automation_engine.py
@@ -2245,7 +2245,7 @@ class TestGetCandidates:
 
     @patch("auto_coder.util.github_action._check_github_actions_status")
     @patch("auto_coder.issue_context.extract_linked_issues_from_pr_body")
-    def test_get_candidates_skips_issues_with_sub_issues_or_linked_prs(
+    def test_get_candidates_skips_issues_with_sub_issues_or_open_linked_prs(
         self,
         mock_extract_issues,
         mock_check_actions,
@@ -2253,7 +2253,10 @@ class TestGetCandidates:
         mock_gemini_client,
         test_repo_name,
     ):
-        """Test that issues with sub-issues or linked PRs are skipped."""
+        """Issues with sub-issues, or with a linked PR that is still open, are skipped.
+
+        A closed PR stays in the issue timeline forever, so it must not hide the issue.
+        """
         # Setup
         engine = AutomationEngine(mock_github_client)
 
@@ -2300,12 +2303,29 @@ class TestGetCandidates:
             },
         ]
 
-        # Execute
-        candidates = engine._get_candidates(test_repo_name, max_items=10)
+        # PR #999 (linked from issue #12) is still open
+        mock_github_client.get_open_prs_json.return_value = [
+            {
+                "number": 999,
+                "title": "PR 999",
+                "body": "",
+                "labels": [],
+                "state": "open",
+                "draft": False,
+                "created_at": "2024-01-03T00:00:00Z",
+                "head": {"ref": "feature", "sha": "sha999"},
+            }
+        ]
 
-        # Assert - Only issue #10 should be returned
-        assert len(candidates) == 1
-        assert candidates[0].data["number"] == 10
+        # Execute
+        with patch("auto_coder.util.github_action.check_github_actions_and_exit_if_in_progress", return_value=False):
+            candidates = engine._get_candidates(test_repo_name, max_items=10)
+
+        # Assert - of the issues only #10 is collected
+        issue_numbers = [c.data["number"] for c in candidates if c.type == "issue"]
+        assert issue_numbers == [10]
+        assert 11 not in issue_numbers  # has open sub-issues
+        assert 12 not in issue_numbers  # linked PR #999 is open
         assert candidates[0].type == "issue"
 
     @patch("auto_coder.util.github_action._check_github_actions_status")

--- a/tests/test_automation_engine_candidates.py
+++ b/tests/test_automation_engine_candidates.py
@@ -32,12 +32,14 @@ class TestAutomationEngineCandidates:
             patch("auto_coder.util.github_action.check_github_actions_and_exit_if_in_progress") as mock_check_actions,
             patch("auto_coder.util.github_action._check_github_actions_status") as mock_check_status,
             patch("auto_coder.pr_processor._should_skip_waiting_for_jules") as mock_skip_jules,
+            patch("auto_coder.pr_processor._close_stale_jules_pr") as mock_close_stale,
         ):
 
             mock_label_manager.return_value.__enter__.return_value = True
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
+            mock_close_stale.return_value = []
 
             # Execute
             candidates = engine._get_candidates(repo_name)
@@ -79,12 +81,14 @@ class TestAutomationEngineCandidates:
             patch("auto_coder.util.github_action.check_github_actions_and_exit_if_in_progress") as mock_check_actions,
             patch("auto_coder.util.github_action._check_github_actions_status") as mock_check_status,
             patch("auto_coder.pr_processor._should_skip_waiting_for_jules") as mock_skip_jules,
+            patch("auto_coder.pr_processor._close_stale_jules_pr") as mock_close_stale,
         ):
 
             mock_label_manager.return_value.__enter__.return_value = True
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
+            mock_close_stale.return_value = []
 
             # Execute
             candidates = engine._get_candidates(repo_name)
@@ -119,12 +123,14 @@ class TestAutomationEngineCandidates:
             patch("auto_coder.util.github_action.check_github_actions_and_exit_if_in_progress") as mock_check_actions,
             patch("auto_coder.util.github_action._check_github_actions_status") as mock_check_status,
             patch("auto_coder.pr_processor._should_skip_waiting_for_jules") as mock_skip_jules,
+            patch("auto_coder.pr_processor._close_stale_jules_pr") as mock_close_stale,
         ):
 
             mock_label_manager.return_value.__enter__.return_value = True
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
+            mock_close_stale.return_value = []
 
             # Execute
             candidates = engine._get_candidates(repo_name)

--- a/tests/test_automation_engine_candidates.py
+++ b/tests/test_automation_engine_candidates.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from auto_coder.automation_config import AutomationConfig
+from auto_coder.automation_config import AutomationConfig, StaleJulesPRResult
 from auto_coder.automation_engine import AutomationEngine
 
 
@@ -39,7 +39,7 @@ class TestAutomationEngineCandidates:
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
-            mock_close_stale.return_value = []
+            mock_close_stale.return_value = StaleJulesPRResult()
 
             # Execute
             candidates = engine._get_candidates(repo_name)
@@ -88,7 +88,7 @@ class TestAutomationEngineCandidates:
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
-            mock_close_stale.return_value = []
+            mock_close_stale.return_value = StaleJulesPRResult()
 
             # Execute
             candidates = engine._get_candidates(repo_name)
@@ -130,7 +130,7 @@ class TestAutomationEngineCandidates:
             mock_check_actions.return_value = True
             mock_check_status.return_value = Mock(success=True)
             mock_skip_jules.return_value = False
-            mock_close_stale.return_value = []
+            mock_close_stale.return_value = StaleJulesPRResult()
 
             # Execute
             candidates = engine._get_candidates(repo_name)

--- a/tests/test_label_manager.py
+++ b/tests/test_label_manager.py
@@ -497,6 +497,39 @@ class TestLabelManager:
         # Label should be removed
         mock_github_client.remove_labels.assert_called_once_with("owner/repo", 123, ["@auto-coder"], "issue")
 
+    def test_label_manager_check_labels_false_proceeds_when_label_cannot_be_acquired(self):
+        """A leftover label must not block explicitly requested work (--only / WIP resume).
+
+        try_add_labels returns False when the label is already present, which happens when a
+        previous run died while holding it. With check_labels=False the caller asked to ignore
+        labels, so processing continues and the foreign label is left untouched.
+        """
+        mock_github_client = Mock()
+        mock_github_client.disable_labels = False
+        mock_github_client.try_add_labels.return_value = False
+
+        config = AutomationConfig()
+
+        with LabelManager(mock_github_client, "owner/repo", 123, "issue", config=config, check_labels=False) as should_process:
+            assert should_process
+
+        # The label belongs to the earlier run, so this run must not remove it
+        mock_github_client.remove_labels.assert_not_called()
+
+    def test_label_manager_check_labels_true_skips_when_label_cannot_be_acquired(self):
+        """With check_labels=True an already-held label still means "another instance owns it"."""
+        mock_github_client = Mock()
+        mock_github_client.disable_labels = False
+        mock_github_client.has_label.return_value = False
+        mock_github_client.try_add_labels.return_value = False
+
+        config = AutomationConfig()
+
+        with LabelManager(mock_github_client, "owner/repo", 123, "issue", config=config, check_labels=True) as should_process:
+            assert not should_process
+
+        mock_github_client.remove_labels.assert_not_called()
+
 
 class TestSemanticLabelFunctions:
     """Test semantic label detection and priority resolution functions."""

--- a/tests/test_pr_processor_jules_timeout_close.py
+++ b/tests/test_pr_processor_jules_timeout_close.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock, patch
 
-from src.auto_coder.automation_config import AutomationConfig
+from src.auto_coder.automation_config import AutomationConfig, StaleJulesPRResult
 from src.auto_coder.pr_processor import _close_stale_jules_pr, _handle_pr_merge, _should_skip_waiting_for_jules, process_pull_request
 from src.auto_coder.util.github_action import DetailedChecksResult, GitHubActionsStatusResult
 
@@ -36,7 +36,8 @@ class TestCloseStaleJulesPR:
         checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
         mock_increment.return_value = 3
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        actions = result.actions
 
         github_client.close_pr.assert_called_once()
         close_args = github_client.close_pr.call_args[0]
@@ -55,8 +56,10 @@ class TestCloseStaleJulesPR:
         pr_data = _jules_pr_data(hours_old=11)
         checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        actions = result.actions
 
+        assert result.closed is False
         assert actions == []
         github_client.close_pr.assert_not_called()
         mock_increment.assert_not_called()
@@ -69,8 +72,10 @@ class TestCloseStaleJulesPR:
         pr_data = _jules_pr_data(hours_old=48)
         checks = MagicMock(spec=GitHubActionsStatusResult, success=True, in_progress=False)
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        actions = result.actions
 
+        assert result.closed is False
         assert actions == []
         github_client.close_pr.assert_not_called()
         mock_increment.assert_not_called()
@@ -83,8 +88,10 @@ class TestCloseStaleJulesPR:
         pr_data = _jules_pr_data(hours_old=48)
         checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=True)
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        actions = result.actions
 
+        assert result.closed is False
         assert actions == []
         github_client.close_pr.assert_not_called()
         mock_increment.assert_not_called()
@@ -98,9 +105,27 @@ class TestCloseStaleJulesPR:
         pr_data["user"] = {"login": "human-dev"}
         pr_data["body"] = "A regular PR without a session reference"
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, None)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, None)
+        actions = result.actions
 
+        assert result.closed is False
         assert actions == []
+        github_client.close_pr.assert_not_called()
+        mock_increment.assert_not_called()
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    def test_ignores_already_closed_pr(self, mock_increment):
+        """A PR closed by an earlier run must not be closed (and counted) twice."""
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["state"] = "closed"
+        checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+
+        assert result.closed is False
         github_client.close_pr.assert_not_called()
         mock_increment.assert_not_called()
 
@@ -116,7 +141,8 @@ class TestCloseStaleJulesPR:
         mock_resolve.return_value = 4636
         mock_increment.return_value = 2
 
-        actions = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+        actions = result.actions
 
         mock_resolve.assert_called_once_with("owner/repo", pr_data, github_client)
         mock_increment.assert_called_once_with("owner/repo", 4636)
@@ -295,6 +321,99 @@ class TestStaleJulesPRWithAutoCoderLabel:
         assert any("Closed stale Jules PR #4643" in action for action in result.actions)
 
 
+class TestUnlockAndRetryLinkedIssue:
+    """Closing a stale Jules PR must hand the linked issue back for a new attempt.
+
+    Jules mode keeps the @auto-coder label on the issue while its session works, so a
+    dead session leaves the issue locked forever unless the label is released.
+    """
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    def test_close_releases_issue_label_and_reports_issue(self, mock_increment):
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=13)
+        checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 2
+
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+
+        github_client.remove_labels.assert_called_once_with("owner/repo", 4636, [config.AUTO_CODER_LABEL], item_type="issue")
+        assert result.issue_numbers == [4636]
+        assert any(f"Removed {config.AUTO_CODER_LABEL} label from issue #4636" in action for action in result.actions)
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    def test_close_keeps_issue_label_when_labels_disabled(self, mock_increment):
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        config.DISABLE_LABELS = True
+        pr_data = _jules_pr_data(hours_old=13)
+        checks = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 2
+
+        result = _close_stale_jules_pr(github_client, "owner/repo", pr_data, config, checks)
+
+        github_client.remove_labels.assert_not_called()
+        assert result.issue_numbers == [4636]
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    @patch("src.auto_coder.pr_processor._check_github_actions_status")
+    def test_single_candidate_starts_new_attempt_on_issue(self, mock_check_status, mock_increment):
+        from src.auto_coder.automation_config import Candidate
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["labels"] = [{"name": "@auto-coder"}]
+        issue_data = {"number": 4636, "title": "Reduce warm /demo load time", "labels": []}
+        github_client.get_issue.return_value = issue_data
+        github_client.get_issue_details.return_value = issue_data
+        github_client.get_all_sub_issues.return_value = []
+        mock_check_status.return_value = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 4
+
+        engine = AutomationEngine(github_client, config=config)
+        candidate = Candidate(type="pr", data=pr_data, priority=1)
+
+        with patch.object(AutomationEngine, "_take_issue_actions", return_value=["Created branch issue-4636/attempt-4"]) as mock_take_issue:
+            result = engine._process_single_candidate_unified("owner/repo", candidate, config)
+
+        mock_take_issue.assert_called_once()
+        assert mock_take_issue.call_args[0][1] == issue_data
+        assert any("Started a new attempt for issue #4636" in action for action in result.actions)
+        assert any("Created branch issue-4636/attempt-4" in action for action in result.actions)
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    @patch("src.auto_coder.pr_processor._check_github_actions_status")
+    def test_get_candidates_queues_unlocked_issue(self, mock_check_status, mock_increment):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["labels"] = [{"name": "@auto-coder"}]
+        pr_data["draft"] = False
+        issue_data = {"number": 4636, "title": "Reduce warm /demo load time", "labels": []}
+        github_client.get_open_prs_json.return_value = [pr_data]
+        github_client.get_open_issues_json.return_value = [issue_data]
+        github_client.get_issue.return_value = issue_data
+        github_client.get_issue_details.return_value = issue_data
+        mock_check_status.return_value = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 4
+
+        engine = AutomationEngine(github_client, config=config)
+        with patch("src.auto_coder.util.github_action.preload_github_actions_status"):
+            candidates = engine._get_candidates("owner/repo")
+
+        issue_candidates = [c for c in candidates if c.type == "issue" and c.data.get("number") == 4636]
+        assert len(issue_candidates) == 1, "the unlocked issue must be queued exactly once"
+
+
 class TestShouldSkipWaitingForJules:
     """Test cases for _should_skip_waiting_for_jules time-based behavior."""
 
@@ -320,3 +439,90 @@ class TestShouldSkipWaitingForJules:
         github_client = self._client_with_wait_comment(comment_age_hours=0.5)
 
         assert _should_skip_waiting_for_jules(github_client, "owner/repo", {"number": 123}, config) is True
+
+
+class TestSingleTargetTypeDetection:
+    """--only <number> must resolve issues that are not PRs.
+
+    get_pull_request() returns an empty result instead of raising for an issue number,
+    so the candidate builder has to verify the payload before treating it as a PR.
+    """
+
+    def test_auto_detection_falls_back_to_issue(self):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        issue_data = {"number": 4636, "title": "Reduce warm /demo load time", "labels": []}
+        # 404 for a PR lookup surfaces as an empty payload, not an exception
+        github_client.get_pull_request.return_value = {}
+        github_client.get_pr_details.return_value = {}
+        github_client.get_issue.return_value = issue_data
+        github_client.get_issue_details.return_value = issue_data
+
+        engine = AutomationEngine(github_client, config=config)
+        candidate = engine._create_candidate_from_single("owner/repo", "auto", 4636)
+
+        assert candidate is not None
+        assert candidate.type == "issue"
+        assert candidate.data["number"] == 4636
+
+    def test_missing_pr_returns_no_candidate(self):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        github_client.get_pull_request.return_value = {}
+        github_client.get_pr_details.return_value = {}
+
+        engine = AutomationEngine(github_client, config=config)
+
+        assert engine._create_candidate_from_single("owner/repo", "pr", 4636) is None
+
+
+class TestLinkedPRSkipUsesOpenPRs:
+    """Closed PRs stay in an issue timeline forever and must not hide the issue."""
+
+    def _engine(self, github_client, config):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        return AutomationEngine(github_client, config=config)
+
+    def _issue(self, linked_pr_numbers):
+        return {
+            "number": 4636,
+            "title": "Reduce warm /demo load time",
+            "labels": [],
+            "created_at": "2026-08-02T06:44:45Z",
+            "linked_pr_numbers": linked_pr_numbers,
+            "has_linked_prs": bool(linked_pr_numbers),
+        }
+
+    def test_issue_with_only_closed_linked_pr_is_collected(self):
+        github_client = Mock()
+        config = AutomationConfig()
+        github_client.get_open_prs_json.return_value = []
+        github_client.get_open_issues_json.return_value = [self._issue([4643])]
+
+        engine = self._engine(github_client, config)
+        with patch("src.auto_coder.util.github_action.preload_github_actions_status"):
+            candidates = engine._get_candidates("owner/repo")
+
+        assert [c.data["number"] for c in candidates if c.type == "issue"] == [4636]
+
+    def test_issue_with_open_linked_pr_is_skipped(self):
+        github_client = Mock()
+        config = AutomationConfig()
+        open_pr = {"number": 4643, "title": "Fix", "labels": [], "draft": False, "created_at": "2026-08-02T16:22:10Z", "head": {"ref": "b", "sha": "s"}, "body": ""}
+        github_client.get_open_prs_json.return_value = [open_pr]
+        github_client.get_open_issues_json.return_value = [self._issue([4643])]
+
+        engine = self._engine(github_client, config)
+        with (
+            patch("src.auto_coder.util.github_action.preload_github_actions_status"),
+            patch("src.auto_coder.pr_processor._close_stale_jules_pr", return_value=StaleJulesPRResult()),
+            patch("src.auto_coder.util.github_action.check_github_actions_and_exit_if_in_progress", return_value=False),
+        ):
+            candidates = engine._get_candidates("owner/repo")
+
+        assert [c.data["number"] for c in candidates if c.type == "issue"] == []

--- a/tests/test_pr_processor_jules_timeout_close.py
+++ b/tests/test_pr_processor_jules_timeout_close.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock, patch
 
 from src.auto_coder.automation_config import AutomationConfig
-from src.auto_coder.pr_processor import _close_stale_jules_pr, _handle_pr_merge, _should_skip_waiting_for_jules
+from src.auto_coder.pr_processor import _close_stale_jules_pr, _handle_pr_merge, _should_skip_waiting_for_jules, process_pull_request
 from src.auto_coder.util.github_action import DetailedChecksResult, GitHubActionsStatusResult
 
 JULES_PR_BODY = "Fixes the reported bug.\n\nSession ID: 901463134778726610\nhttps://jules.google.com/session/901463134778726610\n\nclose #4636"
@@ -216,6 +216,83 @@ class TestHandlePrMergeJulesPR:
         mock_checkout.assert_not_called()
         github_client.close_pr.assert_not_called()
         assert "Jules will handle fixing PR #4643, skipping local fixes" in actions[-1]
+
+
+class TestStaleJulesPRWithAutoCoderLabel:
+    """A stale Jules PR must be closed even when the @auto-coder label is still attached.
+
+    The label stays on the PR from an earlier processing run, so every gate that skips
+    labelled items has to be reached only after the staleness check.
+    """
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    @patch("src.auto_coder.pr_processor._check_github_actions_status")
+    def test_process_pull_request_closes_labelled_stale_jules_pr(self, mock_check_status, mock_increment):
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["labels"] = [{"name": "@auto-coder"}]
+        mock_check_status.return_value = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 4
+
+        result = process_pull_request(github_client, config, "owner/repo", pr_data)
+
+        github_client.close_pr.assert_called_once()
+        mock_increment.assert_called_once_with("owner/repo", 4636)
+        assert any("Closed stale Jules PR #4643" in action for action in result.actions_taken)
+        assert not any("already being processed" in action for action in result.actions_taken)
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    @patch("src.auto_coder.pr_processor._check_github_actions_status")
+    def test_get_candidates_closes_labelled_stale_jules_pr(self, mock_check_status, mock_increment):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["labels"] = [{"name": "@auto-coder"}]
+        pr_data["draft"] = False
+        github_client.get_open_prs_json.return_value = [pr_data]
+        github_client.get_open_issues.return_value = []
+        github_client.get_open_issues_json.return_value = []
+        mock_check_status.return_value = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 4
+
+        engine = AutomationEngine(github_client, config=config)
+        with patch("src.auto_coder.util.github_action.preload_github_actions_status"):
+            candidates = engine._get_candidates("owner/repo")
+
+        github_client.close_pr.assert_called_once()
+        mock_increment.assert_called_once_with("owner/repo", 4636)
+        assert all(candidate.data.get("number") != 4643 for candidate in candidates)
+
+    @patch("src.auto_coder.pr_processor.increment_attempt")
+    @patch("src.auto_coder.pr_processor._check_github_actions_status")
+    def test_single_candidate_closes_labelled_stale_jules_pr(self, mock_check_status, mock_increment):
+        from src.auto_coder.automation_config import Candidate
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = Mock()
+        config = AutomationConfig()
+        config.JULES_PR_CI_TIMEOUT_HOURS = 12
+        pr_data = _jules_pr_data(hours_old=30)
+        pr_data["labels"] = [{"name": "@auto-coder"}]
+        mock_check_status.return_value = MagicMock(spec=GitHubActionsStatusResult, success=False, in_progress=False)
+        mock_increment.return_value = 4
+
+        engine = AutomationEngine(github_client, config=config)
+        candidate = Candidate(type="pr", data=pr_data, priority=1)
+
+        with patch("src.auto_coder.pr_processor.process_pull_request") as mock_process:
+            result = engine._process_single_candidate_unified("owner/repo", candidate, config)
+
+        github_client.close_pr.assert_called_once()
+        mock_increment.assert_called_once_with("owner/repo", 4636)
+        mock_process.assert_not_called()
+        assert result.success is True
+        assert any("Closed stale Jules PR #4643" in action for action in result.actions)
 
 
 class TestShouldSkipWaitingForJules:


### PR DESCRIPTION
## Problem

The 12-hour stale-Jules-PR close added in #1535 never fired in production. `kitamura-tetsuo/outliner` PR #4643 stayed open for ~30 hours with failing CI, and the daemon logged only:

```
pr #4643 already has label(s) ['@auto-coder'] - skipping
Skipping pr #4643 - '@auto-coder' label was just added by another instance
Processed pr #4643
...
No actionable candidates. Sleeping for 300 seconds...
```

A stale Jules PR is precisely the case where the `@auto-coder` label is stuck from an earlier run, and all three code paths bailed out on that label *before* reaching the staleness check:

1. `AutomationEngine._get_candidates()` — labelled PRs are filtered out, so the PR was never queued.
2. `AutomationEngine._process_single_candidate_unified()` — `try_add_labels()` returns `False` for an already-labelled item (even with `CHECK_LABELS=False`, which is what `--only` and WIP resume set), so it returned "Skipped - another instance started processing" before calling `process_pull_request`.
3. `process_pull_request()` — its own label check ran first.

## Fix

`_close_stale_jules_pr()` is now called before the label gate in all three places. Behaviour is otherwise unchanged: only Jules PRs older than `[jules].pr_ci_timeout_hours` whose CI has completed without success are closed, and the linked issue's attempt counter is incremented.

## Verification against the live repo

Ran the real CLI path in the deployed container (`auto-coder process-issues --only .../pull/4643`):

```
  • Actions Taken :
    • Closed stale Jules PR #4643 (no passing CI within 12h)
    • Incremented attempt for issue #4636 to 2
```

Confirmed via the API afterwards: PR #4643 `state=closed, merged=False`, issue #4636 open with a new `Auto-Coder Attempt: 2` comment.

## Tests

- 3 new tests in `tests/test_pr_processor_jules_timeout_close.py` covering each gate with the `@auto-coder` label present: `process_pull_request`, `_get_candidates`, and `_process_single_candidate_unified`.
- Existing `tests/test_automation_engine_candidates.py` tests stub the new call.
- Full suite: 2189 passed / 21 failed / 5 errors — an identical failure list to unmodified `main` in this container (all environment-dependent: gemini/antigravity CLI probing and local `llm_config.toml`), so no regressions. black/isort/flake8/mypy pass.

---
_Generated by [Claude Code](https://claude.com/claude-code)_


---

## Follow-up: the attempt increment had no effect on its own

Closing the PR and bumping the counter still left issue #4636 untouched, because a dead Jules run leaves the issue both *locked* and *hidden*:

1. **Locked** — Jules mode deliberately keeps the `@auto-coder` label on the issue for the lifetime of its session (`issue_processor.py`, `label_context.keep_label()`). When the session dies, nothing releases it.
2. **Hidden** — candidate collection skipped every issue with `has_linked_prs`, which is computed from the issue timeline and therefore includes **closed** PRs. Any issue that ever had a PR could never be collected again.

### Additional changes

- `_close_stale_jules_pr()` now removes the `@auto-coder` label from the linked issue and returns a `StaleJulesPRResult` (`closed` / `actions` / `issue_numbers`) instead of a bare action list. The caller processes those issues right away: queued as candidates in `_get_candidates()`, processed inline via `_process_unlocked_issue()` for single-target runs.
- Only **open** linked PRs hide an issue from candidate collection now.
- `LabelManager` with `check_labels=False` (`--only`, WIP-branch resume) no longer bails out when the label is already present — an explicitly requested run must not be blocked by a leftover lock. The label is left untouched because the run does not own it.
- `--only <number>` resolved issue numbers as PRs: `get_pull_request()` returns an empty payload instead of raising for an issue, so `"auto"` detection stayed on `pr` and failed with `Item number is missing for pr #None`. Detection now validates the payload, and a missing PR yields no candidate.
- An already-closed PR is ignored, so the attempt counter can never be incremented twice for the same PR.

### Verification against the live repo

```
# issue was locked and hidden
issue 4636 labels: ['@auto-coder']   has_linked_prs: True (PR #4643, closed)

# after the fix
_get_candidates() -> issue #4636 priority=0
_process_single_candidate() -> Started Jules session '1602790326868414323' for issue #4636
```

Issue #4636 is now on attempt 2 with a live Jules session.

### Tests

11 further tests: label release and reported issues, labels-disabled case, retry from both the daemon and the single-target path, already-closed PR guard, open-vs-closed linked PR skip, `--only` type detection, and the two `LabelManager` acquisition paths. The existing `test_get_candidates_skips_issues_with_sub_issues_or_linked_prs` was updated to the open-PR semantics.

Full suite: 2200 passed / 21 failed / 5 errors — identical failure list to unmodified `main` in this container.
