### PR TITLE
perf(jules): fetch the Jules session listing only once per automation loop

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -393,6 +393,12 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
       - "The @auto-coder label the Jules run left on the issue is kept in place so no other instance picks the issue up while the fallback works on it; the fallback run passes check_labels=False so the label gate does not skip the issue it already owns."
       - "Stopped sessions are recorded in .auto-coder/jules_session_state.json so they are neither resumed nor handed over twice."
       - "The check runs once per producer/run loop iteration, right after the Jules session resume/archive pass."
+    session_listing_cache:
+      - "Listing Jules sessions walks the whole paginated /sessions collection, which takes minutes once a repository accumulates thousands of sessions."
+      - "The raw (unfiltered) listing is cached process-wide in jules_client, so every list_sessions call shares a single HTTP fetch regardless of the JulesClient instance or the repo_name filter used."
+      - "Repository and ARCHIVED filtering still happens client-side on each call, so callers keep receiving their own filtered view."
+      - "The producer/run loop calls invalidate_jules_sessions_cache() once per iteration, immediately before the Jules resume/archive, stale-issue, and recurrent-task passes: exactly one listing request per loop iteration."
+      - "A failed listing is never cached, so the next call retries the fetch."
     label_locking:
       - "Jules mode keeps the @auto-coder label on an issue for the lifetime of its session, so an aborted session would otherwise lock the issue permanently."
       - "With check_labels=False (--only and WIP-branch resume) an existing @auto-coder label no longer blocks processing; the label is left in place because the run does not own it."

--- a/src/auto_coder/automation_engine.py
+++ b/src/auto_coder/automation_engine.py
@@ -17,6 +17,7 @@ from .git_commit import git_push
 from .git_info import get_current_branch
 from .issue_context import get_linked_issues_context
 from .issue_processor import create_feature_issues
+from .jules_client import invalidate_jules_sessions_cache
 from .jules_engine import check_and_resume_or_archive_sessions, check_and_start_recurrent_jules_tasks
 from .label_manager import LabelManager
 from .llm_backend_config import get_process_issues_empty_sleep_time_from_config, get_process_issues_sleep_time_from_config
@@ -114,6 +115,9 @@ class AutomationEngine:
             try:
                 # Check updates
                 await asyncio.to_thread(check_for_updates_and_restart)
+
+                # Fetch the Jules session listing at most once per loop iteration
+                invalidate_jules_sessions_cache()
 
                 # Resume sessions
                 await asyncio.to_thread(check_and_resume_or_archive_sessions, repo_name)
@@ -1056,6 +1060,9 @@ class AutomationEngine:
             while True:
                 # Check for updates and restart if necessary
                 check_for_updates_and_restart()
+
+                # Fetch the Jules session listing at most once per loop iteration
+                invalidate_jules_sessions_cache()
 
                 # Check and resume failed Jules sessions
                 check_and_resume_or_archive_sessions()

