### PR TITLE
Skip merge conflict resolution for dependency-bot PRs

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -598,6 +598,18 @@ Recent configuration schema changes that require migration:
     implementation: "check_mergeability_with_llm in src/auto_coder/conflict_resolver.py"
     behavior:
       - "For regular PRs the LLM is asked once and must answer SAFE_TO_MERGE or DEGRADING_MERGE; unclear or missing answers are treated as unsafe."
-      - "Dependency-bot PRs (Dependabot/Renovate/'[bot]' logins, detected via _is_dependabot_pr) skip the LLM entirely and are always treated as safe to merge."
-      - "Skipping the LLM for dependency-bot PRs avoids spending an LLM call on mechanical dependency/lockfile conflicts, which are resolved by the existing lockfile and package.json conflict handling."
+      - "Dependency-bot PRs never reach this check because their conflicts are not resolved at all (see dependency_bot_conflict_skip)."
       - "Jules PRs (google-labs-jules[bot]) are not treated as dependency bots and still go through the LLM check."
+
+  dependency_bot_conflict_skip:
+    description: "Merge conflicts of dependency-bot PRs are never resolved by auto-coder."
+    implementation: |
+      _perform_base_branch_merge_and_conflict_resolution in src/auto_coder/conflict_resolver.py,
+      _update_with_base_branch / _resolve_pr_merge_conflicts / _merge_pr in src/auto_coder/pr_processor.py
+    behavior:
+      - "Dependency-bot PRs (Dependabot/Renovate/'[bot]' logins, detected via _is_dependabot_pr) are detected before any conflict resolution starts."
+      - "When a conflict is detected on such a PR the in-progress merge is aborted with 'git merge --abort' and the routine returns without calling the LLM."
+      - "_resolve_pr_merge_conflicts fetches the PR details first and returns False for dependency-bot PRs before checking out the PR branch."
+      - "_merge_pr does not attempt conflict resolution when an unmergeable PR is authored by a dependency bot."
+      - "Rationale: dependency bots recreate or rebase their PRs against the updated base branch themselves, so resolving conflicts locally only wastes LLM calls and can clobber the bot's own update."
+      - "Jules PRs (google-labs-jules[bot]) are not treated as dependency bots and keep their existing conflict handling."

--- a/src/auto_coder/conflict_resolver.py
+++ b/src/auto_coder/conflict_resolver.py
@@ -190,10 +190,6 @@ def check_mergeability_with_llm(
 ) -> bool:
     """Check if merge can be performed without degrading code quality.
 
-    Dependency-bot PRs (Dependabot/Renovate/'[bot]') never consult the LLM:
-    their conflicts are mechanical dependency/lockfile updates, so they are
-    always treated as safe to merge.
-
     Args:
         pr_data: PR data dictionary
         conflict_info: Merge conflict information
@@ -202,12 +198,6 @@ def check_mergeability_with_llm(
     Returns:
         True if safe to merge, False if merge would degrade code quality
     """
-    from .pr_processor import _is_dependabot_pr
-
-    if _is_dependabot_pr(pr_data):
-        logger.info(f"Skipping LLM mergeability check for dependency-bot PR #{pr_data.get('number')}")
-        return True
-
     try:
         # Get commit log since branch creation
         base_branch = pr_data.get("base_branch") or pr_data.get("baseRefName") or config.MAIN_BRANCH
