### PR TITLE
fix(claude): stop forcing --print when --cloud is configured

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -304,6 +304,14 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
   - Typical use: Anthropic Claude API
   - Automatic flags: `--print`, `--dangerously-skip-permissions`, `--allow-dangerously-skip-permissions`
   - Custom options: Path to settings file, debug modes
+  - Cloud sessions: when `options` contain `--cloud` (or `--cloud=<description>`), the run is
+    interactive-only. `--print` is never added and any `--print` / `--output-format <format>`
+    entry is removed from the options, because the claude CLI rejects
+    `--cloud` combined with `--print` and `--output-format` only works with `--print`.
+    The prompt is passed as the trailing argument and becomes the cloud task description.
+  - Configuration recovery: before invoking the CLI, a missing or unparsable `~/.claude.json`
+    (or `$CLAUDE_CONFIG_DIR/.claude.json`) is restored from the newest usable backup in
+    `~/.claude/backups/`; an unparsable file is preserved as `.claude.json.corrupt.<timestamp>`.
 
 - **Gemini Backend** (`backend_type = "antigravity"`):
   ```toml

--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -2,11 +2,15 @@
 Claude CLI client for Auto-Coder.
 """
 
+import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
-from typing import Any, List, Optional
+import time
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
 
 from .exceptions import AutoCoderTimeoutError, AutoCoderUsageLimitError
 from .llm_backend_config import get_llm_config
@@ -16,6 +20,82 @@ from .usage_marker_utils import has_usage_marker_match
 from .utils import CommandExecutor
 
 logger = get_logger(__name__)
+
+CLAUDE_CONFIG_FILENAME = ".claude.json"
+
+
+def get_claude_config_paths() -> Tuple[Path, Path]:
+    """Return the claude CLI configuration file path and its backup directory."""
+    config_dir_env = os.environ.get("CLAUDE_CONFIG_DIR")
+    if config_dir_env:
+        config_dir = Path(config_dir_env)
+        return config_dir / CLAUDE_CONFIG_FILENAME, config_dir / "backups"
+    home = Path.home()
+    return home / CLAUDE_CONFIG_FILENAME, home / ".claude" / "backups"
+
+
+def _load_json_file(path: Path) -> Optional[dict]:
+    """Load a JSON object from path, returning None when it is missing or invalid."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def restore_claude_config_if_needed() -> bool:
+    """Restore the claude CLI configuration from its newest usable backup.
+
+    The claude CLI refuses to run when ~/.claude.json is missing or corrupt. It keeps
+    timestamped copies under ~/.claude/backups/, so recover from the newest backup that
+    still holds account data instead of letting every claude invocation fail.
+
+    Returns:
+        True if the configuration was restored, False otherwise.
+    """
+    config_path, backup_dir = get_claude_config_paths()
+
+    if _load_json_file(config_path) is not None:
+        return False
+
+    try:
+        backups = sorted(backup_dir.glob(f"{CLAUDE_CONFIG_FILENAME}.backup.*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError as e:
+        logger.warning(f"Cannot list claude config backups in {backup_dir}: {e}")
+        return False
+
+    fallback: Optional[Path] = None
+    source: Optional[Path] = None
+    for backup in backups:
+        data = _load_json_file(backup)
+        if data is None:
+            continue
+        # A backup holding only "firstStartTime" is an empty config and restores nothing useful
+        if len(data) > 1:
+            source = backup
+            break
+        if fallback is None:
+            fallback = backup
+    source = source or fallback
+
+    if source is None:
+        logger.warning(f"Claude configuration at {config_path} is missing or invalid and no usable backup was found in {backup_dir}")
+        return False
+
+    try:
+        if config_path.exists():
+            corrupt_path = config_path.with_name(f"{config_path.name}.corrupt.{int(time.time())}")
+            shutil.move(str(config_path), str(corrupt_path))
+            logger.warning(f"Moved invalid claude configuration to {corrupt_path}")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(source), str(config_path))
+    except OSError as e:
+        logger.warning(f"Failed to restore claude configuration from {source}: {e}")
+        return False
+
+    logger.warning(f"Restored missing claude configuration {config_path} from backup {source}")
+    return True
 
 
 class ClaudeClient(LLMClientBase):
@@ -89,6 +169,10 @@ class ClaudeClient(LLMClientBase):
                 for error in required_errors:
                     logger.warning(error)
 
+        # The claude CLI aborts with "configuration file not found" when ~/.claude.json
+        # is missing or unreadable, which breaks every subsequent invocation.
+        restore_claude_config_if_needed()
+
         try:
             override = os.environ.get("AUTOCODER_CLAUDE_CLI")
             base_cmd = shlex.split(override) if override else ["claude"]
@@ -113,6 +197,34 @@ class ClaudeClient(LLMClientBase):
     def _escape_prompt(self, prompt: str) -> str:
         """Escape special characters that may confuse shell/CLI."""
         return prompt.replace("@", "\\@").strip()
+
+    @staticmethod
+    def _strip_print_only_options(options: Any) -> List[str]:
+        """Remove options that are only valid for non-interactive (--print) runs.
+
+        `--print` and `--output-format` cannot be used with `--cloud`, which always
+        starts an interactive cloud session.
+        """
+        stripped: List[str] = []
+        try:
+            index = 0
+            while index < len(options):
+                opt = str(options[index])
+                if opt in ("--print", "-p"):
+                    index += 1
+                    continue
+                if opt == "--output-format":
+                    # Skip the flag and its value
+                    index += 2
+                    continue
+                if opt.startswith("--output-format="):
+                    index += 1
+                    continue
+                stripped.append(options[index])
+                index += 1
+        except (TypeError, AttributeError):
+            return []
+        return stripped
 
     def _run_llm_cli(self, prompt: str, is_noedit: bool = False) -> str:
         """Run claude CLI with the given prompt and show real-time output."""
@@ -158,6 +270,7 @@ class ClaudeClient(LLMClientBase):
             has_print = False
             has_model = False
             has_settings = False
+            has_cloud = False
             # Check for list, MagicMock, or other sequence types
             if options_to_use:
                 try:
@@ -165,10 +278,19 @@ class ClaudeClient(LLMClientBase):
                     has_print = any("--print" in str(opt) for opt in options_to_use)
                     has_model = any("--model" in str(opt) for opt in options_to_use)
                     has_settings = any("--settings" in str(opt) for opt in options_to_use)
-                    logger.info(f"has_print: {has_print}, has_model: {has_model}, has_settings: {has_settings}")
+                    has_cloud = any(str(opt) == "--cloud" or str(opt).startswith("--cloud=") for opt in options_to_use)
+                    logger.info(f"has_print: {has_print}, has_model: {has_model}, has_settings: {has_settings}, has_cloud: {has_cloud}")
                 except (TypeError, AttributeError):
                     # Not iterable, treat as empty
                     pass
+
+            # `--cloud` starts an interactive cloud session, which the CLI refuses to
+            # combine with --print ("Cloud sessions are interactive only"). --output-format
+            # only works together with --print, so drop both and never add --print below.
+            if has_cloud:
+                options_to_use = self._strip_print_only_options(options_to_use)
+                has_print = True
+                logger.info(f"--cloud detected; running interactively without --print: {options_to_use}")
 
             # Filter out --print, --model, and --settings from options to avoid duplication
             # Only filter if we plan to add them separately (i.e., if any is missing)

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -2,11 +2,13 @@
 Tests for Claude client functionality.
 """
 
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.auto_coder.claude_client import ClaudeClient
+from src.auto_coder.claude_client import ClaudeClient, restore_claude_config_if_needed
 
 
 class TestClaudeClient:
@@ -784,6 +786,85 @@ class TestClaudeClient:
     @patch("src.auto_coder.claude_client.get_llm_config")
     @patch("subprocess.run")
     @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
+    def test_cloud_option_drops_print_and_output_format(self, mock_cmd_exec, mock_run, mock_get_config):
+        """`--cloud` runs interactively, so --print and --output-format must be dropped."""
+        mock_run.return_value.returncode = 0
+
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "opus"
+        mock_backend.settings = None
+        cloud_options = ["--output-format", "stream-json", "--verbose", "--model", "opus", "--cloud"]
+        mock_backend.options = cloud_options
+        mock_backend.options_for_noedit = []
+        mock_backend.options_for_resume = []
+        mock_backend.replace_placeholders.return_value = {
+            "options": cloud_options,
+            "options_for_noedit": [],
+            "options_for_resume": [],
+        }
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Test output"
+        mock_result.stderr = ""
+        mock_cmd_exec.return_value = mock_result
+
+        client = ClaudeClient()
+        client._run_llm_cli("test prompt")
+
+        called_cmd = mock_cmd_exec.call_args[0][0]
+        assert called_cmd == [
+            "claude",
+            "--verbose",
+            "--model",
+            "opus",
+            "--cloud",
+            "test prompt",
+        ]
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
+    def test_cloud_with_value_keeps_print_out_of_command(self, mock_cmd_exec, mock_run, mock_get_config):
+        """`--cloud=<description>` must also suppress the automatically added --print."""
+        mock_run.return_value.returncode = 0
+
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "opus"
+        mock_backend.settings = None
+        cloud_options = ["--print", "--cloud=task from auto-coder"]
+        mock_backend.options = cloud_options
+        mock_backend.options_for_noedit = []
+        mock_backend.options_for_resume = []
+        mock_backend.replace_placeholders.return_value = {
+            "options": cloud_options,
+            "options_for_noedit": [],
+            "options_for_resume": [],
+        }
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Test output"
+        mock_result.stderr = ""
+        mock_cmd_exec.return_value = mock_result
+
+        client = ClaudeClient()
+        client._run_llm_cli("test prompt")
+
+        called_cmd = mock_cmd_exec.call_args[0][0]
+        assert "--print" not in called_cmd
+        assert "--cloud=task from auto-coder" in called_cmd
+        assert called_cmd[-1] == "test prompt"
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
     def test_command_execution_includes_all_arguments(self, mock_cmd_exec, mock_run, mock_get_config):
         """ClaudeClient should execute command with all configured arguments."""
         mock_run.return_value.returncode = 0
@@ -1072,3 +1153,59 @@ class TestClaudeClientSessionExtraction:
         output = "Session ID: not-a-uuid-format"
         client._extract_and_store_session_id(output)
         assert client.get_last_session_id() is None
+
+
+class TestClaudeConfigRestore:
+    """Test cases for restoring a missing claude CLI configuration file."""
+
+    @staticmethod
+    def _write_json(path, data):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_no_restore_when_config_is_valid(self, tmp_path, monkeypatch):
+        """A readable configuration must be left untouched."""
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        config_path = tmp_path / ".claude.json"
+        self._write_json(config_path, {"userID": "current"})
+        self._write_json(tmp_path / "backups" / ".claude.json.backup.1", {"userID": "old"})
+
+        assert restore_claude_config_if_needed() is False
+        assert json.loads(config_path.read_text(encoding="utf-8")) == {"userID": "current"}
+
+    def test_restores_newest_backup_with_account_data(self, tmp_path, monkeypatch):
+        """A missing configuration is restored from the newest non-empty backup."""
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        config_path = tmp_path / ".claude.json"
+        older = tmp_path / "backups" / ".claude.json.backup.1"
+        newer = tmp_path / "backups" / ".claude.json.backup.2"
+        empty = tmp_path / "backups" / ".claude.json.backup.3"
+        self._write_json(older, {"userID": "old", "oauthAccount": {"emailAddress": "old@example.com"}})
+        self._write_json(newer, {"userID": "new", "oauthAccount": {"emailAddress": "new@example.com"}})
+        self._write_json(empty, {"firstStartTime": "2026-08-04T04:10:43.814Z"})
+        os.utime(older, (1000, 1000))
+        os.utime(newer, (2000, 2000))
+        os.utime(empty, (3000, 3000))
+
+        assert restore_claude_config_if_needed() is True
+        assert json.loads(config_path.read_text(encoding="utf-8"))["userID"] == "new"
+
+    def test_corrupt_config_is_preserved_and_replaced(self, tmp_path, monkeypatch):
+        """An unparsable configuration is moved aside, not deleted."""
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        config_path = tmp_path / ".claude.json"
+        config_path.write_text("{ this is not json", encoding="utf-8")
+        self._write_json(tmp_path / "backups" / ".claude.json.backup.1", {"userID": "restored", "installMethod": "npm"})
+
+        assert restore_claude_config_if_needed() is True
+        assert json.loads(config_path.read_text(encoding="utf-8"))["userID"] == "restored"
+        corrupt_copies = list(tmp_path.glob(".claude.json.corrupt.*"))
+        assert len(corrupt_copies) == 1
+        assert corrupt_copies[0].read_text(encoding="utf-8") == "{ this is not json"
+
+    def test_returns_false_without_usable_backup(self, tmp_path, monkeypatch):
+        """Nothing is restored when no backup directory exists."""
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+        assert restore_claude_config_if_needed() is False
+        assert not (tmp_path / ".claude.json").exists()


### PR DESCRIPTION
The claude CLI rejects `--cloud` combined with `--print` ("Cloud sessions are interactive only"), but _run_llm_cli always appended --print when the configured options did not already contain it. Detect --cloud/--cloud=<description> and, in that case, skip adding --print and drop --print/--output-format from the options (--output-format only works together with --print).

Also restore the claude CLI configuration before invoking it: a missing or unparsable ~/.claude.json (or $CLAUDE_CONFIG_DIR/.claude.json) makes every claude run fail with "Claude configuration file not found". It is now recovered from the newest usable backup in ~/.claude/backups/, and an unparsable file is preserved as .claude.json.corrupt.<timestamp> instead of being discarded.