### PR TITLE
fix(claude): run --cloud sessions under a pseudo terminal

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -309,6 +309,10 @@ The following examples demonstrate typical `options` and `options_for_noedit` co
     entry is removed from the options, because the claude CLI rejects
     `--cloud` combined with `--print` and `--output-format` only works with `--print`.
     The prompt is passed as the trailing argument and becomes the cloud task description.
+    Such runs are executed through a pseudo terminal (`CommandExecutor.run_command(..., use_pty=True)`),
+    because the claude CLI aborts with "--cloud requires an interactive terminal" when stdout is a pipe.
+    In pty mode stdout and stderr are merged into a single stream and ANSI escape sequences are stripped
+    from the captured output.
   - Configuration recovery: before invoking the CLI, a missing or unparsable `~/.claude.json`
     (or `$CLAUDE_CONFIG_DIR/.claude.json`) is restored from the newest usable backup in
     `~/.claude/backups/`; an unparsable file is preserved as `.claude.json.corrupt.<timestamp>`.

--- a/src/auto_coder/claude_client.py
+++ b/src/auto_coder/claude_client.py
@@ -287,6 +287,11 @@ class ClaudeClient(LLMClientBase):
             # `--cloud` starts an interactive cloud session, which the CLI refuses to
             # combine with --print ("Cloud sessions are interactive only"). --output-format
             # only works together with --print, so drop both and never add --print below.
+            #
+            # The CLI additionally refuses `--cloud` when stdout is not a TTY
+            # ("--cloud requires an interactive terminal"), so such runs are executed
+            # through a pseudo terminal.
+            run_interactively = has_cloud
             if has_cloud:
                 options_to_use = self._strip_print_only_options(options_to_use)
                 has_print = True
@@ -409,6 +414,7 @@ class ClaudeClient(LLMClientBase):
                     env=env if len(env) > len(os.environ) else None,
                     dot_format=True,
                     idle_timeout=1800,
+                    use_pty=run_interactively,
                 )
                 logger.info("=" * 60)
                 stdout = (result.stdout or "").strip()

--- a/src/auto_coder/utils.py
+++ b/src/auto_coder/utils.py
@@ -4,9 +4,11 @@ Utility classes for Auto-Coder automation engine.
 
 import os
 import queue
+import re
 import shlex
 import shutil
 import signal
+import struct
 import subprocess
 import sys
 import threading
@@ -20,6 +22,16 @@ from .security_utils import redact_string
 from .test_log_utils import extract_first_failed_test
 
 logger = get_logger(__name__)