--- a/src/auto_coder/jules_client.py
+++ b/src/auto_coder/jules_client.py
@@ -6,8 +6,10 @@ This client uses HTTP API instead of Jules CLI to communicate with Jules.
 """
 
 import json
+import threading
 import time
 import uuid
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import requests  # type: ignore
@@ -19,6 +21,34 @@ from .llm_client_base import LLMClientBase
 from .logger_config import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class _SessionListCache:
+    """Process-wide cache holding the sessions fetched by ``list_sessions``.
+
+    Listing every Jules session requires walking the whole paginated collection,
+    which takes minutes once a repository accumulates a thousand sessions. The
+    automation loop needs that listing several times per iteration, so the raw
+    (unfiltered) result is cached here and reused until the loop explicitly
+    invalidates it via :func:`invalidate_jules_sessions_cache`.
+    """
+
+    sessions: Optional[List[Dict[str, Any]]] = None
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_session_list_cache = _SessionListCache()
+
+
+def invalidate_jules_sessions_cache() -> None:
+    """Drop the cached Jules session listing so the next call refetches it.
+
+    Call this once per automation loop iteration: every ``list_sessions`` call
+    within the same iteration then shares a single HTTP fetch.
+    """
+    with _session_list_cache.lock:
+        _session_list_cache.sessions = None
 
 
 class JulesClient(LLMClientBase):
@@ -125,6 +155,63 @@ class JulesClient(LLMClientBase):
             logger.error(f"Failed to start Jules session: {e}")
             raise RuntimeError(f"Failed to start Jules session: {e}")
 
+    def _fetch_all_sessions(self, page_size: int) -> List[Dict[str, Any]]:
+        """Fetch every Jules session by walking the paginated collection."""
+        url = f"{self.base_url}/sessions"
+
+        # Note: The API does not support server-side filtering for 'state' or 'source'.
+        # We must fetch sessions and filter them client-side.
+        base_params = {
+            "pageSize": page_size,
+        }
+
+        all_sessions: List[Dict[str, Any]] = []
+        page_token = None
+
+        while True:
+            params = base_params.copy()
+            if page_token:
+                params["pageToken"] = page_token
+
+            logger.debug(f"🤖 GET {url} (pageToken={page_token if page_token else 'None'})")
+
+            response = self.session.get(url, params=params, timeout=self.timeout)
+
+            # Check if request was successful
+            if response.status_code != 200:
+                error_msg = f"HTTP {response.status_code}: {response.text}"
+                logger.error(f"Failed to list Jules sessions: {error_msg}")
+                raise RuntimeError(f"Failed to list Jules sessions: {error_msg}")
+
+            # Parse the response
+            try:
+                response_data = response.json()
+                sessions = response_data.get("sessions", [])
+                all_sessions.extend(sessions)
+
+                # Check for next page
+                page_token = response_data.get("nextPageToken")
+                if not page_token:
+                    break
+
+            except json.JSONDecodeError:
+                logger.error("Failed to parse Jules sessions response as JSON")
+                break
+
+        return all_sessions
+
+    def _get_all_sessions(self, page_size: int) -> List[Dict[str, Any]]:
+        """Return every Jules session, fetching them only once per loop iteration."""
+        with _session_list_cache.lock:
+            if _session_list_cache.sessions is not None:
+                logger.debug(f"Reusing cached Jules session listing ({len(_session_list_cache.sessions)} sessions)")
+                return _session_list_cache.sessions
+
+            logger.info(f"Listing Jules sessions (pageSize={page_size})")
+            all_sessions = self._fetch_all_sessions(page_size)
+            _session_list_cache.sessions = all_sessions
+            return all_sessions
+
     def list_sessions(self, repo_name: Optional[str] = None, page_size: int = 20) -> List[Dict[str, Any]]:
         """List recent Jules sessions, optionally filtered by repository.
 