@@ -565,6 +555,15 @@ def _perform_base_branch_merge_and_conflict_resolution(
         else:
             # Merge conflicts detected, check if merge would degrade code quality
             logger.info(f"Merge conflicts detected for PR #{pr_number}, checking mergeability")
+
+            # Dependency-bot PRs (Dependabot/Renovate) are never conflict-resolved:
+            # the bot recreates the PR against the updated base branch by itself.
+            from .pr_processor import _is_dependabot_pr
+
+            if _is_dependabot_pr(pr_data):
+                logger.info(f"Skipping merge conflict resolution for dependency-bot PR #{pr_number}")
+                cmd.run_command(["git", "merge", "--abort"])
+                return False
 
             # Get conflict information
             conflict_info = "\n".join(scan_conflict_markers())

--- a/src/auto_coder/pr_processor.py
+++ b/src/auto_coder/pr_processor.py
@@ -1684,6 +1684,14 @@ def _update_with_base_branch(
                 except Exception as e:
                     actions.append(f"Error requesting Jules to resolve conflict: {e}")
 
+            # Dependency-bot PRs (Dependabot/Renovate) are never conflict-resolved:
+            # the bot recreates the PR against the updated base branch by itself.
+            if _is_dependabot_pr(pr_data):
+                actions.append(f"PR #{pr_number} is a dependency-bot PR with merge conflicts. Skipping conflict resolution.")
+                cmd.run_command(["git", "merge", "--abort"])
+                actions.append("ACTION_FLAG:SKIP_ANALYSIS")
+                return actions
+
             # Use the common subroutine for conflict resolution
             from .conflict_resolver import _perform_base_branch_merge_and_conflict_resolution, scan_conflict_markers
 
@@ -2388,6 +2396,13 @@ def _merge_pr(
                 except Exception as e:
                     logger.error(f"Error requesting Jules to resolve conflict: {e}")
 
+            # Dependency-bot PRs (Dependabot/Renovate) are never conflict-resolved:
+            # the bot recreates the PR against the updated base branch by itself.
+            if _is_dependabot_pr(pr_info):
+                logger.info(f"PR #{pr_number} is a dependency-bot PR with merge conflicts. Skipping conflict resolution.")
+                log_action(f"Skipped merge conflict resolution for dependency-bot PR #{pr_number}")
+                return False
+
             # Try to resolve merge conflicts
             if _resolve_pr_merge_conflicts(repo_name, pr_number, config):
                 # Poll for mergeability
@@ -2532,17 +2547,8 @@ def _resolve_pr_merge_conflicts(repo_name: str, pr_number: int, config: Automati
         if abort_result.success:
             logger.info("Aborted ongoing merge")
 
-        # Step 1: Checkout the PR branch
-        # Step 1: Checkout the PR branch
-        logger.info(f"Checking out PR #{pr_number} to resolve merge conflicts")
-        # Use reusable _checkout_pr_branch which uses direct git commands
-        checkout_success = _checkout_pr_branch(repo_name, {"number": pr_number}, config)
-
-        if not checkout_success:
-            logger.error(f"Failed to checkout PR #{pr_number}")
-            return False
-
-        # Step 1.5: Get PR details to determine the target base branch
+        # Step 1: Get PR details to determine the target base branch and the author
+        pr_data = None
         try:
             from auto_coder.util.gh_cache import get_ghapi_client
 
@@ -2556,7 +2562,22 @@ def _resolve_pr_merge_conflicts(repo_name: str, pr_number: int, config: Automati
             logger.warning(f"Failed to get PR #{pr_number} details via GhApi: {e}")
             base_branch = config.MAIN_BRANCH
 
-        # Step 2: Fetch the latest base branch
+        # Dependency-bot PRs (Dependabot/Renovate) are never conflict-resolved:
+        # the bot recreates the PR against the updated base branch by itself.
+        if pr_data is not None and _is_dependabot_pr(pr_data):
+            logger.info(f"Skipping merge conflict resolution for dependency-bot PR #{pr_number}")
+            return False
+
+        # Step 2: Checkout the PR branch
+        logger.info(f"Checking out PR #{pr_number} to resolve merge conflicts")
+        # Use reusable _checkout_pr_branch which uses direct git commands
+        checkout_success = _checkout_pr_branch(repo_name, {"number": pr_number}, config)
+
+        if not checkout_success:
+            logger.error(f"Failed to checkout PR #{pr_number}")
+            return False
+
+        # Step 3: Fetch the latest base branch
         logger.info(f"Fetching latest {base_branch} branch")
         fetch_result = cmd.run_command(["git", "fetch", "origin", base_branch])
 
@@ -2564,7 +2585,7 @@ def _resolve_pr_merge_conflicts(repo_name: str, pr_number: int, config: Automati
             logger.error(f"Failed to fetch {base_branch} branch: {fetch_result.stderr}")
             return False
 
-        # Step 3: Attempt to merge base branch
+        # Step 4: Attempt to merge base branch
         logger.info(f"Merging refs/remotes/origin/{base_branch} into PR #{pr_number}")
         merge_result = cmd.run_command(["git", "merge", f"refs/remotes/origin/{base_branch}"])
 

--- a/tests/test_conflict_resolver.py
+++ b/tests/test_conflict_resolver.py
@@ -233,15 +233,38 @@ def test_perform_base_merge_closes_jules_pr_recreates_session_on_degrade():
         assert kwargs["config"] == config
 
 
-def test_check_mergeability_skips_llm_for_dependabot_pr():
-    """Dependabot PRs must never consult the LLM for mergeability."""
+def test_perform_base_merge_skips_conflict_resolution_for_dependabot_pr():
+    """Merge conflicts of dependency-bot PRs must never be resolved."""
     config = AutomationConfig()
 
     with (
-        patch("src.auto_coder.conflict_resolver.run_llm_noedit_prompt") as mock_llm,
-        patch("src.auto_coder.conflict_resolver.create_high_score_backend_manager") as mock_create_backend,
-        patch("src.auto_coder.conflict_resolver.render_prompt") as mock_render_prompt,
+        patch("src.auto_coder.conflict_resolver.cmd") as mock_cmd,
+        patch("src.auto_coder.conflict_resolver.GitHubClient") as mock_gh_client_class,
+        patch("src.auto_coder.conflict_resolver.check_mergeability_with_llm") as mock_check_mergeability,
+        patch("src.auto_coder.conflict_resolver.resolve_merge_conflicts_with_llm") as mock_resolve,
+        patch("src.auto_coder.conflict_resolver._trigger_fallback_for_conflict_failure") as mock_fallback,
     ):
+        mock_client = MagicMock()
+        mock_gh_client_class.get_instance.return_value = mock_client
+        mock_client.get_pr_details.return_value = {
+            "number": 4242,
+            "head_branch": "dependabot/pip/requests-2.32.0",
+            "author": {"login": "dependabot[bot]"},
+        }
+
+        # Sequence: reset, clean, abort, fetch pr, checkout, fetch base, rev-parse, merge (fails), merge --abort
+        mock_cmd.run_command.side_effect = [
+            CommandResult(True, "", "", 0),  # reset
+            CommandResult(True, "", "", 0),  # clean
+            CommandResult(True, "", "", 0),  # merge --abort
+            CommandResult(True, "", "", 0),  # fetch pr
+            CommandResult(True, "", "", 0),  # checkout pr
+            CommandResult(True, "", "", 0),  # fetch origin main
+            CommandResult(True, "abc123\n", "", 0),  # rev-parse
+            CommandResult(False, "CONFLICT", "", 1),  # git merge fails
+            CommandResult(True, "", "", 0),  # merge --abort after skipping
+        ]
+
         pr_data = {
             "number": 4242,
             "title": "Bump requests from 2.31.0 to 2.32.0",
@@ -250,11 +273,20 @@ def test_check_mergeability_skips_llm_for_dependabot_pr():
             "baseRefName": "main",
         }
 
-        assert check_mergeability_with_llm(pr_data, "conflict in uv.lock", config) is True
+        ok = _perform_base_branch_merge_and_conflict_resolution(
+            pr_number=4242,
+            base_branch="main",
+            config=config,
+            repo_name="test/repo",
+            pr_data=pr_data,
+        )
 
-        mock_llm.assert_not_called()
-        mock_create_backend.assert_not_called()
-        mock_render_prompt.assert_not_called()
+        assert ok is False
+        mock_check_mergeability.assert_not_called()
+        mock_resolve.assert_not_called()
+        mock_fallback.assert_not_called()
+        # The conflicted merge must be aborted instead of resolved
+        assert mock_cmd.run_command.call_args_list[-1][0][0] == ["git", "merge", "--abort"]
 
 
 def test_check_mergeability_uses_llm_for_human_pr():

--- a/tests/test_pr_processor.py
+++ b/tests/test_pr_processor.py
@@ -626,3 +626,105 @@ class TestPRProcessorMerge:
             mock_api.pulls.merge.assert_any_call("owner", "repo", 125, merge_method="squash")
             # Verify fallback method was tried and succeeded
             mock_api.pulls.merge.assert_any_call("owner", "repo", 125, merge_method="merge")
+
+    @patch("auto_coder.util.gh_cache.get_ghapi_client")
+    @patch("src.auto_coder.pr_processor.GitHubClient")
+    @patch("src.auto_coder.pr_processor._get_allowed_merge_methods")
+    def test_merge_pr_skips_conflict_resolution_for_dependabot(self, mock_get_allowed_methods, mock_github_client_class, mock_get_ghapi_client):
+        """Merge conflicts of Dependabot PRs must not trigger conflict resolution."""
+        from src.auto_coder.automation_config import AutomationConfig
+        from src.auto_coder.pr_processor import _merge_pr
+
+        config = AutomationConfig()
+        config.MERGE_METHOD = "--squash"
+
+        mock_instance = MagicMock()
+        mock_instance.token = "fake-token"
+        mock_github_client_class.get_instance.return_value = mock_instance
+
+        mock_api = MagicMock()
+        mock_get_ghapi_client.return_value = mock_api
+
+        # Dependabot PR that cannot be merged because of conflicts
+        mock_api.pulls.get.return_value = {
+            "number": 126,
+            "user": {"login": "dependabot[bot]"},
+            "head": {"ref": "dependabot/pip/requests-2.32.0"},
+            "mergeable": False,
+        }
+        mock_api.pulls.merge.return_value = {"merged": False}
+        mock_get_allowed_methods.return_value = []
+
+        with (
+            patch("src.auto_coder.pr_processor._resolve_pr_merge_conflicts") as mock_resolve,
+            patch("src.auto_coder.pr_processor._close_linked_issues"),
+            patch("src.auto_coder.pr_processor._archive_jules_session"),
+        ):
+            result = _merge_pr("owner/repo", 126, {}, config)
+
+        assert result is False
+        mock_resolve.assert_not_called()
+
+
+class TestUpdateWithBaseBranchDependabot:
+    """Dependency-bot PRs must never have their merge conflicts resolved."""
+
+    @patch("src.auto_coder.pr_processor.cmd")
+    def test_update_with_base_branch_skips_dependabot_conflicts(self, mock_cmd):
+        from src.auto_coder.automation_config import AutomationConfig
+        from src.auto_coder.pr_processor import _update_with_base_branch
+        from src.auto_coder.utils import CommandResult
+
+        mock_cmd.run_command.side_effect = [
+            CommandResult(True, "", "", 0),  # git fetch origin
+            CommandResult(True, "3\n", "", 0),  # rev-list --count
+            CommandResult(False, "CONFLICT", "", 1),  # git merge
+            CommandResult(True, "", "", 0),  # git merge --abort
+        ]
+
+        pr_data = {
+            "number": 4242,
+            "base_branch": "main",
+            "title": "Bump requests from 2.31.0 to 2.32.0",
+            "body": "",
+            "author": {"login": "dependabot[bot]"},
+        }
+
+        with patch("src.auto_coder.conflict_resolver._perform_base_branch_merge_and_conflict_resolution") as mock_perform:
+            actions = _update_with_base_branch("owner/repo", pr_data, AutomationConfig())
+
+        mock_perform.assert_not_called()
+        assert any("Skipping conflict resolution" in action for action in actions)
+        assert "ACTION_FLAG:SKIP_ANALYSIS" in actions
+        assert mock_cmd.run_command.call_args_list[-1][0][0] == ["git", "merge", "--abort"]
+
+
+class TestResolvePRMergeConflictsDependabot:
+    """_resolve_pr_merge_conflicts must bail out for dependency-bot PRs."""
+
+    @patch("auto_coder.util.gh_cache.get_ghapi_client")
+    @patch("src.auto_coder.pr_processor.GitHubClient")
+    @patch("src.auto_coder.pr_processor.cmd")
+    def test_resolve_pr_merge_conflicts_skips_dependabot(self, mock_cmd, mock_github_client_class, mock_get_ghapi_client):
+        from src.auto_coder.automation_config import AutomationConfig
+        from src.auto_coder.pr_processor import _resolve_pr_merge_conflicts
+        from src.auto_coder.utils import CommandResult
+
+        mock_instance = MagicMock()
+        mock_instance.token = "fake-token"
+        mock_github_client_class.get_instance.return_value = mock_instance
+
+        mock_api = MagicMock()
+        mock_get_ghapi_client.return_value = mock_api
+        mock_api.pulls.get.return_value = {
+            "number": 4242,
+            "user": {"login": "dependabot[bot]"},
+            "base": {"ref": "main"},
+        }
+
+        mock_cmd.run_command.return_value = CommandResult(True, "", "", 0)
+
+        with patch("src.auto_coder.pr_processor._checkout_pr_branch") as mock_checkout:
+            assert _resolve_pr_merge_conflicts("owner/repo", 4242, AutomationConfig()) is False
+
+        mock_checkout.assert_not_called()


### PR DESCRIPTION
## Summary

Auto-coder no longer tries to resolve merge conflicts on PRs created by dependency bots (Dependabot / Renovate / `[bot]` logins). Those bots recreate or rebase their PRs against the updated base branch themselves, so resolving the conflicts locally only wastes LLM calls and can clobber the bot's own update.

## Changes

- `conflict_resolver._perform_base_branch_merge_and_conflict_resolution`: when a conflict is detected and the PR is authored by a dependency bot, the in-progress merge is aborted with `git merge --abort` and the routine returns without any LLM call.
- `pr_processor._update_with_base_branch`: skips conflict resolution for dependency-bot PRs (aborts the merge, flags `SKIP_ANALYSIS`).
- `pr_processor._resolve_pr_merge_conflicts`: fetches PR details first and bails out for dependency-bot PRs *before* checking out the PR branch.
- `pr_processor._merge_pr`: does not start conflict resolution when an unmergeable PR is authored by a dependency bot.
- Removed the now-unreachable dependency-bot special case in `check_mergeability_with_llm` (it could only be reached through the conflict path that now returns earlier).

Jules PRs (`google-labs-jules[bot]`) are not treated as dependency bots and keep their existing conflict handling.

## Tests

- Replaced `test_check_mergeability_skips_llm_for_dependabot_pr` with `test_perform_base_merge_skips_conflict_resolution_for_dependabot_pr`, asserting no mergeability check, no LLM resolution, no fallback trigger, and that the merge is aborted.
- Added `test_merge_pr_skips_conflict_resolution_for_dependabot`, `test_update_with_base_branch_skips_dependabot_conflicts`, and `test_resolve_pr_merge_conflicts_skips_dependabot`.
- Full suite: 2275 passed, 33 skipped. black / isort / flake8 / mypy clean.

## Docs

`docs/client-features.yaml` gains a `dependency_bot_conflict_skip` entry and the `mergeability_check` entry was updated accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqfAmPsTG3UpLPjJC5Y996)_