+
+# CSI/OSC escape sequences emitted by interactive terminal UIs
+_ANSI_ESCAPE_RE = re.compile(r"\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def strip_ansi_sequences(text: str) -> str:
+    """Remove ANSI escape sequences from terminal output."""
+    if not text:
+        return text
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 def get_target_container(config: Any) -> Optional[str]:
@@ -336,6 +348,54 @@ class CommandExecutor:
         thread.start()
         return thread
 
+    @staticmethod
+    def _set_pty_window_size(master_fd: int) -> None:
+        """Give the pseudo terminal a sane window size so TUIs render correctly."""
+        try:
+            import fcntl
+            import termios
+
+            size = shutil.get_terminal_size(fallback=(120, 40))
+            packed = struct.pack("HHHH", size.lines, size.columns, 0, 0)
+            fcntl.ioctl(master_fd, termios.TIOCSWINSZ, packed)
+        except Exception:  # pragma: no cover - platform dependent
+            pass
+
+    @staticmethod
+    def _spawn_pty_reader(master_fd: int, out_queue: "queue.Queue[Tuple[str, Optional[str]]]") -> threading.Thread:
+        """Spawn a background reader thread for a pseudo terminal master fd.
+
+        A pty merges stdout and stderr into a single stream, so everything is
+        reported as "stdout". ANSI escape sequences emitted by interactive CLIs
+        are stripped so the captured text stays usable for marker matching.
+        """
+
+        def _reader() -> None:
+            buffer = ""
+            try:
+                while True:
+                    try:
+                        data = os.read(master_fd, 4096)
+                    except OSError:
+                        # Linux raises EIO on the master fd once the child closes the pty
+                        break
+                    if not data:
+                        break
+                    buffer += data.decode("utf-8", errors="replace").replace("\r\n", "\n")
+                    while "\n" in buffer:
+                        line, buffer = buffer.split("\n", 1)
+                        out_queue.put(("stdout", strip_ansi_sequences(line) + "\n"))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(f"Streaming reader failed for pty: {exc}")
+            finally:
+                if buffer:
+                    out_queue.put(("stdout", strip_ansi_sequences(buffer)))
+                out_queue.put(("stdout", None))
+
+        thread = threading.Thread(target=_reader, name="CommandStream-pty", daemon=True)
+        thread.start()
+        return thread
+
     @classmethod
     def _run_with_streaming(
         cls,
@@ -347,22 +407,53 @@ class CommandExecutor:
         dot_format: bool = False,
         idle_timeout: Optional[int] = None,
         log_output: bool = True,
+        use_pty: bool = False,
     ) -> Tuple[int, str, str]:
         """Run a command while streaming stdout/stderr to the logger.
 
         on_stream: optional callback invoked for each chunk (stream_name, chunk).
         The callback may raise to abort the process early; the exception is propagated.
         log_output: if False, suppress logging of stdout/stderr chunks (default: True).
+        use_pty: run the command attached to a pseudo terminal so CLIs that require
+        an interactive terminal (e.g. `claude --cloud`) work. stdout and stderr are
+        merged into stdout because a pty exposes a single stream.
         """
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-            cwd=cwd,
-            env=env,
-        )
+        process: "subprocess.Popen[Any]"
+        pty_master: Optional[int] = None
+        if use_pty and hasattr(os, "openpty"):
+            pty_master, pty_slave = os.openpty()
+            cls._set_pty_window_size(pty_master)
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    stdin=pty_slave,
+                    stdout=pty_slave,
+                    stderr=pty_slave,
+                    cwd=cwd,
+                    env=env,
+                    close_fds=True,
+                    start_new_session=True,
+                )
+            except Exception:
+                os.close(pty_master)
+                os.close(pty_slave)
+                raise
+            finally:
+                # The child owns the slave end now; keeping it open here would hide EOF.
+                try:
+                    os.close(pty_slave)
+                except OSError:
+                    pass
+        else:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=cwd,
+                env=env,
+            )
 
         stdout_lines: List[str] = []
         stderr_lines: List[str] = []
@@ -371,12 +462,16 @@ class CommandExecutor:
         output_queue: "queue.Queue[Tuple[str, Optional[str]]]" = queue.Queue()
         readers: List[threading.Thread] = []
 
-        if process.stdout is not None:
+        if pty_master is not None:
             streams_active.add("stdout")
-            readers.append(cls._spawn_reader(process.stdout, "stdout", output_queue))
-        if process.stderr is not None:
-            streams_active.add("stderr")
-            readers.append(cls._spawn_reader(process.stderr, "stderr", output_queue))
+            readers.append(cls._spawn_pty_reader(pty_master, output_queue))
+        else:
+            if process.stdout is not None:
+                streams_active.add("stdout")
+                readers.append(cls._spawn_reader(process.stdout, "stdout", output_queue))
+            if process.stderr is not None:
+                streams_active.add("stderr")
+                readers.append(cls._spawn_reader(process.stderr, "stderr", output_queue))
 
         start = time.monotonic()
         last_output_time = time.monotonic()
@@ -513,6 +608,11 @@ class CommandExecutor:
                     reader.join(timeout=1)
                 except Exception:
                     pass
+            if pty_master is not None:
+                try:
+                    os.close(pty_master)
+                except OSError:
+                    pass
             # Avoid explicit close() on pipes to prevent rare blocking on some platforms
 
     @classmethod
