### PR TITLE
Increment attempt and keep @auto-coder label on Jules timeout fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,7 +906,9 @@ backend_type = "jules"
 
 When a Jules session works on an issue for longer than `[jules].issue_pr_timeout_hours`
 (default: 12) without opening a pull request, Auto-Coder sends a `stop` message to the
-session and implements the issue with the `backend_with_high_score` backend instead:
+session, increments the attempt counter of the issue, and implements the issue with the
+`backend_with_high_score` backend instead. The `@auto-coder` label stays on the issue for
+the whole hand-over so no other instance starts working on it in parallel:
 
 ```toml
 # config.toml

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -389,7 +389,8 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
       - "The session-to-issue mapping comes from cloud.csv; sessions tracked against a PR number are ignored by this rule."
       - "Sessions whose outputs already contain a pullRequest, and issues that already have a linked PR on GitHub, are never stopped."
       - "Closed issues are skipped, and a session that fails to accept the stop message keeps the issue."
-      - "The @auto-coder label the Jules run left on the issue is removed before the fallback implementation runs, otherwise the label gate would skip the issue."
+      - "The attempt counter of the issue is incremented, so the fallback starts from a fresh attempt branch instead of the one the Jules run left behind."
+      - "The @auto-coder label the Jules run left on the issue is kept in place so no other instance picks the issue up while the fallback works on it; the fallback run passes check_labels=False so the label gate does not skip the issue it already owns."
       - "Stopped sessions are recorded in .auto-coder/jules_session_state.json so they are neither resumed nor handed over twice."
       - "The check runs once per producer/run loop iteration, right after the Jules session resume/archive pass."
     label_locking:
@@ -494,7 +495,7 @@ Recent configuration schema changes that require migration:
     fallback:
       - "PR failures that cannot be auto-merged (LLM CANNOT_FIX/unclear output, commit/push errors, failed merges or conflict resolution) trigger attempt increments for every linked issue."
       - "Jules PRs that still have failing CI more than [jules].pr_ci_timeout_hours (default 12) after PR creation are closed, and the attempt counter of the linked issue is incremented so the issue is retried from scratch."
-      - "Jules sessions that do not open a PR within [jules].issue_pr_timeout_hours (default 12) are stopped, and the issue is implemented by the backend_with_high_score backend instead."
+      - "Jules sessions that do not open a PR within [jules].issue_pr_timeout_hours (default 12) are stopped, the attempt counter of the issue is incremented, and the issue is implemented by the backend_with_high_score backend instead."
       - "Conflict resolver fallbacks do the same when LLM-based conflict handling leaves unresolved markers or cannot push a clean merge."
       - "When attempt count reaches 3 for any linked issue, the system automatically switches to the configured fallback backend (see [backend_with_high_score] configuration)."
       - "Backend fallback provides a fresh perspective using a different LLM after multiple failed attempts, improving chances of successful PR resolution."

--- a/src/auto_coder/issue_processor.py
+++ b/src/auto_coder/issue_processor.py
@@ -12,7 +12,7 @@ from dateutil import parser
 from auto_coder.util.gh_cache import get_ghapi_client
 from auto_coder.util.github_action import _check_github_actions_status, check_and_handle_closed_state, check_github_actions_and_exit_if_in_progress, get_detailed_checks_from_history
 
-from .attempt_manager import get_current_attempt
+from .attempt_manager import get_current_attempt, increment_attempt
 from .automation_config import AutomationConfig, ProcessedIssueResult, ProcessResult, StaleJulesIssueResult
 from .backend_manager import BackendManager, get_llm_backend_manager, parse_llm_output_as_json, run_llm_noedit_prompt
 from .branch_manager import BranchManager
@@ -357,12 +357,16 @@ def _take_issue_actions(
     config: AutomationConfig,
     github_client: GitHubClient,
     backend_manager: Optional[BackendManager] = None,
+    check_labels: Optional[bool] = None,
 ) -> List[str]:
     """Take actions on an issue using direct LLM CLI analysis and implementation.
 
     Args:
         backend_manager: Backend manager used for the implementation run.
             Defaults to the current LLM backend manager.
+        check_labels: Whether an existing @auto-coder label blocks processing.
+            Defaults to ``config.CHECK_LABELS``. Pass False when this run already
+            owns the label and must keep it in place.
     """
     actions = []
     issue_number = issue_data["number"]
@@ -398,6 +402,7 @@ def _take_issue_actions(
                 config,
                 github_client,
                 backend_manager=backend_manager,
+                check_labels=check_labels,
             )
             actions.extend(action_results)
 
@@ -727,11 +732,14 @@ def handle_stale_jules_issue_sessions(
                 details={"session_id": session_id, "timeout_hours": timeout_hours},
             )
 
-            # Release the @auto-coder label so the issue can be processed again
-            from .pr_processor import _release_issue_processing_label
-
-            if _release_issue_processing_label(github_client, repo_name, issue_number, config):
-                result.actions.append(f"Removed {config.AUTO_CODER_LABEL} label from issue #{issue_number}")
+            # The abandoned Jules run counts as a failed attempt, so the fallback starts
+            # from a fresh attempt branch instead of the one Jules left behind.
+            try:
+                new_attempt = increment_attempt(repo_name, issue_number)
+                result.actions.append(f"Incremented attempt for issue #{issue_number} to {new_attempt}")
+            except Exception as e:
+                logger.error(f"Failed to increment attempt for issue #{issue_number}: {e}")
+                result.actions.append(f"Failed to increment attempt for issue #{issue_number}: {e}")
 
             from .cli_helpers import create_high_score_backend_manager
 
@@ -739,6 +747,10 @@ def handle_stale_jules_issue_sessions(
             if backend_manager is None:
                 logger.warning("backend_with_high_score is not configured; using the default backend for the Jules fallback")
 
+            # The @auto-coder label the Jules run left on the issue is kept so no other
+            # instance picks the issue up while the fallback is working on it. Passing
+            # check_labels=False makes the label gate let this run through instead of
+            # skipping the issue it already owns.
             result.actions.extend(
                 _take_issue_actions(
                     repo_name,
@@ -746,6 +758,7 @@ def handle_stale_jules_issue_sessions(
                     config,
                     github_client,
                     backend_manager=backend_manager,
+                    check_labels=False,
                 )
             )
             result.issue_numbers.append(issue_number)
@@ -937,12 +950,16 @@ def _apply_issue_actions_directly(
     config: AutomationConfig,
     github_client: GitHubClient,
     backend_manager: Optional[BackendManager] = None,
+    check_labels: Optional[bool] = None,
 ) -> List[str]:
     """Ask LLM CLI to analyze an issue and take appropriate actions directly.
 
     Args:
         backend_manager: Backend manager used for the implementation run.
             Defaults to the current LLM backend manager.
+        check_labels: Whether an existing @auto-coder label blocks processing.
+            Defaults to ``config.CHECK_LABELS``. Pass False when this run already
+            owns the label and must keep it in place.
     """
     issue_number = issue_data.get("number", "unknown")
     actions = []
@@ -1089,7 +1106,7 @@ def _apply_issue_actions_directly(
             issue_number,
             item_type="issue",
             config=config,
-            check_labels=config.CHECK_LABELS,
+            check_labels=config.CHECK_LABELS if check_labels is None else check_labels,
             known_labels=issue_data.get("labels"),
         ) as should_process:
             if not should_process:

--- a/tests/test_issue_processor_jules_stale_sessions.py
+++ b/tests/test_issue_processor_jules_stale_sessions.py
@@ -69,7 +69,7 @@ class TestHandleStaleJulesIssueSessions:
             patch("src.auto_coder.issue_processor.is_session_stopped", return_value=stopped),
             patch("src.auto_coder.issue_processor.mark_session_stopped") as mark_stopped,
             patch("src.auto_coder.issue_processor._take_issue_actions", take_actions),
-            patch("src.auto_coder.pr_processor._release_issue_processing_label", return_value=True),
+            patch("src.auto_coder.issue_processor.increment_attempt", return_value=3) as increment,
             patch(
                 "src.auto_coder.cli_helpers.create_high_score_backend_manager",
                 return_value=backend_manager,
@@ -77,14 +77,14 @@ class TestHandleStaleJulesIssueSessions:
         ):
             result = handle_stale_jules_issue_sessions("owner/repo", config, github_client)
 
-        return result, jules_client, take_actions, mark_stopped
+        return result, jules_client, take_actions, mark_stopped, increment
 
     def test_stops_session_and_delegates_to_high_score_backend(self, config):
         """A session older than the timeout without a PR is stopped and handed over."""
         github_client = _github_client()
         backend_manager = MagicMock()
 
-        result, jules_client, take_actions, mark_stopped = self._run(
+        result, jules_client, take_actions, mark_stopped, increment = self._run(
             [_session("sess-1", age_hours=13)],
             github_client,
             config,
@@ -100,6 +100,15 @@ class TestHandleStaleJulesIssueSessions:
         assert take_actions.call_args.args[0] == "owner/repo"
         assert "Implemented issue #42" in result.actions
 
+        # The abandoned Jules run counts as a failed attempt
+        increment.assert_called_once_with("owner/repo", 42)
+        assert "Incremented attempt for issue #42 to 3" in result.actions
+
+        # The @auto-coder label stays on the issue so no other instance picks it up,
+        # and the label gate must not skip the fallback run because of it
+        assert take_actions.call_args.kwargs["check_labels"] is False
+        github_client.remove_labels.assert_not_called()
+
         # The issue gets a comment explaining the hand-over
         github_client.add_comment_to_issue.assert_called_once()
         comment = github_client.add_comment_to_issue.call_args.args[2]
@@ -110,7 +119,7 @@ class TestHandleStaleJulesIssueSessions:
         """A session that is still within the timeout keeps working on the issue."""
         github_client = _github_client()
 
-        result, jules_client, take_actions, mark_stopped = self._run(
+        result, jules_client, take_actions, mark_stopped, increment = self._run(
             [_session("sess-1", age_hours=11)],
             github_client,
             config,
@@ -119,6 +128,7 @@ class TestHandleStaleJulesIssueSessions:
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
         mark_stopped.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
         assert result.actions == []
 
@@ -127,37 +137,40 @@ class TestHandleStaleJulesIssueSessions:
         github_client = _github_client()
         session = _session("sess-1", age_hours=48, outputs={"pullRequest": {"url": "https://github.com/owner/repo/pull/7"}})
 
-        result, jules_client, take_actions, _ = self._run([session], github_client, config)
+        result, jules_client, take_actions, _, increment = self._run([session], github_client, config)
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_issue_with_linked_pr_is_left_alone(self, config):
         """A PR linked on GitHub counts even when session outputs do not show it yet."""
         github_client = _github_client(has_linked_pr=True)
 
-        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+        result, jules_client, take_actions, _, increment = self._run([_session("sess-1", age_hours=13)], github_client, config)
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_closed_issue_is_left_alone(self, config):
         """Closed issues are not re-implemented."""
         github_client = _github_client(state="closed")
 
-        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+        result, jules_client, take_actions, _, increment = self._run([_session("sess-1", age_hours=13)], github_client, config)
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_already_stopped_session_is_not_handled_twice(self, config):
         """A session that was already stopped is skipped on the next run."""
         github_client = _github_client()
 
-        result, jules_client, take_actions, _ = self._run(
+        result, jules_client, take_actions, _, increment = self._run(
             [_session("sess-1", age_hours=30)],
             github_client,
             config,
@@ -166,6 +179,7 @@ class TestHandleStaleJulesIssueSessions:
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_pull_request_number_in_cloud_csv_is_skipped(self, config):
@@ -178,10 +192,11 @@ class TestHandleStaleJulesIssueSessions:
             "pull_request": {"url": "https://github.com/owner/repo/pull/42"},
         }
 
-        result, jules_client, take_actions, _ = self._run([_session("sess-1", age_hours=13)], github_client, config)
+        result, jules_client, take_actions, _, increment = self._run([_session("sess-1", age_hours=13)], github_client, config)
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_failed_stop_message_does_not_delegate(self, config):
@@ -202,18 +217,20 @@ class TestHandleStaleJulesIssueSessions:
             patch("src.auto_coder.issue_processor.is_session_stopped", return_value=False),
             patch("src.auto_coder.issue_processor.mark_session_stopped") as mark_stopped,
             patch("src.auto_coder.issue_processor._take_issue_actions", take_actions),
+            patch("src.auto_coder.issue_processor.increment_attempt") as increment,
         ):
             result = handle_stale_jules_issue_sessions("owner/repo", config, github_client)
 
         mark_stopped.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
     def test_no_session_for_issue_is_skipped(self, config):
         """Sessions without a tracked issue number are ignored."""
         github_client = _github_client()
 
-        result, jules_client, take_actions, _ = self._run(
+        result, jules_client, take_actions, _, increment = self._run(
             [_session("sess-1", age_hours=13)],
             github_client,
             config,
@@ -222,6 +239,7 @@ class TestHandleStaleJulesIssueSessions:
 
         jules_client.send_message.assert_not_called()
         take_actions.assert_not_called()
+        increment.assert_not_called()
         assert result.issue_numbers == []
 
 
@@ -250,3 +268,61 @@ class TestAutomationEngineHook:
 
         with patch("src.auto_coder.issue_processor.handle_stale_jules_issue_sessions", side_effect=RuntimeError("boom")):
             assert engine.handle_stale_jules_issue_sessions("owner/repo") == []
+
+
+class TestLabelGateOverride:
+    """The fallback run keeps the label it inherited and is not blocked by it."""
+
+    def _cmd_result(self, success=True, stdout="", stderr="", returncode=0):
+        result = MagicMock()
+        result.success = success
+        result.stdout = stdout
+        result.stderr = stderr
+        result.returncode = returncode
+        return result
+
+    def _run_with_label_manager(self, check_labels):
+        from contextlib import contextmanager
+
+        from src.auto_coder.issue_processor import _apply_issue_actions_directly
+
+        captured = {}
+
+        @contextmanager
+        def fake_label_manager(*args, **kwargs):
+            captured.update(kwargs)
+            yield False  # stop right after the label gate
+
+        @contextmanager
+        def fake_branch_context(*_args, **_kwargs):
+            yield
+
+        github_client = MagicMock()
+        github_client.get_parent_issue_details.return_value = None
+        github_client.get_all_sub_issues.return_value = []
+
+        with (
+            patch("src.auto_coder.issue_processor.cmd") as mock_cmd,
+            patch("src.auto_coder.issue_processor.LabelManager", fake_label_manager),
+            patch("src.auto_coder.issue_processor.BranchManager", fake_branch_context),
+            patch("src.auto_coder.issue_processor.get_current_branch", return_value="main"),
+            patch("src.auto_coder.issue_processor.get_current_attempt", return_value=2),
+        ):
+            mock_cmd.run_command.return_value = self._cmd_result(success=True)
+            _apply_issue_actions_directly(
+                "owner/repo",
+                {"number": 4636, "title": "Test Issue"},
+                AutomationConfig(),
+                github_client,
+                check_labels=check_labels,
+            )
+
+        return captured
+
+    def test_check_labels_override_reaches_label_manager(self):
+        """check_labels=False lets the run through the gate it already owns."""
+        assert self._run_with_label_manager(check_labels=False)["check_labels"] is False
+
+    def test_check_labels_defaults_to_config(self):
+        """Without an override the configured behaviour is unchanged."""
+        assert self._run_with_label_manager(check_labels=None)["check_labels"] == AutomationConfig().CHECK_LABELS


### PR DESCRIPTION
Follow-up to #1537, fixing two problems observed in production logs for issue #4636 of `kitamura-tetsuo/outliner`.

## Problems

1. **The attempt counter was not incremented.** The fallback reused the attempt branch the dead Jules run left behind (`issue-4636_attempt-2`) instead of starting a fresh attempt.
2. **The fallback never started.** The `@auto-coder` label was removed to get past the label gate, but `_apply_issue_actions_directly` re-enters `LabelManager`, which re-added the label and then skipped the issue:

   ```
   label_manager.py:470 - Skipping issue #4636 - '@auto-coder' label already exists
   ```

   Removing the label also opened a window where another instance could pick the issue up.

## Changes

- `handle_stale_jules_issue_sessions` calls `increment_attempt` before delegating, so the abandoned Jules run counts as a failed attempt and the fallback works on a new attempt branch.
- The `@auto-coder` label is now **kept** on the issue for the whole hand-over (the `_release_issue_processing_label` call is gone), preventing duplicate execution.
- `_take_issue_actions` and `_apply_issue_actions_directly` gained an optional `check_labels` override (defaults to `config.CHECK_LABELS`). The fallback passes `check_labels=False`, which makes `LabelManager` process the issue despite the existing label and leave the label untouched on exit — the same semantics already used for `--only` and WIP-branch resume.

## Tests

- New: attempt increment is asserted on the hand-over path and asserted *not* to happen on every skip path (within timeout, PR already exists, linked PR, closed issue, already-stopped session, PR-bound cloud.csv entry, failed stop message, no tracked issue).
- New: the hand-over passes `check_labels=False` and never calls `remove_labels`.
- New: `_apply_issue_actions_directly` propagates the `check_labels` override to `LabelManager`, and defaults to `config.CHECK_LABELS` when not given.
- `tests/test_issue_processor_jules_stale_sessions.py`: 13 passed. Wider run over issue-processor, jules-engine, label-manager and attempt-manager tests: 251 passed, 3 failed — all three failures (`test_parent_issue_branch_creation_uses_main_base`, `TestCreatePRForParentIssue::test_create_pr_for_parent_issue_new_branch`, `TestCreatePRForParentIssue::test_create_pr_for_parent_issue_with_attempt_branch`) reproduce identically on `origin/main` with these changes reverted, and are unrelated to this diff.
- black / isort / flake8 / mypy clean.

## Docs

`docs/client-features.yaml` and `README.md` updated to describe the attempt increment and the label-retention behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ3ixLYAuGrttsDVJVgmPX)_