### PR TITLE
feat(conflict-resolver): skip LLM mergeability check for Dependabot PRs

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -577,3 +577,15 @@ Recent configuration schema changes that require migration:
       integration: "Lock check in cli.py before command execution"
       skip_conditions: "Temporary directories (paths containing 'tmp' or 'pytest')"
       storage_format: "JSON file with pid, hostname, and started_at fields"
+
+
+## Merge Conflict Handling
+
+  mergeability_check:
+    description: "Decides whether merging the base branch into a PR would degrade code quality before conflicts are resolved."
+    implementation: "check_mergeability_with_llm in src/auto_coder/conflict_resolver.py"
+    behavior:
+      - "For regular PRs the LLM is asked once and must answer SAFE_TO_MERGE or DEGRADING_MERGE; unclear or missing answers are treated as unsafe."
+      - "Dependency-bot PRs (Dependabot/Renovate/'[bot]' logins, detected via _is_dependabot_pr) skip the LLM entirely and are always treated as safe to merge."
+      - "Skipping the LLM for dependency-bot PRs avoids spending an LLM call on mechanical dependency/lockfile conflicts, which are resolved by the existing lockfile and package.json conflict handling."
+      - "Jules PRs (google-labs-jules[bot]) are not treated as dependency bots and still go through the LLM check."

--- a/src/auto_coder/conflict_resolver.py
+++ b/src/auto_coder/conflict_resolver.py
@@ -190,6 +190,10 @@ def check_mergeability_with_llm(
 ) -> bool:
     """Check if merge can be performed without degrading code quality.
 
+    Dependency-bot PRs (Dependabot/Renovate/'[bot]') never consult the LLM:
+    their conflicts are mechanical dependency/lockfile updates, so they are
+    always treated as safe to merge.
+
     Args:
         pr_data: PR data dictionary
         conflict_info: Merge conflict information
@@ -198,6 +202,12 @@ def check_mergeability_with_llm(
     Returns:
         True if safe to merge, False if merge would degrade code quality
     """
+    from .pr_processor import _is_dependabot_pr
+
+    if _is_dependabot_pr(pr_data):
+        logger.info(f"Skipping LLM mergeability check for dependency-bot PR #{pr_data.get('number')}")
+        return True
+
     try:
         # Get commit log since branch creation
         base_branch = pr_data.get("base_branch") or pr_data.get("baseRefName") or config.MAIN_BRANCH

--- a/tests/test_conflict_resolver.py
+++ b/tests/test_conflict_resolver.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from src.auto_coder.automation_config import AutomationConfig
-from src.auto_coder.conflict_resolver import _extract_session_id_from_pr_body, _perform_base_branch_merge_and_conflict_resolution
+from src.auto_coder.conflict_resolver import _extract_session_id_from_pr_body, _perform_base_branch_merge_and_conflict_resolution, check_mergeability_with_llm
 from src.auto_coder.utils import CommandResult
 
 
@@ -231,3 +231,56 @@ def test_perform_base_merge_closes_jules_pr_recreates_session_on_degrade():
         assert kwargs["repo_name"] == "test/repo"
         assert kwargs["issue_data"]["number"] == 123
         assert kwargs["config"] == config
+
+
+def test_check_mergeability_skips_llm_for_dependabot_pr():
+    """Dependabot PRs must never consult the LLM for mergeability."""
+    config = AutomationConfig()
+
+    with (
+        patch("src.auto_coder.conflict_resolver.run_llm_noedit_prompt") as mock_llm,
+        patch("src.auto_coder.conflict_resolver.create_high_score_backend_manager") as mock_create_backend,
+        patch("src.auto_coder.conflict_resolver.render_prompt") as mock_render_prompt,
+    ):
+        pr_data = {
+            "number": 4242,
+            "title": "Bump requests from 2.31.0 to 2.32.0",
+            "body": "",
+            "author": {"login": "dependabot[bot]"},
+            "baseRefName": "main",
+        }
+
+        assert check_mergeability_with_llm(pr_data, "conflict in uv.lock", config) is True
+
+        mock_llm.assert_not_called()
+        mock_create_backend.assert_not_called()
+        mock_render_prompt.assert_not_called()
+
+
+def test_check_mergeability_uses_llm_for_human_pr():
+    """Non-bot PRs still go through the LLM mergeability check."""
+    config = AutomationConfig()
+
+    with (
+        patch("src.auto_coder.conflict_resolver.run_llm_noedit_prompt") as mock_llm,
+        patch("src.auto_coder.conflict_resolver.create_high_score_backend_manager") as mock_create_backend,
+        patch("src.auto_coder.conflict_resolver.render_prompt") as mock_render_prompt,
+        patch("src.auto_coder.conflict_resolver.get_commit_log") as mock_commit_log,
+        patch("src.auto_coder.conflict_resolver.GitHubClient"),
+    ):
+        mock_create_backend.return_value = None
+        mock_commit_log.return_value = "abc123 commit"
+        mock_render_prompt.return_value = "prompt"
+        mock_llm.return_value = "SAFE_TO_MERGE"
+
+        pr_data = {
+            "number": 4243,
+            "title": "Add feature",
+            "body": "",
+            "author": {"login": "some-human"},
+            "baseRefName": "main",
+        }
+
+        assert check_mergeability_with_llm(pr_data, "conflict in src/app.py", config) is True
+
+        mock_llm.assert_called_once()


### PR DESCRIPTION
## Summary

Dependency-bot PRs no longer ask the LLM whether merging the base branch would degrade code quality. `check_mergeability_with_llm` now short-circuits to `True` (safe to merge) for PRs authored by a dependency bot, so no LLM call is made at all.

Their conflicts are mechanical dependency/lockfile updates, already handled by the existing lockfile and `package.json` dependency-conflict resolution — spending an LLM call (and risking a pessimistic `DEGRADING_MERGE` verdict that blocks the merge) adds no value there.

## Changes

- `src/auto_coder/conflict_resolver.py`: `check_mergeability_with_llm` returns `True` immediately when `_is_dependabot_pr(pr_data)` matches, logging the skip. `_is_dependabot_pr` is imported lazily inside the function since `pr_processor` imports `conflict_resolver` at module level.
- `tests/test_conflict_resolver.py`: two new tests — a Dependabot PR returns `True` with `run_llm_noedit_prompt`, `create_high_score_backend_manager` and `render_prompt` all unused; a human-authored PR still goes through the LLM.
- `docs/client-features.yaml`: new "Merge Conflict Handling" section documenting the mergeability check and the dependency-bot skip.

Detection reuses the existing `_is_dependabot_pr` helper, so it covers Dependabot, Renovate and `[bot]` logins. Jules PRs (`google-labs-jules[bot]`) are explicitly excluded by that helper and still go through the LLM check unchanged.

## Testing

- `uv run pytest tests/test_conflict_resolver.py tests/test_pr_processor.py` — 18 passed.
- Full suite: 2232 passed, 21 failed / 5 errors. The failure set is byte-for-byte identical with and without this change (verified by diffing the FAILED/ERROR lines against a stashed working tree), so all of them are pre-existing and unrelated.
- black / isort / flake8 / mypy clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hd8kvLNuHPLtUa7fpZ1DFq)_