@@ -527,8 +627,13 @@ class CommandExecutor:
         on_stream: Optional[Callable[[str, str], None]] = None,
         dot_format: bool = False,
         idle_timeout: Optional[int] = None,
+        use_pty: bool = False,
     ) -> CommandResult:
-        """Run a command with consistent error handling."""
+        """Run a command with consistent error handling.
+
+        use_pty: attach the command to a pseudo terminal, for CLIs that refuse to
+        run without an interactive terminal.
+        """
         if timeout is None:
             # Auto-detect timeout based on command type
             cmd_type = cmd[0] if cmd else "default"
@@ -570,6 +675,7 @@ class CommandExecutor:
                     dot_format,
                     idle_timeout=idle_timeout,
                     log_output=True,
+                    use_pty=use_pty,
                 )
             else:
                 # Use _run_with_streaming even when not streaming to logger,
@@ -583,6 +689,7 @@ class CommandExecutor:
                     dot_format,
                     idle_timeout=idle_timeout,
                     log_output=False,
+                    use_pty=use_pty,
                 )
 
             success = return_code == 0

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -824,6 +824,8 @@ class TestClaudeClient:
             "--cloud",
             "test prompt",
         ]
+        # `--cloud` is refused unless stdout is a terminal, so it must run under a pty
+        assert mock_cmd_exec.call_args.kwargs["use_pty"] is True
 
     @patch("src.auto_coder.claude_client.get_llm_config")
     @patch("subprocess.run")
@@ -861,6 +863,41 @@ class TestClaudeClient:
         assert "--print" not in called_cmd
         assert "--cloud=task from auto-coder" in called_cmd
         assert called_cmd[-1] == "test prompt"
+        assert mock_cmd_exec.call_args.kwargs["use_pty"] is True
+
+    @patch("src.auto_coder.claude_client.get_llm_config")
+    @patch("subprocess.run")
+    @patch("src.auto_coder.claude_client.CommandExecutor.run_command")
+    def test_non_cloud_run_does_not_use_pty(self, mock_cmd_exec, mock_run, mock_get_config):
+        """Regular `--print` runs stay on pipes; only interactive runs need a pty."""
+        mock_run.return_value.returncode = 0
+
+        mock_config = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.model = "opus"
+        mock_backend.settings = None
+        options = ["--print", "--model", "opus"]
+        mock_backend.options = options
+        mock_backend.options_for_noedit = []
+        mock_backend.options_for_resume = []
+        mock_backend.replace_placeholders.return_value = {
+            "options": options,
+            "options_for_noedit": [],
+            "options_for_resume": [],
+        }
+        mock_config.get_backend_config.return_value = mock_backend
+        mock_get_config.return_value = mock_config
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Test output"
+        mock_result.stderr = ""
+        mock_cmd_exec.return_value = mock_result
+
+        client = ClaudeClient()
+        client._run_llm_cli("test prompt")
+
+        assert mock_cmd_exec.call_args.kwargs["use_pty"] is False
 
     @patch("src.auto_coder.claude_client.get_llm_config")
     @patch("subprocess.run")

--- a/tests/test_utils_command_executor.py
+++ b/tests/test_utils_command_executor.py
@@ -119,3 +119,80 @@ def test_run_command_env_overrides(monkeypatch):
 
     assert result.stdout.strip() == "scoped"
     assert "FAKE_PROVIDER_TOKEN" not in os.environ
