### PR TITLE
Hand issues over to backend_with_high_score when Jules times out without a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,21 @@ backend_type = "jules"
 - Sessions are tracked in `~/.auto-coder/<repo>/cloud.csv` files
 - Jules automatically comments on issues with session information
 
+**Issue timeout fallback:**
+
+When a Jules session works on an issue for longer than `[jules].issue_pr_timeout_hours`
+(default: 12) without opening a pull request, Auto-Coder sends a `stop` message to the
+session and implements the issue with the `backend_with_high_score` backend instead:
+
+```toml
+# config.toml
+[jules]
+issue_pr_timeout_hours = 12
+```
+
+Sessions that already produced a PR, issues that already have a linked PR, and closed
+issues are never taken away from Jules.
+
 For more details about Jules mode architecture and migration from legacy Jules label logic, see the [Migration Guide: v2026.2.0](docs/MIGRATION_GUIDE_v2026.2.0.md).
 
 ### Retry Configuration

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -383,6 +383,15 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
       - "The check runs before every '@auto-coder label present' skip (candidate collection, single-target processing, and process_pull_request); a stale PR normally still carries the label from an earlier run and would otherwise never be revisited."
       - "Closing also releases the issue: the @auto-coder label that the dead Jules session kept on the linked issue is removed, and the issue is processed again in the same run (queued as a candidate in the daemon, processed inline for single-target runs)."
       - "PRs that are already closed are ignored, so the attempt counter is never incremented twice for the same PR."
+    issue_pr_timeout:
+      - "When a Jules session has been working on an issue for more than [jules].issue_pr_timeout_hours without opening a PR, the session is sent a 'stop' message and the issue is implemented by the backend_with_high_score backend instead."
+      - "Default timeout: 12 hours. Configurable via [jules].issue_pr_timeout_hours in config.toml."
+      - "The session-to-issue mapping comes from cloud.csv; sessions tracked against a PR number are ignored by this rule."
+      - "Sessions whose outputs already contain a pullRequest, and issues that already have a linked PR on GitHub, are never stopped."
+      - "Closed issues are skipped, and a session that fails to accept the stop message keeps the issue."
+      - "The @auto-coder label the Jules run left on the issue is removed before the fallback implementation runs, otherwise the label gate would skip the issue."
+      - "Stopped sessions are recorded in .auto-coder/jules_session_state.json so they are neither resumed nor handed over twice."
+      - "The check runs once per producer/run loop iteration, right after the Jules session resume/archive pass."
     label_locking:
       - "Jules mode keeps the @auto-coder label on an issue for the lifetime of its session, so an aborted session would otherwise lock the issue permanently."
       - "With check_labels=False (--only and WIP-branch resume) an existing @auto-coder label no longer blocks processing; the label is left in place because the run does not own it."
@@ -485,6 +494,7 @@ Recent configuration schema changes that require migration:
     fallback:
       - "PR failures that cannot be auto-merged (LLM CANNOT_FIX/unclear output, commit/push errors, failed merges or conflict resolution) trigger attempt increments for every linked issue."
       - "Jules PRs that still have failing CI more than [jules].pr_ci_timeout_hours (default 12) after PR creation are closed, and the attempt counter of the linked issue is incremented so the issue is retried from scratch."
+      - "Jules sessions that do not open a PR within [jules].issue_pr_timeout_hours (default 12) are stopped, and the issue is implemented by the backend_with_high_score backend instead."
       - "Conflict resolver fallbacks do the same when LLM-based conflict handling leaves unresolved markers or cannot push a clean merge."
       - "When attempt count reaches 3 for any linked issue, the system automatically switches to the configured fallback backend (see [backend_with_high_score] configuration)."
       - "Backend fallback provides a fresh perspective using a different LLM after multiple failed attempts, improving chances of successful PR resolution."

--- a/docs/process_issues_activity.md
+++ b/docs/process_issues_activity.md
@@ -39,6 +39,10 @@ else (no)
         while (True) is (active)
             :check_for_updates_and_restart;
             :check_and_resume_or_archive_sessions;