@@ -136,49 +223,7 @@ class JulesClient(LLMClientBase):
             List of session dictionaries
         """
         try:
-            # Prepare the request
-            url = f"{self.base_url}/sessions"
-
-            # Note: The API does not support server-side filtering for 'state' or 'source'.
-            # We must fetch sessions and filter them client-side.
-            base_params = {
-                "pageSize": page_size,
-            }
-
-            logger.info(f"Listing Jules sessions (pageSize={page_size}, repo_name={repo_name})")
-
-            all_sessions = []
-            page_token = None
-
-            while True:
-                params = base_params.copy()
-                if page_token:
-                    params["pageToken"] = page_token
-
-                logger.debug(f"🤖 GET {url} (pageToken={page_token if page_token else 'None'})")
-
-                response = self.session.get(url, params=params, timeout=self.timeout)
-
-                # Check if request was successful
-                if response.status_code != 200:
-                    error_msg = f"HTTP {response.status_code}: {response.text}"
-                    logger.error(f"Failed to list Jules sessions: {error_msg}")
-                    raise RuntimeError(f"Failed to list Jules sessions: {error_msg}")
-
-                # Parse the response
-                try:
-                    response_data = response.json()
-                    sessions = response_data.get("sessions", [])
-                    all_sessions.extend(sessions)
-
-                    # Check for next page
-                    page_token = response_data.get("nextPageToken")
-                    if not page_token:
-                        break
-
-                except json.JSONDecodeError:
-                    logger.error("Failed to parse Jules sessions response as JSON")
-                    break
+            all_sessions = self._get_all_sessions(page_size)
 
             # Filter sessions client-side
             filtered_sessions = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ if str(_src_path) not in sys.path:
 from src.auto_coder.automation_engine import AutomationEngine
 from src.auto_coder.backend_manager import LLMBackendManager, get_llm_backend_manager
 from src.auto_coder.gemini_client import GeminiClient
+from src.auto_coder.jules_client import invalidate_jules_sessions_cache
 from src.auto_coder.llm_backend_config import reset_llm_config
 from src.auto_coder.util.gh_cache import GitHubClient
 
@@ -79,6 +80,14 @@ def _reset_llm_config_singleton():
     reset_llm_config()
     yield
     reset_llm_config()
+
+
+@pytest.fixture(autouse=True)
+def _reset_jules_sessions_cache():
+    """Reset the cached Jules session listing between tests to ensure isolation."""
+    invalidate_jules_sessions_cache()
+    yield
+    invalidate_jules_sessions_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_automation_engine_simple.py
+++ b/tests/test_automation_engine_simple.py
@@ -217,15 +217,18 @@ class TestAutomationEngine:
         with (
             patch("src.auto_coder.automation_engine.check_for_updates_and_restart") as mock_updates,
             patch("src.auto_coder.automation_engine.check_and_resume_or_archive_sessions") as mock_resume,
+            patch("src.auto_coder.automation_engine.invalidate_jules_sessions_cache"),
             patch.object(engine, "_check_and_handle_closed_branch", return_value=True),
+            patch.object(engine, "handle_stale_jules_issue_sessions", return_value=[]),
             patch.object(engine, "check_and_start_recurrent_jules_tasks_async") as mock_recurrent,
         ):
 
-            # Make the mock raise a ValueError to break the infinite loop
-            mock_recurrent.side_effect = ValueError("Stop Loop")
+            # KeyboardInterrupt is not swallowed by the loop's `except Exception`,
+            # so it breaks out of the infinite producer loop.
+            mock_recurrent.side_effect = KeyboardInterrupt("Stop Loop")
 
             # Execute - run producer loop
-            with pytest.raises(ValueError, match="Stop Loop"):
+            with pytest.raises(KeyboardInterrupt):
                 await engine._producer_loop("owner/repo")
 
             # Assertions

--- a/tests/test_jules_client_session_cache.py
+++ b/tests/test_jules_client_session_cache.py
@@ -1,0 +1,130 @@
+"""Tests for the per-loop caching of the Jules session listing."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.auto_coder.automation_config import AutomationConfig
+from src.auto_coder.automation_engine import AutomationEngine
+from src.auto_coder.jules_client import JulesClient, invalidate_jules_sessions_cache
+
+
+def _mock_llm_config(mock_get_config):
+    mock_config = Mock()
+    mock_backend_config = Mock()
+    mock_backend_config.options = []
+    mock_backend_config.options_for_noedit = []
+    mock_backend_config.api_key = None
+    mock_config.get_backend_config.return_value = mock_backend_config
+    mock_get_config.return_value = mock_config
+
+
+def _sessions_response():
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "sessions": [
+            {"name": "sessions/s1", "state": "IN_PROGRESS", "sourceContext": {"source": "sources/github/owner/repo"}},
+            {"name": "sessions/s2", "state": "COMPLETED", "sourceContext": {"source": "sources/github/owner/other"}},
+        ]
+    }
+    return response
+
+
+class TestJulesSessionCache:
+    """The listing is fetched once and reused until explicitly invalidated."""
+
+    @patch("src.auto_coder.jules_client.get_llm_config")
+    @patch("requests.Session.get")
+    def test_repeated_list_sessions_performs_single_fetch(self, mock_get, mock_get_config):
+        _mock_llm_config(mock_get_config)
+        mock_get.side_effect = [_sessions_response()]
+
+        client = JulesClient()
+        first = client.list_sessions(repo_name="owner/repo")
+        second = client.list_sessions(repo_name="owner/repo")
+
+        assert mock_get.call_count == 1
+        assert [s["name"] for s in first] == ["sessions/s1"]
+        assert first == second
+
+    @patch("src.auto_coder.jules_client.get_llm_config")
+    @patch("requests.Session.get")
+    def test_cache_is_shared_between_client_instances(self, mock_get, mock_get_config):
+        _mock_llm_config(mock_get_config)
+        mock_get.side_effect = [_sessions_response()]
+
+        JulesClient().list_sessions(repo_name="owner/repo")
+        JulesClient().list_sessions(repo_name="owner/repo")
+
+        assert mock_get.call_count == 1
+
+    @patch("src.auto_coder.jules_client.get_llm_config")
+    @patch("requests.Session.get")
+    def test_different_repo_filters_reuse_the_same_fetch(self, mock_get, mock_get_config):
+        _mock_llm_config(mock_get_config)
+        mock_get.side_effect = [_sessions_response()]
+
+        client = JulesClient()
+        unfiltered = client.list_sessions()
+        filtered = client.list_sessions(repo_name="owner/other")
+
+        assert mock_get.call_count == 1
+        assert [s["name"] for s in unfiltered] == ["sessions/s1", "sessions/s2"]
+        assert [s["name"] for s in filtered] == ["sessions/s2"]
+
+    @patch("src.auto_coder.jules_client.get_llm_config")
+    @patch("requests.Session.get")
+    def test_invalidation_triggers_a_new_fetch(self, mock_get, mock_get_config):
+        _mock_llm_config(mock_get_config)
+        mock_get.side_effect = [_sessions_response(), _sessions_response()]
+
+        client = JulesClient()
+        client.list_sessions(repo_name="owner/repo")
+        invalidate_jules_sessions_cache()
+        client.list_sessions(repo_name="owner/repo")
+
+        assert mock_get.call_count == 2
+
+    @patch("src.auto_coder.jules_client.get_llm_config")
+    @patch("requests.Session.get")
+    def test_failed_fetch_is_not_cached(self, mock_get, mock_get_config):
+        _mock_llm_config(mock_get_config)
+        error_response = Mock()
+        error_response.status_code = 500
+        error_response.text = "boom"
+        mock_get.side_effect = [error_response, _sessions_response()]
+
+        client = JulesClient()
+        try:
+            client.list_sessions(repo_name="owner/repo")
+            raise AssertionError("Expected RuntimeError")
+        except RuntimeError:
+            pass
+
+        sessions = client.list_sessions(repo_name="owner/repo")
+
+        assert mock_get.call_count == 2
+        assert [s["name"] for s in sessions] == ["sessions/s1"]
+
+
+class TestProducerLoopInvalidatesCache:
+    """The automation loop refreshes the listing exactly once per iteration."""
+
+    @pytest.mark.asyncio
+    async def test_producer_loop_invalidates_cache_before_jules_checks(self, mock_github_client):
+        engine = AutomationEngine(mock_github_client, config=AutomationConfig())
+        calls = []
+
+        with (
+            patch("src.auto_coder.automation_engine.check_for_updates_and_restart"),
+            patch("src.auto_coder.automation_engine.invalidate_jules_sessions_cache", side_effect=lambda: calls.append("invalidate")),
+            patch("src.auto_coder.automation_engine.check_and_resume_or_archive_sessions", side_effect=lambda *_: calls.append("resume")),
+            patch.object(engine, "_check_and_handle_closed_branch", return_value=True),
+            patch.object(engine, "handle_stale_jules_issue_sessions", side_effect=KeyboardInterrupt("Stop Loop")),
+        ):
+            # KeyboardInterrupt is not swallowed by the loop's `except Exception`
+            with pytest.raises(KeyboardInterrupt):
+                await engine._producer_loop("owner/repo")
+
+        assert calls == ["invalidate", "resume"]