+
+
+def test_run_command_without_pty_has_no_tty():
+    """Without use_pty the child process sees pipes, not a terminal."""
+    script = [
+        sys.executable,
+        "-c",
+        "import sys; print(sys.stdout.isatty())",
+    ]
+
+    result = utils.CommandExecutor.run_command(script, stream_output=False)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "False"
+
+
+def test_run_command_with_pty_provides_interactive_terminal():
+    """use_pty must give the child process a real terminal on stdin/stdout/stderr."""
+    script = [
+        sys.executable,
+        "-c",
+        "import sys; print(sys.stdin.isatty(), sys.stdout.isatty(), sys.stderr.isatty())",
+    ]
+
+    result = utils.CommandExecutor.run_command(script, stream_output=False, use_pty=True)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "True True True"
+
+
+def test_run_command_with_pty_merges_stderr_into_stdout():
+    """A pty exposes a single stream, so stderr output is captured as stdout."""
+    script = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stderr.write('boom\\n'); sys.stderr.flush()",
+    ]
+
+    result = utils.CommandExecutor.run_command(script, stream_output=False, use_pty=True)
+
+    assert result.returncode == 0
+    assert "boom" in result.stdout
+    assert result.stderr == ""
+
+
+def test_run_command_with_pty_reports_non_zero_exit():
+    """Exit codes must survive the pty path."""
+    script = [sys.executable, "-c", "raise SystemExit(3)"]
+
+    result = utils.CommandExecutor.run_command(script, stream_output=False, use_pty=True)
+
+    assert result.returncode == 3
+    assert result.success is False
+
+
+def test_run_command_with_pty_strips_ansi_sequences():
+    """Escape sequences from interactive UIs must not pollute captured output."""
+    script = [
+        sys.executable,
+        "-c",
+        r"print('\x1b[31mred\x1b[0m done')",
+    ]
+
+    result = utils.CommandExecutor.run_command(script, stream_output=False, use_pty=True)
+
+    assert result.stdout.strip() == "red done"
+
+
+def test_strip_ansi_sequences_removes_csi_and_osc():
+    text = "\x1b[2J\x1b[1;32mhello\x1b[0m\x1b]0;title\x07 world"
+
+    assert utils.strip_ansi_sequences(text) == "hello world"
+
+
+def test_strip_ansi_sequences_keeps_plain_text():
+    assert utils.strip_ansi_sequences("plain text") == "plain text"
+    assert utils.strip_ansi_sequences("") == ""


### PR DESCRIPTION
## Problem

`claude --cloud` runs failed with:

```
Failed to run claude CLI: claude CLI failed with return code 1
Error: --cloud requires an interactive terminal.
Non-interactive invocations (piped stdout, --init-only, --sdk-url) run locally and would silently ignore --cloud. Drop --cloud, or run from a TTY.
```

Dropping `--print` (#1542) was not enough: the CLI also checks that stdout is a TTY, and `CommandExecutor` always spawned commands with `subprocess.PIPE`.

## Changes

- `CommandExecutor.run_command` / `_run_with_streaming` gained a `use_pty` flag. When set, the child is spawned with `start_new_session=True` and stdin/stdout/stderr attached to a pty slave, and output is read from the master fd by a dedicated reader thread (`OSError`/EIO from the closed pty is treated as EOF). Timeout, idle-timeout, streaming, and cleanup paths are unchanged.
- `strip_ansi_sequences()` helper; pty output has CSI/OSC sequences stripped and `\r\n` normalized so usage-limit marker matching and session-id extraction keep working on interactive output.
- `ClaudeClient._run_llm_cli` passes `use_pty=True` exactly for `--cloud` runs (the same condition that already suppresses `--print`/`--output-format`); all other runs keep using pipes.
- Documented the behavior in `docs/client-features.yaml`.

## Tests

- `tests/test_utils_command_executor.py`: pty run reports `isatty()` true on stdin/stdout/stderr, non-pty run reports false, stderr is merged into stdout, non-zero exit codes propagate, ANSI sequences are stripped, plus direct `strip_ansi_sequences` cases.
- `tests/test_claude_client.py`: `use_pty=True` asserted for both `--cloud` and `--cloud=<description>` configurations, and a new test asserting `use_pty=False` for regular `--print` runs.

Full suite run before and after the change produces an identical failure set (21 pre-existing failures / 5 errors on the branch, all in unrelated gemini/mcp/cli-sleep tests); lint (black/isort/flake8) and mypy pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TX2eNHP4MPm31xrwR4mznc)_