+            :handle_stale_jules_issue_sessions
+            (stop Jules sessions without a PR after
+            [jules].issue_pr_timeout_hours and implement
+            the issue with backend_with_high_score);
 
             partition "automation_engine.run" {
                 :Get candidates (_get_candidates);

--- a/docs/process_issues_activity.puml
+++ b/docs/process_issues_activity.puml
@@ -34,6 +34,10 @@ else (no)
         while (True) is (active)
             :check_for_updates_and_restart;
             :check_and_resume_or_archive_sessions;
+            :handle_stale_jules_issue_sessions
+            (stop Jules sessions without a PR after
+            [jules].issue_pr_timeout_hours and implement
+            the issue with backend_with_high_score);
 
             partition "automation_engine.run" {
                 :Get candidates (_get_candidates);

--- a/src/auto_coder/automation_config.py
+++ b/src/auto_coder/automation_config.py
@@ -155,12 +155,14 @@ class AutomationConfig:
         # Load Jules wait timeout from config
         from .llm_backend_config import (
             get_github_action_log_max_length_from_config,
+            get_jules_issue_pr_timeout_hours_from_config,
             get_jules_pr_ci_timeout_hours_from_config,
             get_jules_wait_timeout_hours_from_config,
         )
 
         object.__setattr__(self, "JULES_WAIT_TIMEOUT_HOURS", get_jules_wait_timeout_hours_from_config())
         object.__setattr__(self, "JULES_PR_CI_TIMEOUT_HOURS", get_jules_pr_ci_timeout_hours_from_config())
+        object.__setattr__(self, "JULES_ISSUE_PR_TIMEOUT_HOURS", get_jules_issue_pr_timeout_hours_from_config())
         object.__setattr__(self, "GITHUB_ACTION_LOG_MAX_LENGTH", get_github_action_log_max_length_from_config())
 
         object.__setattr__(self, "FORCE_CLEAN_BEFORE_CHECKOUT", False)
@@ -495,6 +497,12 @@ class AutomationConfig:
     # Configurable via [jules].pr_ci_timeout_hours in config.toml
     JULES_PR_CI_TIMEOUT_HOURS: int = 12
 
+    # Maximum time a Jules session may work on an issue without opening a PR (default: 12 hours)
+    # After this timeout the session is stopped and the issue is implemented by the
+    # backend_with_high_score backend instead.
+    # Configurable via [jules].issue_pr_timeout_hours in config.toml
+    JULES_ISSUE_PR_TIMEOUT_HOURS: int = 12
+
     # GitHub Action log max length (default: 50000)
     # Configurable via [github_action].max_log_length in config.toml
     GITHUB_ACTION_LOG_MAX_LENGTH: int = 50000
@@ -692,6 +700,20 @@ class StaleJulesPRResult:
     """
 
     closed: bool = False
+    actions: List[str] = field(default_factory=list)
+    issue_numbers: List[int] = field(default_factory=list)
+
+
+@dataclass
+class StaleJulesIssueResult:
+    """Result of the stale Jules issue-session check.
+
+    Attributes:
+        actions: Human-readable actions taken
+        issue_numbers: Issues that were taken away from Jules and implemented by the
+            backend_with_high_score backend
+    """
+
     actions: List[str] = field(default_factory=list)
     issue_numbers: List[int] = field(default_factory=list)
 

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -65,6 +65,19 @@ class AutomationEngine:
         except Exception as e:
             logger.error(f"Error checking/starting recurrent Jules tasks: {e}")
 
+    def handle_stale_jules_issue_sessions(self, repo_name: str) -> List[str]:
+        """Hand issues over to backend_with_high_score when Jules times out without a PR."""
+        from .issue_processor import handle_stale_jules_issue_sessions
+
+        try:
+            stale_result = handle_stale_jules_issue_sessions(repo_name, self.config, self.github)
+            for action in stale_result.actions:
+                logger.info(f"Stale Jules issue session: {action}")
+            return stale_result.actions
+        except Exception as e:
+            logger.error(f"Error handling stale Jules issue sessions: {e}")
+            return []
+
     async def start_automation(self, repo_name: str, concurrency: Optional[int] = None) -> None:
         """Start the automation engine with event-driven architecture."""
         if concurrency is None:
@@ -104,6 +117,9 @@ class AutomationEngine:
 
                 # Resume sessions
                 await asyncio.to_thread(check_and_resume_or_archive_sessions, repo_name)
+
+                # Take issues away from Jules sessions that timed out without creating a PR
+                await asyncio.to_thread(self.handle_stale_jules_issue_sessions, repo_name)
 
                 # Check and start recurrent Jules tasks
                 await self.check_and_start_recurrent_jules_tasks_async(repo_name)
@@ -1043,6 +1059,9 @@ class AutomationEngine:
 
                 # Check and resume failed Jules sessions
                 check_and_resume_or_archive_sessions()
+
+                # Take issues away from Jules sessions that timed out without creating a PR
+                self.handle_stale_jules_issue_sessions(repo_name)
 
                 # Check and start recurrent Jules tasks
                 check_and_start_recurrent_jules_tasks(repo_name)

--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -4,15 +4,17 @@ Issue processing functionality for Auto-Coder automation engine.
 
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, TypedDict, cast
+
+from dateutil import parser
 
 from auto_coder.util.gh_cache import get_ghapi_client
 from auto_coder.util.github_action import _check_github_actions_status, check_and_handle_closed_state, check_github_actions_and_exit_if_in_progress, get_detailed_checks_from_history
 
 from .attempt_manager import get_current_attempt
-from .automation_config import AutomationConfig, ProcessedIssueResult, ProcessResult
-from .backend_manager import get_llm_backend_manager, parse_llm_output_as_json, run_llm_noedit_prompt
+from .automation_config import AutomationConfig, ProcessedIssueResult, ProcessResult, StaleJulesIssueResult
+from .backend_manager import BackendManager, get_llm_backend_manager, parse_llm_output_as_json, run_llm_noedit_prompt
 from .branch_manager import BranchManager
 from .cloud_manager import CloudManager
 from .git_branch import branch_context, extract_attempt_from_branch
@@ -20,6 +22,7 @@ from .git_commit import commit_and_push_changes
 from .git_info import get_commit_log, get_current_branch
 from .issue_context import get_linked_issues_context, validate_issue_references
 from .jules_client import JulesClient
+from .jules_engine import get_session_pull_request, is_session_stopped, mark_session_stopped
 from .label_manager import LabelManager, LabelManagerContext, LabelOperationError, resolve_pr_labels_with_priority
 from .logger_config import get_gh_logger, get_logger
 from .progress_footer import ProgressStage, newline_progress, set_progress_item
@@ -353,8 +356,14 @@ def _take_issue_actions(
     issue_data: Dict[str, Any],
     config: AutomationConfig,
     github_client: GitHubClient,
+    backend_manager: Optional[BackendManager] = None,
 ) -> List[str]:
-    """Take actions on an issue using direct LLM CLI analysis and implementation."""
+    """Take actions on an issue using direct LLM CLI analysis and implementation.
+
+    Args:
+        backend_manager: Backend manager used for the implementation run.
+            Defaults to the current LLM backend manager.
+    """
     actions = []
     issue_number = issue_data["number"]
 
@@ -388,6 +397,7 @@ def _take_issue_actions(
                 issue_data,
                 config,
                 github_client,
+                backend_manager=backend_manager,
             )
             actions.extend(action_results)
 
@@ -571,6 +581,181 @@ def _process_issue_jules_mode(
     return actions
 
 
+def _extract_session_id(session: Dict[str, Any]) -> Optional[str]:
+    """Extract the session ID from a Jules session object."""
+    name = session.get("name")
+    if isinstance(name, str) and name:
+        return name.split("/")[-1]
+
+    session_id = session.get("id")
+    return session_id if isinstance(session_id, str) and session_id else None
+
+
+def _stop_jules_session_for_issue(
+    jules_client: JulesClient,
+    repo_name: str,
+    issue_number: int,
+    session_id: str,
+    timeout_hours: int,
+    github_client: GitHubClient,
+) -> bool:
+    """Tell a stale Jules session to stop and record it as stopped.
+
+    Returns:
+        True when the stop message was accepted by the Jules API.
+    """
+    try:
+        jules_client.send_message(session_id, "stop")
+    except Exception as e:
+        logger.error(f"Failed to send stop message to Jules session {session_id} for issue #{issue_number}: {e}")
+        return False
+
+    mark_session_stopped(session_id)
+    logger.info(f"Stopped Jules session {session_id} for issue #{issue_number} after {timeout_hours}h without a PR")
+
+    try:
+        github_client.add_comment_to_issue(
+            repo_name,
+            issue_number,
+            f"Auto-Coder: Jules did not open a PR within {timeout_hours} hours, so I stopped the Jules session `{session_id}` and will implement this issue with the backend_with_high_score backend instead.",
+        )
+    except Exception as e:
+        logger.warning(f"Failed to comment on issue #{issue_number} about the stopped Jules session: {e}")
+
+    return True
+
+
+def handle_stale_jules_issue_sessions(
+    repo_name: str,
+    config: AutomationConfig,
+    github_client: GitHubClient,
+) -> StaleJulesIssueResult:
+    """Take issues away from Jules sessions that ran out of time without opening a PR.
+
+    A Jules session that has been working on an issue for longer than
+    ``config.JULES_ISSUE_PR_TIMEOUT_HOURS`` without producing a pull request is
+    considered stuck. Such a session is sent a ``stop`` message, the ``@auto-coder``
+    label the Jules run left on the issue is released, and the issue is implemented
+    by the ``backend_with_high_score`` backend instead.
+
+    Args:
+        repo_name: Repository name (e.g., 'owner/repo')
+        config: AutomationConfig instance
+        github_client: GitHub client for API operations
+
+    Returns:
+        StaleJulesIssueResult describing which issues were handled.
+    """
+    result = StaleJulesIssueResult()
+    timeout_hours = config.JULES_ISSUE_PR_TIMEOUT_HOURS
+
+    try:
+        jules_client = JulesClient()
+        sessions = jules_client.list_sessions(repo_name=repo_name)
+    except Exception as e:
+        logger.warning(f"Failed to list Jules sessions for stale issue check: {e}")
+        return result
+
+    cloud_manager = CloudManager(repo_name)
+    now = datetime.now(timezone.utc)
+    timeout = timedelta(hours=timeout_hours)
+
+    for session in sessions:
+        if not isinstance(session, dict):
+            logger.warning(f"Skipping invalid Jules session object (expected dict, got {type(session)})")
+            continue
+
+        session_id = _extract_session_id(session)
+        if not session_id:
+            continue
+
+        try:
+            if is_session_stopped(session_id):
+                continue
+
+            # A session that already produced a PR is doing its job
+            if get_session_pull_request(session):
+                continue
+
+            create_time_str = session.get("createTime")
+            if not create_time_str:
+                continue
+
+            try:
+                create_time = parser.parse(str(create_time_str))
+            except Exception as e:
+                logger.warning(f"Failed to parse createTime '{create_time_str}' for Jules session {session_id}: {e}")
+                continue
+
+            if create_time.tzinfo is None:
+                create_time = create_time.replace(tzinfo=timezone.utc)
+
+            if (now - create_time) <= timeout:
+                continue
+
+            issue_number = cloud_manager.get_issue_by_session(session_id)
+            if not issue_number:
+                continue
+
+            issue = github_client.get_issue(repo_name, issue_number)
+            if issue is None:
+                continue
+
+            issue_data = github_client.get_issue_details(issue)
+
+            # cloud.csv also tracks PR-bound sessions; only issues are handled here
+            is_pull_request = (issue.get("pull_request") if isinstance(issue, dict) else getattr(issue, "pull_request", None)) is not None
+            if is_pull_request:
+                continue
+
+            if issue_data.get("state") != "open":
+                continue
+
+            # Jules may have opened the PR without the session outputs reflecting it yet
+            if github_client.has_linked_pr(repo_name, issue_number):
+                continue
+
+            if not _stop_jules_session_for_issue(jules_client, repo_name, issue_number, session_id, timeout_hours, github_client):
+                continue
+
+            result.actions.append(f"Stopped Jules session '{session_id}' for issue #{issue_number} (no PR within {timeout_hours}h)")
+            get_trace_logger().log(
+                "Jules Timeout",
+                f"Stopped Jules session for issue #{issue_number}",
+                item_type="issue",
+                item_number=issue_number,
+                details={"session_id": session_id, "timeout_hours": timeout_hours},
+            )
+
+            # Release the @auto-coder label so the issue can be processed again
+            from .pr_processor import _release_issue_processing_label
+
+            if _release_issue_processing_label(github_client, repo_name, issue_number, config):
+                result.actions.append(f"Removed {config.AUTO_CODER_LABEL} label from issue #{issue_number}")
+
+            from .cli_helpers import create_high_score_backend_manager
+
+            backend_manager = create_high_score_backend_manager()
+            if backend_manager is None:
+                logger.warning("backend_with_high_score is not configured; using the default backend for the Jules fallback")
+
+            result.actions.extend(
+                _take_issue_actions(
+                    repo_name,
+                    issue_data,
+                    config,
+                    github_client,
+                    backend_manager=backend_manager,
+                )
+            )
+            result.issue_numbers.append(issue_number)
+
+        except Exception as e:
+            logger.error(f"Failed to handle stale Jules session {session_id}: {e}")
+
+    return result
+
+
 def _create_pr_for_issue(
     repo_name: str,
     issue_data: Dict[str, Any],
@@ -751,8 +936,14 @@ def _apply_issue_actions_directly(
     issue_data: Dict[str, Any],
     config: AutomationConfig,
     github_client: GitHubClient,
+    backend_manager: Optional[BackendManager] = None,
 ) -> List[str]:
-    """Ask LLM CLI to analyze an issue and take appropriate actions directly."""
+    """Ask LLM CLI to analyze an issue and take appropriate actions directly.
+
+    Args:
+        backend_manager: Backend manager used for the implementation run.
+            Defaults to the current LLM backend manager.
+    """
     issue_number = issue_data.get("number", "unknown")
     actions = []
 
@@ -949,7 +1140,7 @@ def _apply_issue_actions_directly(
                 get_trace_logger().log("Analysis Start", f"Starting analysis for issue #{issue_number}", item_type="issue", item_number=issue_number)
 
                 # Call LLM client
-                response = get_llm_backend_manager()._run_llm_cli(action_prompt)
+                response = (backend_manager or get_llm_backend_manager())._run_llm_cli(action_prompt)
 
                 # Parse the response
                 if response and len(response.strip()) > 0:

--- a/src/auto_coder/jules_engine.py
+++ b/src/auto_coder/jules_engine.py
@@ -21,6 +21,10 @@ logger = get_logger(__name__)
 
 STATE_FILE = os.path.join(os.getcwd(), ".auto-coder", "jules_session_state.json")
 
+# Sentinel retry-state values (regular values are non-negative retry counts)
+SESSION_STATE_NOT_FOUND = -1  # Session returned 404 on the server
+SESSION_STATE_STOPPED = -2  # Session was stopped because it timed out without creating a PR
+
 
 def _load_state() -> Dict[str, int]:
     """Load Jules session state from file."""
@@ -41,6 +45,45 @@ def _save_state(state: Dict[str, int]) -> None:
             json.dump(state, f)
     except Exception as e:
         logger.warning(f"Failed to save Jules session state: {e}")
+
+
+def normalize_session_outputs(outputs: Any) -> Dict[str, Any]:
+    """Normalize the ``outputs`` field of a Jules session into a dict.
+
+    The API returns a mapping, but some responses deliver it as a list of
+    single-entry dicts or key/value pairs.
+    """
+    if isinstance(outputs, dict):
+        return outputs
+
+    if isinstance(outputs, list):
+        normalized: Dict[str, Any] = {}
+        for item in outputs:
+            if isinstance(item, dict):
+                normalized.update(item)
+            elif isinstance(item, (list, tuple)) and len(item) == 2:
+                normalized[item[0]] = item[1]
+        return normalized
+
+    return {}
+
+
+def get_session_pull_request(session: Dict[str, Any]) -> Any:
+    """Return the pull request recorded in a Jules session's outputs, if any."""
+    outputs = normalize_session_outputs(session.get("outputs", {}))
+    return outputs.get("pullRequest") or outputs.get("pull_request")
+
+
+def is_session_stopped(session_id: str) -> bool:
+    """Return True if the session was stopped after failing to create a PR in time."""
+    return _load_state().get(session_id) == SESSION_STATE_STOPPED
+
+
+def mark_session_stopped(session_id: str) -> None:
+    """Persist that a session was stopped so it is never resumed again."""
+    state = _load_state()
+    state[session_id] = SESSION_STATE_STOPPED
+    _save_state(state)
 
 
 def check_and_resume_or_archive_sessions(repo_name: Optional[str] = None) -> None:
@@ -102,8 +145,13 @@ def check_and_resume_or_archive_sessions(repo_name: Optional[str] = None) -> Non
 
             try:
                 # Skip sessions that are known to be not found (404) on the server
-                if retry_state.get(session_id) == -1:
+                if retry_state.get(session_id) == SESSION_STATE_NOT_FOUND:
                     logger.debug(f"Skipping session {session_id} as it was previously not found (404) on the server.")
+                    continue
+
+                # Skip sessions that were stopped because they timed out without creating a PR
+                if retry_state.get(session_id) == SESSION_STATE_STOPPED:
+                    logger.debug(f"Skipping session {session_id} as it was stopped after failing to create a PR in time.")
                     continue
 
                 # Check if session is expired
@@ -129,20 +177,7 @@ def check_and_resume_or_archive_sessions(repo_name: Optional[str] = None) -> Non
                         logger.error(f"Failed to check creation time for session {session_id}: {e}")
 
                 state = session.get("state")
-                outputs = session.get("outputs", {})
-                if isinstance(outputs, list):
-                    try:
-                        new_outputs = {}
-                        for item in outputs:
-                            if isinstance(item, dict):
-                                new_outputs.update(item)
-                            elif isinstance(item, (list, tuple)) and len(item) == 2:
-                                new_outputs[item[0]] = item[1]
-                        outputs = new_outputs
-                    except Exception as e:
-                        logger.warning(f"Failed to convert list outputs to dict: {outputs} - {e}")
-                        outputs = {}
-
+                outputs = normalize_session_outputs(session.get("outputs", {}))
                 pull_request = outputs.get("pullRequest") or outputs.get("pull_request")
                 automation_mode = session.get("automationMode") or session.get("automation_mode")
                 if automation_mode is None:
@@ -546,21 +581,7 @@ def check_and_start_recurrent_jules_tasks(repo_name: str) -> None:
                 if match_found:
                     # Check if the session is completed and merged/closed on GitHub
                     state = session.get("state")
-                    outputs = session.get("outputs", {})
-                    if isinstance(outputs, list):
-                        try:
-                            new_outputs = {}
-                            for item in outputs:
-                                if isinstance(item, dict):
-                                    new_outputs.update(item)
-                                elif isinstance(item, (list, tuple)) and len(item) == 2:
-                                    new_outputs[item[0]] = item[1]
-                            outputs = new_outputs
-                        except Exception as e:
-                            logger.warning(f"Failed to convert list outputs to dict: {e}")
-                            outputs = {}
-
-                    pull_request = outputs.get("pullRequest") or outputs.get("pull_request")
+                    pull_request = get_session_pull_request(session)
                     if state == "COMPLETED" and pull_request:
                         try:
                             github_client = GitHubClient.get_instance()

--- a/src/auto_coder/llm_backend_config.py
+++ b/src/auto_coder/llm_backend_config.py
@@ -812,6 +812,24 @@ def get_jules_wait_timeout_hours_from_config(config_path: Optional[str] = None) 
     )
 
 
+def get_jules_issue_pr_timeout_hours_from_config(config_path: Optional[str] = None) -> int:
+    """Get the maximum time Jules may work on an issue without opening a PR.
+
+    Args:
+        config_path: Optional explicit path to config.toml file.
+
+    Returns:
+        Timeout in hours (default: 12)
+    """
+    return _get_config_value(
+        section="jules",
+        key="issue_pr_timeout_hours",
+        default=12,
+        config_path=config_path,
+        value_type=int,
+    )
+
+
 def get_jules_pr_ci_timeout_hours_from_config(config_path: Optional[str] = None) -> int:
     """Get the maximum time a Jules PR may stay open without passing CI.
 

--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -338,22 +338,10 @@ def _should_skip_waiting_for_jules(github_client: Any, repo_name: str, pr_data: 
                     target_session = None
 
                 if target_session:
-                    state = target_session.get("state")
-                    outputs = target_session.get("outputs", {})
-                    # Handle list outputs same as jules_engine
-                    if isinstance(outputs, list):
-                        try:
-                            new_outputs = {}
-                            for item in outputs:
-                                if isinstance(item, dict):
-                                    new_outputs.update(item)
-                                elif isinstance(item, (list, tuple)) and len(item) == 2:
-                                    new_outputs[item[0]] = item[1]
-                            outputs = new_outputs
-                        except Exception:
-                            outputs = {}
+                    from auto_coder.jules_engine import get_session_pull_request
 
-                    pull_request = outputs.get("pullRequest")
+                    state = target_session.get("state")
+                    pull_request = get_session_pull_request(target_session)
 
                     if state == "COMPLETED" and pull_request:
                         # Extract PR info

--- a/tests/test_issue_processor_jules_stale_sessions.py
+++ b/tests/test_issue_processor_jules_stale_sessions.py
@@ -1,0 +1,252 @@
+"""
+Tests for handing stale Jules issue sessions over to the backend_with_high_score backend.
+
+A Jules session that works on an issue for longer than
+``JULES_ISSUE_PR_TIMEOUT_HOURS`` without opening a PR is stopped and the issue is
+implemented by the backend_with_high_score backend instead.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.auto_coder.automation_config import AutomationConfig
+from src.auto_coder.issue_processor import handle_stale_jules_issue_sessions
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _session(session_id: str, age_hours: float, outputs=None) -> dict:
+    created = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {
+        "name": f"sessions/{session_id}",
+        "state": "IN_PROGRESS",
+        "createTime": _iso(created),
+        "outputs": outputs if outputs is not None else {},
+    }
+
+
+def _github_client(issue_number: int = 42, state: str = "open", has_linked_pr: bool = False) -> MagicMock:
+    client = MagicMock()
+    client.get_issue.return_value = {"number": issue_number, "title": "Broken thing", "state": state}
+    client.get_issue_details.return_value = {
+        "number": issue_number,
+        "title": "Broken thing",
+        "body": "Please fix",
+        "state": state,
+        "labels": ["@auto-coder"],
+        "author": "someone",
+    }
+    client.has_linked_pr.return_value = has_linked_pr
+    return client
+
+
+@pytest.fixture
+def config() -> AutomationConfig:
+    config = AutomationConfig()
+    object.__setattr__(config, "JULES_ISSUE_PR_TIMEOUT_HOURS", 12)
+    return config
+
+
+class TestHandleStaleJulesIssueSessions:
+    """Test cases for handle_stale_jules_issue_sessions."""
+
+    def _run(self, sessions, github_client, config, issue_number=42, stopped=False, backend_manager=None):
+        jules_client = MagicMock()
+        jules_client.list_sessions.return_value = sessions
+
+        cloud_manager = MagicMock()
+        cloud_manager.get_issue_by_session.return_value = issue_number
+
+        take_actions = MagicMock(return_value=["Implemented issue #42"])
+
+        with (
+            patch("src.auto_coder.issue_processor.JulesClient", return_value=jules_client),
+            patch("src.auto_coder.issue_processor.CloudManager", return_value=cloud_manager),
+            patch("src.auto_coder.issue_processor.is_session_stopped", return_value=stopped),
+            patch("src.auto_coder.issue_processor.mark_session_stopped") as mark_stopped,
+            patch("src.auto_coder.issue_processor._take_issue_actions", take_actions),
+            patch("src.auto_coder.pr_processor._release_issue_processing_label", return_value=True),
+            patch(
+                "src.auto_coder.cli_helpers.create_high_score_backend_manager",
+                return_value=backend_manager,
+            ),
+        ):
+            result = handle_stale_jules_issue_sessions("owner/repo", config, github_client)
+
+        return result, jules_client, take_actions, mark_stopped
+
+    def test_stops_session_and_delegates_to_high_score_backend(self, config):
+        """A session older than the timeout without a PR is stopped and handed over."""
+        github_client = _github_client()
+        backend_manager = MagicMock()
+
+        result, jules_client, take_actions, mark_stopped = self._run(
+            [_session("sess-1", age_hours=13)],
+            github_client,
+            config,
+            backend_manager=backend_manager,
+        )
+
+        jules_client.send_message.assert_called_once_with("sess-1", "stop")
+        mark_stopped.assert_called_once_with("sess-1")
+        assert result.issue_numbers == [42]
+
+        take_actions.assert_called_once()
+        assert take_actions.call_args.kwargs["backend_manager"] is backend_manager
+        assert take_actions.call_args.args[0] == "owner/repo"
+        assert "Implemented issue #42" in result.actions
+
+        # The issue gets a comment explaining the hand-over
+        github_client.add_comment_to_issue.assert_called_once()
+        comment = github_client.add_comment_to_issue.call_args.args[2]
+        assert "12 hours" in comment
+        assert "sess-1" in comment
+
+    def test_session_within_timeout_is_left_alone(self, config):
+        """A session that is still within the timeout keeps working on the issue."""
+        github_client = _github_client()
+
+        result, jules_client, take_actions, mark_stopped = self._run(
+            [_session("sess-1", age_hours=11)],
+            github_client,
+            config,
+        )
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        mark_stopped.assert_not_called()
+        assert result.issue_numbers == []
+        assert result.actions == []
+
+    def test_session_with_pull_request_is_left_alone(self, config):
+        """A session that already produced a PR is never stopped."""
+        github_client = _github_client()
+        session = _session("sess-1", age_hours=48, outputs={"pullRequest": {"url": "https://github.com/owner/repo/pull/7"}})
+
+        result, jules_client, take_actions, _ = self._run([session], github_client, config)
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_issue_with_linked_pr_is_left_alone(self, config):
+        """A PR linked on GitHub counts even when session outputs do not show it yet."""
+        github_client = _github_client(has_linked_pr=True)
+
+        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_closed_issue_is_left_alone(self, config):
+        """Closed issues are not re-implemented."""
+        github_client = _github_client(state="closed")
+
+        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_already_stopped_session_is_not_handled_twice(self, config):
+        """A session that was already stopped is skipped on the next run."""
+        github_client = _github_client()
+
+        result, jules_client, take_actions, _ = self._run(
+            [_session("sess-1", age_hours=30)],
+            github_client,
+            config,
+            stopped=True,
+        )
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_pull_request_number_in_cloud_csv_is_skipped(self, config):
+        """cloud.csv also tracks PR sessions; those are not implemented as issues."""
+        github_client = _github_client()
+        github_client.get_issue.return_value = {
+            "number": 42,
+            "title": "A PR",
+            "state": "open",
+            "pull_request": {"url": "https://github.com/owner/repo/pull/42"},
+        }
+
+        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_failed_stop_message_does_not_delegate(self, config):
+        """When Jules rejects the stop message the issue stays with Jules."""
+        github_client = _github_client()
+        jules_client = MagicMock()
+        jules_client.list_sessions.return_value = [_session("sess-1", age_hours=13)]
+        jules_client.send_message.side_effect = RuntimeError("HTTP 500")
+
+        cloud_manager = MagicMock()
+        cloud_manager.get_issue_by_session.return_value = 42
+
+        take_actions = MagicMock(return_value=[])
+
+        with (
+            patch("src.auto_coder.issue_processor.JulesClient", return_value=jules_client),
+            patch("src.auto_coder.issue_processor.CloudManager", return_value=cloud_manager),
+            patch("src.auto_coder.issue_processor.is_session_stopped", return_value=False),
+            patch("src.auto_coder.issue_processor.mark_session_stopped") as mark_stopped,
+            patch("src.auto_coder.issue_processor._take_issue_actions", take_actions),
+        ):
+            result = handle_stale_jules_issue_sessions("owner/repo", config, github_client)
+
+        mark_stopped.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+    def test_no_session_for_issue_is_skipped(self, config):
+        """Sessions without a tracked issue number are ignored."""
+        github_client = _github_client()
+
+        result, jules_client, take_actions, _ = self._run(
+            [_session("sess-1", age_hours=13)],
+            github_client,
+            config,
+            issue_number=None,
+        )
+
+        jules_client.send_message.assert_not_called()
+        take_actions.assert_not_called()
+        assert result.issue_numbers == []
+
+
+class TestAutomationEngineHook:
+    """The engine exposes the stale-session hand-over as part of its loop."""
+
+    def test_engine_delegates_and_returns_actions(self, config):
+        from src.auto_coder.automation_config import StaleJulesIssueResult
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        github_client = MagicMock()
+        engine = AutomationEngine(github_client, config=config)
+
+        stale_result = StaleJulesIssueResult(actions=["Stopped Jules session 's1' for issue #42"], issue_numbers=[42])
+
+        with patch("src.auto_coder.issue_processor.handle_stale_jules_issue_sessions", return_value=stale_result) as mock_handle:
+            actions = engine.handle_stale_jules_issue_sessions("owner/repo")
+
+        mock_handle.assert_called_once_with("owner/repo", config, github_client)
+        assert actions == stale_result.actions
+
+    def test_engine_swallows_errors(self, config):
+        from src.auto_coder.automation_engine import AutomationEngine
+
+        engine = AutomationEngine(MagicMock(), config=config)
+
+        with patch("src.auto_coder.issue_processor.handle_stale_jules_issue_sessions", side_effect=RuntimeError("boom")):
+            assert engine.handle_stale_jules_issue_sessions("owner/repo") == []

--- a/tests/test_jules_engine.py
+++ b/tests/test_jules_engine.py
@@ -3,9 +3,14 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from auto_coder.jules_engine import (
+    SESSION_STATE_STOPPED,
     check_and_restart_recurrent_jules_task_for_pr,
     check_and_resume_or_archive_sessions,
     check_and_start_recurrent_jules_tasks,
+    get_session_pull_request,
+    is_session_stopped,
+    mark_session_stopped,
+    normalize_session_outputs,
 )
 
 
@@ -701,3 +706,56 @@ This is a recurrent task prompt."""
         # Verify
         mock_github_client.get_pull_request.assert_called_once_with("owner/repo", 123)
         mock_jules_client.start_session.assert_called_once()
+
+
+class TestJulesStoppedSessions(unittest.TestCase):
+    """Tests for sessions stopped after failing to create a PR in time."""
+
+    @patch("auto_coder.jules_engine.JulesClient")
+    @patch("auto_coder.jules_engine.GitHubClient")
+    @patch("auto_coder.jules_engine._load_state")
+    @patch("auto_coder.jules_engine._save_state")
+    def test_stopped_session_is_not_resumed(self, mock_save_state, mock_load_state, mock_github_client_cls, mock_jules_client_cls):
+        mock_jules_client = mock_jules_client_cls.return_value
+        mock_jules_client.list_sessions.return_value = [{"name": "projects/p/locations/l/sessions/s9", "state": "FAILED", "automationMode": "AUTO_CREATE_PR"}]
+        mock_load_state.return_value = {"s9": SESSION_STATE_STOPPED}
+
+        check_and_resume_or_archive_sessions()
+
+        mock_jules_client.send_message.assert_not_called()
+        mock_save_state.assert_not_called()
+
+    @patch("auto_coder.jules_engine._load_state")
+    @patch("auto_coder.jules_engine._save_state")
+    def test_mark_and_check_stopped_state(self, mock_save_state, mock_load_state):
+        mock_load_state.return_value = {"other": 2}
+
+        mark_session_stopped("s9")
+        mock_save_state.assert_called_once_with({"other": 2, "s9": SESSION_STATE_STOPPED})
+
+        mock_load_state.return_value = {"s9": SESSION_STATE_STOPPED}
+        self.assertTrue(is_session_stopped("s9"))
+
+        mock_load_state.return_value = {"s9": 1}
+        self.assertFalse(is_session_stopped("s9"))
+
+
+class TestNormalizeSessionOutputs(unittest.TestCase):
+    """Tests for Jules session output normalization."""
+
+    def test_dict_outputs_pass_through(self):
+        self.assertEqual(normalize_session_outputs({"pullRequest": {"number": 1}}), {"pullRequest": {"number": 1}})
+
+    def test_list_of_dicts_is_merged(self):
+        self.assertEqual(normalize_session_outputs([{"a": 1}, {"b": 2}]), {"a": 1, "b": 2})
+
+    def test_list_of_pairs_is_merged(self):
+        self.assertEqual(normalize_session_outputs([("a", 1), ["b", 2]]), {"a": 1, "b": 2})
+
+    def test_unsupported_type_returns_empty_dict(self):
+        self.assertEqual(normalize_session_outputs("nonsense"), {})
+
+    def test_get_session_pull_request_supports_both_keys(self):
+        self.assertEqual(get_session_pull_request({"outputs": {"pullRequest": "url-1"}}), "url-1")
+        self.assertEqual(get_session_pull_request({"outputs": [{"pull_request": "url-2"}]}), "url-2")
+        self.assertIsNone(get_session_pull_request({"outputs": {}}))

--- a/tests/test_jules_timeout_config.py
+++ b/tests/test_jules_timeout_config.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.auto_coder.automation_config import AutomationConfig
-from src.auto_coder.llm_backend_config import get_jules_wait_timeout_hours_from_config
+from src.auto_coder.llm_backend_config import get_jules_issue_pr_timeout_hours_from_config, get_jules_wait_timeout_hours_from_config
 
 
 class TestJulesTimeoutConfig:
@@ -68,3 +68,40 @@ class TestJulesTimeoutConfig:
         with patch("src.auto_coder.llm_backend_config.get_jules_wait_timeout_hours_from_config", return_value=8):
             config = AutomationConfig()
             assert config.JULES_WAIT_TIMEOUT_HOURS == 8
+
+
+class TestJulesIssuePRTimeoutConfig:
+    """Tests for the Jules issue-to-PR timeout configuration."""
+
+    def test_get_timeout_default(self):
+        """Default is 12 hours when no config exists."""
+        with patch("os.path.exists", return_value=False):
+            assert get_jules_issue_pr_timeout_hours_from_config() == 12
+
+    def test_get_timeout_from_file_explicit(self):
+        """Reads [jules].issue_pr_timeout_hours from an explicit config file."""
+        config_content = b"""
+        [jules]
+        issue_pr_timeout_hours = 6
+        """
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as f:
+            f.write(config_content)
+            config_path = f.name
+
+        try:
+            assert get_jules_issue_pr_timeout_hours_from_config(config_path) == 6
+        finally:
+            if os.path.exists(config_path):
+                os.remove(config_path)
+
+    def test_automation_config_integration(self):
+        """AutomationConfig picks up the configured value."""
+        with patch("src.auto_coder.llm_backend_config.get_jules_issue_pr_timeout_hours_from_config", return_value=24):
+            config = AutomationConfig()
+            assert config.JULES_ISSUE_PR_TIMEOUT_HOURS == 24
+
+    def test_automation_config_default(self):
+        """AutomationConfig defaults to 12 hours."""
+        with patch("os.path.exists", return_value=False):
+            config = AutomationConfig()
+            assert config.JULES_ISSUE_PR_TIMEOUT_HOURS == 12


### PR DESCRIPTION
## Summary

When a Jules session has been working on an issue for longer than `[jules].issue_pr_timeout_hours` (default: 12) without opening a pull request, Auto-Coder now sends a `stop` message to the Jules session and implements the issue with the `backend_with_high_score` backend instead.

## Changes

- **`issue_processor.handle_stale_jules_issue_sessions()`** (new): lists Jules sessions for the repo, and for each session that is older than the timeout and has no PR:
  1. sends `stop` to the Jules session and records it as stopped,
  2. comments on the issue explaining the hand-over,
  3. removes the `@auto-coder` label the Jules run left on the issue (otherwise the label gate would skip it),
  4. implements the issue via `_take_issue_actions` using `create_high_score_backend_manager()`.
- **`AutomationEngine.handle_stale_jules_issue_sessions()`**: runs once per iteration of both the async producer loop and the synchronous `run()` loop, right after the session resume/archive pass.
- **Backend threading**: `_take_issue_actions` and `_apply_issue_actions_directly` accept an optional `backend_manager`, defaulting to the current LLM backend manager.
- **State**: stopped sessions are stored in `.auto-coder/jules_session_state.json` with a new `SESSION_STATE_STOPPED` sentinel, so they are neither resumed by `check_and_resume_or_archive_sessions` nor handed over twice.
- **Config**: `[jules].issue_pr_timeout_hours` (default 12) → `AutomationConfig.JULES_ISSUE_PR_TIMEOUT_HOURS`.
- **Dedup**: extracted `normalize_session_outputs()` / `get_session_pull_request()` in `jules_engine` and reused them in `jules_engine` (2 sites) and `pr_processor`.

Sessions that already produced a PR, issues that already have a linked PR on GitHub, closed issues, and PR-bound sessions tracked in `cloud.csv` are never taken away from Jules. If the Jules API rejects the `stop` message, the issue stays with Jules.

## Tests

- `tests/test_issue_processor_jules_stale_sessions.py` (new, 11 tests): stop + hand-over path, timeout boundary, session with PR, issue with linked PR, closed issue, already-stopped session, PR-numbered cloud.csv entry, failed stop message, missing session mapping, and the engine hook.
- `tests/test_jules_engine.py`: stopped sessions are not resumed, state helpers, and output normalization.
- `tests/test_jules_timeout_config.py`: default / explicit-file / `AutomationConfig` integration for the new timeout.

Lint (black, isort, flake8) and mypy pass via `scripts/test.sh`.

## Docs

`docs/client-features.yaml`, `README.md`, and the `process_issues` activity diagrams describe the new behavior and config key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZ3ixLYAuGrttsDVJVgmPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ3ixLYAuGrttsDVJVgmPX)_