### PR DESCRIPTION
## Problem

`JulesClient.list_sessions()` walks the whole paginated `/sessions` collection. With ~1000 sessions and `pageSize=20` that is ~50 sequential HTTP requests and takes minutes:

```
13:04:25 Listing Jules sessions (pageSize=20, repo_name=kitamura-tetsuo/outliner)
13:07:08 Total sessions retrieved: 1006, Filtered: 757
```

Each producer/run loop iteration did this three times: `check_and_resume_or_archive_sessions`, `handle_stale_jules_issue_sessions`, and `check_and_start_recurrent_jules_tasks`.

## Change

- `jules_client` now caches the raw (unfiltered) listing process-wide. `list_sessions()` fetches it only when the cache is empty, then applies the ARCHIVED/repository filtering client-side as before — so callers with different `repo_name` filters still get their own view from one fetch.
- New `invalidate_jules_sessions_cache()` is called once per iteration of both the async producer loop and the synchronous `run()` loop, right before the Jules passes. Result: exactly one listing request per loop iteration instead of three.
- The cache is guarded by a lock, and a failed fetch is not cached, so the next call retries.
- Pagination logic moved unchanged into `_fetch_all_sessions()`.

## Tests

- New `tests/test_jules_client_session_cache.py`: single fetch across repeated calls, sharing across `JulesClient` instances, different repo filters served from one fetch, refetch after invalidation, failed fetch not cached, and the producer loop invalidating before the Jules passes.
- Autouse fixture in `tests/conftest.py` resets the cache between tests.
- `tests/test_automation_engine_simple.py::test_producer_loop_calls_recurrent_jules_tasks` previously hung: its `ValueError` was swallowed by the loop's `except Exception`, and the unpatched stale-session handler hit the real Jules API. It now patches that handler and breaks the loop with `KeyboardInterrupt`.

Lint (black/isort/flake8) and mypy pass. Full `pytest tests/` run was still in progress at the time of push; the Jules and automation-engine suites pass locally.

## Note

Not changed here: the default `pageSize=20` means ~50 round trips per fetch. Raising it (the API generally allows up to 100) would cut the remaining fetch time further, but I left the request shape alone since the reported ask was one listing per loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh39wAwfB3ySYPSJRxBGTK)_